### PR TITLE
Fix to correctly reinitialize turbine turbulence intensity when reinitializing the flow field.

### DIFF
--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -311,8 +311,6 @@ class FlowField():
             self.wind_veer = wind_veer
         if turbulence_intensity is not None:
             self.turbulence_intensity = turbulence_intensity
-            for turbine in self.turbine_map.turbines:
-                turbine.turbulence_intensity = self.turbulence_intensity
         if air_density is not None:
             self.air_density = air_density
             for turbine in self.turbine_map.turbines:
@@ -335,7 +333,7 @@ class FlowField():
 
         # reinitialize the turbines
         for turbine in self.turbine_map.turbines:
-            turbine.reinitialize_turbine()
+            turbine.reinitialize_turbine(self.turbulence_intensity)
 
     def calculate_wake(self, no_wake=False):
         """

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -93,7 +93,7 @@ class Turbine():
             raise ValueError(
                 "Turbine.grid_point_count must be the square of a number")
 
-        self.reinitialize_turbine()
+        self.reinitialize_turbine(turbulence_intensity=0.0)
 
         # initialize derived attributes
         self.grid = self._create_swept_area_grid()
@@ -286,7 +286,7 @@ class Turbine():
             rotated_z
         )
 
-    def reinitialize_turbine(self):
+    def reinitialize_turbine(self, turbulence_intensity):
         """
         This method sets the velocities at the turbine's rotor swept 
         area grid points to zero.
@@ -295,7 +295,8 @@ class Turbine():
             *None* -- The velocities are updated directly in the 
             :py:class:`floris.simulation.turbine` object.
         """
-        self.velocities = [0] * self.grid_point_count
+        self.velocities = [0.0] * self.grid_point_count
+        self.turbulence_intensity = turbulence_intensity
 
     def set_yaw_angle(self, yaw_angle):
         """

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -93,7 +93,7 @@ class Turbine():
             raise ValueError(
                 "Turbine.grid_point_count must be the square of a number")
 
-        self.reinitialize_turbine(turbulence_intensity=0.0)
+        self.reinitialize_turbine(turbulence_intensity=None)
 
         # initialize derived attributes
         self.grid = self._create_swept_area_grid()


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
A bug was identified where a turbine's turbulence intensity (TI) was retained even after reinitializing the flow field. Code was changed to correctly reset the TI using the `reinitialize_turbines()` method. This was a combined effort from @ejsimley , @rafmudaf , and @bayc .

**Related issue, if one exists**
https://github.com/NREL/floris/issues/15, raised by @jfst

**Impacted areas of the software**
This will change the power output of wind farms when re-calculated at different wind directions.

**Additional supporting information**
Below, the problem is demonstrated before the fix, and then the results after the fix are shown.

Running the `example_input.json` file for an input wind direction of 270 deg, the farm and turbine powers produced are:

__Case 1 before the bug fix:__
```
Farm Power:  4.494816398178318
Turbine Powers:  [1690358.3095915292, 557049.8894976295, 1690358.3095915292, 557049.8894976295]
```
After reinitializing the flow field, and then re-calculating the wake for an input wind direction of 90 deg should return the same farm power and reversed turbine powers, but instead returned:

__Case 2 before the bug fix:__
```
Farm Power:  5.235071691416997
Turbine Powers:  [927177.5361169698, 1690358.3095915292, 927177.5361169698, 1690358.3095915292]
```

This can be seen in the images below, where the first case is shown in the first image and the second case in the second image. The wakes of the upstream turbine in the second image can be seen to be less strong than the wakes in the first image. This is because the TI for the downstream turbines of the first case is retained and uses by the upstream turbines in the second case. By correctly reinitializing the TI for all turbines when the flow field is reinitialized, the two cases return the same powers and the wakes appear equal (shown in the 3rd and 4th figures).

__Case 1 after the bug fix:__
```
Farm Power:  4.494816398178318
Turbine Powers:  [1690358.3095915292, 557049.8894976295, 1690358.3095915292, 557049.8894976295]
```

__Case 2 after the bug fix:__
```
Farm Power:  4.494816398178318
Turbine Powers:  [557049.8894976297, 1690358.3095915292, 557049.8894976295, 1690358.3095915292]
```

__Figure 1: First case with a wind direction of 270 deg before the bug fix.__
![old_wd_270](https://user-images.githubusercontent.com/12664940/59877644-8ab9f980-9363-11e9-83bb-6a395bc3a034.png)

__Figure 2: Second case with a wind direction of 90 deg before the bug fix.__
![old_wd_90](https://user-images.githubusercontent.com/12664940/59877673-a3c2aa80-9363-11e9-8b72-2594108114cd.png)

__Figure 3: First case with a wind direction of 270 deg after the bug fix.__
![new_wd_270](https://user-images.githubusercontent.com/12664940/59878222-fb154a80-9364-11e9-8615-bbb2d8785763.png)

__Figure 4: Second case with a wind direction of 90 deg after the bug fix.__
![new_wd_90](https://user-images.githubusercontent.com/12664940/59878267-12ecce80-9365-11e9-89fa-33c14aeffd04.png)

The code used to produce these values and images is posted below.

```
import numpy as np
import floris.tools as wfct
import matplotlib.pyplot as plt

fi = wfct.floris_utilities.FlorisInterface('example_input.json')

fi.reinitialize_flow_field(wind_direction = 270)
print('Wind speed/dir: ', fi.floris.farm.wind_speed, '/', fi.floris.farm.wind_direction)
fi.calculate_wake()
print('Farm Power: ', fi.get_farm_power()/1e6)
print('Turbine Powers: ', fi.get_turbine_power())
print()

# Initialize the horizontal cut
hor_plane_1 = wfct.cut_plane.HorPlane(
    fi.get_flow_data(),
    fi.floris.farm.turbines[0].hub_height
)

fi.reinitialize_flow_field(wind_direction = 90)
print('Wind speed/dir: ', fi.floris.farm.wind_speed, '/', fi.floris.farm.wind_direction)
fi.calculate_wake()
print('Farm Power: ', fi.get_farm_power()/1e6)
print('Turbine Powers: ', fi.get_turbine_power())
print()

# Initialize the horizontal cut
hor_plane_2 = wfct.cut_plane.HorPlane(
    fi.get_flow_data(),
    fi.floris.farm.turbines[0].hub_height
)

# Plot and show
fig, ax = plt.subplots()
wfct.visualization.visualize_cut_plane(hor_plane_1, ax=ax)
fig, ax = plt.subplots()
wfct.visualization.visualize_cut_plane(hor_plane_2, ax=ax)
plt.show()
```

**Test results, if applicable**
