### PR TITLE
Add option to allow a deflection multipler def

### DIFF
--- a/floris/simulation/wake_deflection.py
+++ b/floris/simulation/wake_deflection.py
@@ -150,7 +150,7 @@ class Gauss(WakeDeflection):
         if 'dm' in model_dictionary:
             self.deflection_multiplier = float(model_dictionary["dm"])
         else:
-            print('Using default multipler of 1.2')
+            print('Using default gauss deflection multipler of 1.2')
             self.deflection_multiplier = 1.2
 
     def function(self, x_locations, y_locations, turbine, coord, flow_field):

--- a/floris/simulation/wake_deflection.py
+++ b/floris/simulation/wake_deflection.py
@@ -147,7 +147,11 @@ class Gauss(WakeDeflection):
         self.bd = float(model_dictionary["bd"])
         self.alpha = float(model_dictionary["alpha"])
         self.beta = float(model_dictionary["beta"])
-        self.deflection_multiplier = 1.2
+        if 'dm' in model_dictionary:
+            self.deflection_multiplier = float(model_dictionary["dm"])
+        else:
+            print('Using default multipler of 1.2')
+            self.deflection_multiplier = 1.2
 
     def function(self, x_locations, y_locations, turbine, coord, flow_field):
         """


### PR DESCRIPTION
**Complete this sentence**
Ready to merge

Allow an option to specify the deflection multiplier in the json.  If not defined, default to the current 1.2, 