### PR TITLE
InputParser should only parse input

### DIFF
--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -35,15 +35,10 @@ class Floris():
 
     def __init__(self, input_file=None, input_dict=None):
         input_reader = InputReader()
-        json_dict = input_reader.read(input_file, input_dict)
-
-        turbine_dict = input_reader.validate_turbine(json_dict["turbine"])
+        self.meta_dict, turbine_dict, wake_dict, farm_dict \
+            = input_reader.read(input_file, input_dict)
         turbine = Turbine(turbine_dict)
-                
-        wake_dict = input_reader.validate_wake(json_dict["wake"])
         wake = Wake(wake_dict)
-
-        farm_dict = input_reader.validate_farm(json_dict["farm"])
         self.farm = Farm(farm_dict, turbine, wake)
 
     def export_pickle(self, pickle_file):

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -9,6 +9,9 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+from .turbine import Turbine
+from .wake import Wake
+from .farm import Farm
 import pickle
 from .input_reader import InputReader
 
@@ -31,79 +34,17 @@ class Floris():
     """
 
     def __init__(self, input_file=None, input_dict=None):
-        self.input_reader = InputReader()
-        self.input_file = input_file
-        self.input_dict = input_dict
-        self._farm = []
-        self.add_farm(
-            input_file=self.input_file,
-            input_dict=self.input_dict
-        )
+        input_reader = InputReader()
+        json_dict = input_reader.read(input_file, input_dict)
 
-    @property
-    def farm(self):
-        """
-        Property of the Floris object that returns the farm(s) 
-        contained within the object.
+        turbine_dict = input_reader.validate_turbine(json_dict["turbine"])
+        turbine = Turbine(turbine_dict)
+                
+        wake_dict = input_reader.validate_wake(json_dict["wake"])
+        wake = Wake(wake_dict)
 
-        Returns:
-            Farm: A Farm object, or if multiple farms, a list of Farm 
-            objects.
-
-        Examples:
-            To get the Farm object(s) stored in a Floris object:
-
-            >>> farms = floris.farm()
-        """
-        if len(self._farm) == 1:
-            return self._farm[0]
-        else:
-            return self._farm
-
-    @farm.setter
-    def farm(self, value):
-        if not hasattr(self._farm):
-            self._farm = value
-
-    def add_farm(self, input_file=None, input_dict=None):
-        """
-        A method that adds a farm with user-defined input file to the 
-        Floris object.
-
-        Returns:
-            *None* -- The :py:class:`floris.simulation.floris` object 
-            is updated directly.
-
-        Examples:
-            To add a farm to a Floris object using a specific input 
-            file:
-
-            >>> floris.add_farm(input_file='input.json')
-
-            To add a farm to a Floris object using the stored input 
-            file:
-
-            >>> floris.add_farm()
-        """
-        self._farm.append(self.input_reader.read(input_file=input_file,
-                                                 input_dict=input_dict))
-
-    def list_farms(self):
-        """
-        A method that lists the farms and relevant farm details stored 
-        in Floris object.
-
-        Returns:
-            *None* -- The farm infomation is printed to the console.
-
-        Examples:
-            To list the current farms in Floris object:
-
-            >>> floris.list_farms()
-        """
-        for num, farm in enumerate(self._farm):
-            print('Farm {}'.format(num))
-            print(farm)
+        farm_dict = input_reader.validate_farm(json_dict["farm"])
+        self.farm = Farm(farm_dict, turbine, wake)
 
     def export_pickle(self, pickle_file):
         """

--- a/floris/simulation/input_reader.py
+++ b/floris/simulation/input_reader.py
@@ -215,4 +215,9 @@ class InputReader():
             json_dict = input_dict.copy()
         else:
             raise ValueError("Input file or dictionary must be provided")
-        return json_dict
+
+        turbine_dict = json_dict.pop("turbine")
+        wake_dict = json_dict.pop("wake")
+        farm_dict = json_dict.pop("farm")
+        meta_dict = json_dict
+        return meta_dict, turbine_dict, wake_dict, farm_dict

