### PR TITLE
Change bounds in FlorisInterface.get_hub_height_flow_data

### DIFF
--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -293,6 +293,10 @@ class FlowField():
             with_resolution: A :py:class:`floris.utilities.Vec3` object 
                 that defines the flow field resolution at which to 
                 calculate the wake (default is *None*).
+            bounds_to_set: A list of values representing the mininum 
+                and maximum values for the domain 
+                [xmin, xmax, ymin, ymax, zmin, zmax] 
+                (default is *None*).
 
         Returns:
             *None* -- The flow field is updated directly in the 

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -259,7 +259,8 @@ class FlowField():
                                 air_density=None,
                                 wake=None,
                                 turbine_map=None,
-                                with_resolution=None):
+                                with_resolution=None,
+                                bounds_to_set=None):
         """
         Reiniaitilzies the flow field when a parameter needs to be 
         updated.
@@ -326,7 +327,7 @@ class FlowField():
         self.specified_wind_height = self.turbine_map.turbines[0].hub_height
 
         # Set the domain bounds
-        self.set_bounds()
+        self.set_bounds(bounds_to_set=bounds_to_set)
 
         # reinitialize the flow field
         self._compute_initialized_domain(with_resolution=with_resolution)

--- a/floris/tools/floris_utilities.py
+++ b/floris/tools/floris_utilities.py
@@ -150,12 +150,10 @@ class FlorisInterface():
         bounds_to_set = (x_bounds[0], x_bounds[1], y_bounds[0], y_bounds[1],
                          hub_height - 5., hub_height + 5.)
 
-        # Set new bounds
-        flow_field.set_bounds(bounds_to_set=bounds_to_set)
-
         # Change the resolution
         flow_field.reinitialize_flow_field(
-            with_resolution=Vec3(x_resolution, y_resolution, 3))
+            with_resolution=Vec3(x_resolution, y_resolution, 3), 
+            bounds_to_set=bounds_to_set)
 
         # Calculate the wakes
         flow_field.calculate_wake()


### PR DESCRIPTION
I tried to use the x_bounds and y_bounds arguments in the FlorisInterface.get_hub_height_flow_data function, the bounds are passed to flow_field.set_bounds, but then flow_field.reinitialize_flow_field calls self.set_bounds without an argument and the bounds are reset. To fix this I suggest to pass a bounds_to_set argument to reinitialize_flow_field, and set the bounds there.

BR,
Knut S. Seim