### PR TITLE
Instantiate wake models only as they are needed

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/examples/example_0006_gch.py
+++ b/examples/example_0006_gch.py
@@ -40,8 +40,8 @@ print(np.array(fi.get_turbine_power())/1000.0)
 # Switch to gch
 fi.floris.farm.wake.velocity_model = "gauss_curl_hybrid"
 fi.floris.farm.wake.deflection_model = "gauss_curl_hybrid"
-fi.floris.farm.wake.velocity_models["gauss_curl_hybrid"].use_yar = True
-fi.floris.farm.wake.deflection_models["gauss_curl_hybrid"].use_ss = True
+fi.floris.farm.wake.velocity_model.use_yar = True
+fi.floris.farm.wake.deflection_model.use_ss = True
 
 # Calculate wake
 fi.calculate_wake(yaw_angles=yaw_angles)

--- a/floris/simulation/wake_velocity.py
+++ b/floris/simulation/wake_velocity.py
@@ -55,14 +55,22 @@ class WakeVelocity():
         self.requires_resolution = False
         self.model_string = None
         self.model_grid_resolution = None
+        self.parameter_dictionary = parameter_dictionary
 
         # turbulence parameters
-        turbulence_intensity = parameter_dictionary["turbulence_intensity"]
+        turbulence_intensity = self.parameter_dictionary["turbulence_intensity"]
         self.ti_initial = float(turbulence_intensity["initial"])
         self.ti_constant = float(turbulence_intensity["constant"])
         self.ti_ai = float(turbulence_intensity["ai"])
         self.ti_downstream = float(turbulence_intensity["downstream"])
-
+    
+    def _get_model_dict(self):
+        if self.model_string not in self.parameter_dictionary.keys():
+            raise KeyError("The {} wake model was".format(self.model_string) +
+                " instantiated but the model parameters were not found in the" +
+                " input file or dictionary under" +
+                " 'wake.properties.parameters.{}'.".format(self.model_string))
+        return self.parameter_dictionary[self.model_string]
 
 class Jensen(WakeVelocity):
     """
@@ -112,7 +120,7 @@ class Jensen(WakeVelocity):
     def __init__(self, parameter_dictionary):
         super().__init__(parameter_dictionary)
         self.model_string = "jensen"
-        model_dictionary = parameter_dictionary[self.model_string]
+        model_dictionary = self._get_model_dict()
         self.we = float(model_dictionary["we"])
 
     def function(self, x_locations, y_locations, z_locations, turbine, turbine_coord, deflection_field, flow_field):
@@ -250,7 +258,7 @@ class MultiZone(WakeVelocity):
     def __init__(self, parameter_dictionary):
         super().__init__(parameter_dictionary)
         self.model_string = "multizone"
-        model_dictionary = parameter_dictionary[self.model_string]
+        model_dictionary = self._get_model_dict()
         self.me = [float(n) for n in model_dictionary["me"]]
         self.we = float(model_dictionary["we"])
         self.aU = float(model_dictionary["aU"])
@@ -430,7 +438,7 @@ class Gauss(WakeVelocity):
     def __init__(self, parameter_dictionary):
         super().__init__(parameter_dictionary)
         self.model_string = "gauss"
-        model_dictionary = parameter_dictionary[self.model_string]
+        model_dictionary = self._get_model_dict()
 
         # wake expansion parameters
         self.ka = float(model_dictionary["ka"])
@@ -642,7 +650,7 @@ class Curl(WakeVelocity):
     def __init__(self, parameter_dictionary):
         super().__init__(parameter_dictionary)
         self.model_string = "curl"
-        model_dictionary = parameter_dictionary[self.model_string]
+        model_dictionary = self._get_model_dict()
         self.model_grid_resolution = Vec3(
             model_dictionary["model_grid_resolution"])
         self.initial_deficit = float(model_dictionary["initial_deficit"])
@@ -931,7 +939,7 @@ class GaussCurlHybrid(WakeVelocity):
 
         super().__init__(parameter_dictionary)
         self.model_string = "gauss_curl_hybrid"
-        model_dictionary = parameter_dictionary[self.model_string]
+        model_dictionary = self._get_model_dict()
 
         # wake expansion parameter
         self.ka = float(model_dictionary["ka"])

--- a/tests/change_model_test.py
+++ b/tests/change_model_test.py
@@ -1,0 +1,82 @@
+"""
+Copyright 2017 NREL
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+import numpy as np
+from floris.simulation import Floris
+from .gauss_regression_test import GaussRegressionTest
+from .curl_regression_test import CurlRegressionTest
+
+class ChangeModelTest():
+    """
+    This test checks the ability to change the wake models programmatically.
+    These tests use the baselines from other regression tests.
+
+    Currently, it tests the parameters on the Turbines.
+    TODO:
+    - Timing test
+    - Memory test
+    """
+
+    def __init__(self):
+        self.debug = False
+
+def test_gauss_to_curl_to_gauss():
+    """
+    Start with the Gauss wake model
+    Then, switch to Curl
+    Then, switch back to Gauss
+    """
+    test_class = ChangeModelTest()
+
+    # Establish that the Gauss test passes
+    gauss_test_class = GaussRegressionTest()
+    floris = Floris(input_dict=gauss_test_class.input_dict)
+    floris.farm.flow_field.calculate_wake()
+    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
+        if test_class.debug:
+            print("({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
+        baseline = gauss_test_class.baseline(i)
+        assert pytest.approx(turbine.Cp) == baseline[0]
+        assert pytest.approx(turbine.Ct) == baseline[1]
+        assert pytest.approx(turbine.power) == baseline[2]
+        assert pytest.approx(turbine.aI) == baseline[3]
+        assert pytest.approx(turbine.average_velocity) == baseline[4]
+
+    # Change the model to Curl, rerun calculate_wake, and compare to Curl
+    floris.farm.set_wake_model("curl")
+    floris.farm.flow_field.calculate_wake()
+
+    curl_test_class = CurlRegressionTest()
+    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
+        if test_class.debug:
+            print("({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
+        baseline = curl_test_class.baseline(i)
+        assert pytest.approx(turbine.Cp) == baseline[0]
+        assert pytest.approx(turbine.Ct) == baseline[1]
+        assert pytest.approx(turbine.power) == baseline[2]
+        assert pytest.approx(turbine.aI) == baseline[3]
+        assert pytest.approx(turbine.average_velocity) == baseline[4]
+
+    # Change back to Gauss, rerun calculate_wake, and compare to gauss
+    floris.farm.set_wake_model("gauss")
+    floris.farm.flow_field.calculate_wake()
+    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
+        if test_class.debug:
+            print("({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(turbine.Cp, turbine.Ct, turbine.power, turbine.aI, turbine.average_velocity))
+        baseline = gauss_test_class.baseline(i)
+        assert pytest.approx(turbine.Cp) == baseline[0]
+        assert pytest.approx(turbine.Ct) == baseline[1]
+        assert pytest.approx(turbine.power) == baseline[2]
+        assert pytest.approx(turbine.aI) == baseline[3]
+        assert pytest.approx(turbine.average_velocity) == baseline[4]


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
This pull request changes the `Wake` class to instantiate each wake model (`WakeVelocity`, `WakeDeflection`, and `WakeCombination`) only when they are going to be used. In this way, the wake parameters for each model are not required in the input file.

**Related issue, if one exists**
None

**Impacted areas of the software**
`Wake` class definition.

**Additional supporting information**
None

**Test results, if applicable**
None