--- a/floris/simulation/input_reader.py
+++ b/floris/simulation/input_reader.py
@@ -9,9 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from .turbine import Turbine
-from .wake import Wake
-from .farm import Farm
 import json
 import numpy as np
 
@@ -158,61 +155,59 @@ class InputReader():
         except ValueError:
             return None, ValueError
 
-    def _build_turbine(self, json_dict):
+    def validate_turbine(self, json_dict):
         """
-        Instantiates a Turbine object from a given input file.
+        Checks for the required values and types of input in the
+        given input dictionary as required by the
+        :py:obj:`floris.simulation.turbine` object.
 
         Args:
             json_dict: Input dictionary describing a turbine model.
 
         Returns:
-            Turbine: An instantiated Turbine object.
+            dict: A validated dictionary
         """
-        propertyDict = self._validateJSON(json_dict, self._turbine_properties)
-        propertyDict["properties"]["yaw_angle"] = propertyDict["properties"]["yaw_angle"]
-        propertyDict["properties"]["tilt_angle"] = propertyDict["properties"]["tilt_angle"]
-        return Turbine(propertyDict)
+        return self._validateJSON(json_dict, self._turbine_properties)
 
-    def _build_wake(self, json_dict):
+    def validate_wake(self, json_dict):
         """
-        Instantiates a Wake object from a given input file.
+        Checks for the required values and types of input in the
+        given input dictionary as required by the
+        :py:obj:`floris.simulation.wake` object.
 
         Args:
             json_dict: dict - Input dictionary describing a wake model.
 
         Returns:
-            Wake: An instantiated Wake object.
+            dict: A validated dictionary
         """
-        propertyDict = self._validateJSON(json_dict, self._wake_properties)
-        return Wake(propertyDict)
+        return self._validateJSON(json_dict, self._wake_properties)
 
-    def _build_farm(self, json_dict, turbine, wake):
+    def validate_farm(self, json_dict):
         """
-        Instantiates a Farm object from a given input file.
+        Checks for the required values and types of input in the
+        given input dictionary as required by the
+        :py:obj:`floris.simulation.farm` object.
 
         Args:
             json_dict: Input dictionary describing a farm model.
-            turbine: :py:class:`floris.simulation.turbine.Turbine` 
-                instance used in 
-                :py:class:`floris.simulation.farm.Farm`.
-            wake: :py:class:`floris.simulation.wake.Wake` instance used 
-                in :py:class:`floris.simulation.farm.Farm`.
 
         Returns:
-            Farm: An instantiated Farm object.
+            dict: A validated dictionary
         """
-        propertyDict = self._validateJSON(json_dict, self._farm_properties)
-        return Farm(propertyDict, turbine, wake)
+        return self._validateJSON(json_dict, self._farm_properties)
 
     def read(self, input_file=None, input_dict=None):
         """
-        Parses main input file and instantiates floris objects.
+        Parses a given input file or input dictionary and validated the
+        contents.
 
         Args:
             input_file: A string path to the json input file.
+            input_dict: A Python dictionary of inputs
 
         Returns:
-            Farm: An instantiated FLORIS model of wind farm.
+            json_dict: A validated dictionary
         """
         if input_file is not None:
             json_dict = self._parseJSON(input_file)
@@ -220,8 +215,4 @@ class InputReader():
             json_dict = input_dict.copy()
         else:
             raise ValueError("Input file or dictionary must be provided")
-
-        turbine = self._build_turbine(json_dict["turbine"])
-        wake = self._build_wake(json_dict["wake"])
-        farm = self._build_farm(json_dict["farm"], turbine, wake)
-        return farm
+        return json_dict


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
This pull request updates the InputParser class so that it no longer instantiates simulation objects and only deals with parsing the inputs. It also removes the functionality for the main Floris object to hold multiple farms in a list.

**Related issue, if one exists**
None

**Impacted areas of the software**
Input handling and Floris class

**Test results, if applicable**
https://github.com/NREL/floris/actions
