### PR TITLE
Add checking to ensure layout array x and y coordinates are same length

### DIFF
--- a/floris/simulation/turbine_map.py
+++ b/floris/simulation/turbine_map.py
@@ -17,9 +17,10 @@ import numpy as np
 
 from .turbine import Turbine
 from ..utilities import Vec3, wrap_180
+from ..logging_manager import LoggerBase
 
 
-class TurbineMap:
+class TurbineMap(LoggerBase):
     """
     Container object that maps a :py:class:`~.turbine.Turbine` instance to a
     :py:class:`~.utilities.Vec3` object. This class also provides some helper
@@ -53,6 +54,16 @@ class TurbineMap:
             turbines ( list(float) ): Turbine objects corresponding to
                 the locations given in layout_x and layout_y.
         """
+        # check if the length of x and y coordinates are equal
+        if len(layout_x) != len(layout_y):
+            err_msg = ('The number of turbine x locations ({0}) is ' + \
+                'not equal to the number of turbine y locations ' + \
+                '({1}). Please check your layout array.').format(
+                    len(layout_x), len(layout_y)
+                )
+            self.logger.error(err_msg, stack_info=True)
+            raise ValueError(err_msg)
+
         coordinates = [Vec3(x1, x2, 0) for x1, x2 in list(zip(layout_x, layout_y))]
         self._turbine_map_dict = self._build_internal_dict(coordinates, turbines)
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -10,6 +10,9 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+# See https://floris.readthedocs.io for documentation
+
+
 import copy
 
 import numpy as np

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -1,19 +1,14 @@
 # Copyright 2020 NREL
 
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not 
+# use this file except in compliance with the License. You may obtain a copy of 
 # the License at http://www.apache.org/licenses/LICENSE-2.0
 
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+# License for the specific language governing permissions and limitations under 
 # the License.
-
-# See https://floris.readthedocs.io for documentation
-
-
-import copy
 
 import numpy as np
 import pandas as pd
@@ -143,9 +138,11 @@ class FlorisInterface(LoggerBase):
         wind_map = self.floris.farm.wind_map
         turbine_map = self.floris.farm.flow_field.turbine_map
         if turbulence_kinetic_energy is not None:
-            if wind_speed is None:
-                wind_map.input_speed
-            turbulence_intensity = self.TKE_to_TI(turbulence_kinetic_energy, wind_speed)
+            if wind_speed == None: wind_map.input_speed
+            turbulence_intensity = self.TKE_to_TI(
+                turbulence_kinetic_energy,
+                wind_speed
+            )
 
         if wind_layout or layout_array is not None:
             # Build turbine map and wind map (convenience layer for user)
@@ -298,7 +295,10 @@ class FlorisInterface(LoggerBase):
                 coords = self.floris.farm.flow_field.turbine_map.coords
                 max_diameter = self.floris.farm.flow_field.max_diameter
                 x = [coord.x1 for coord in coords]
-                x1_bounds = (min(x) - 2 * max_diameter, max(x) + 10 * max_diameter)
+                x1_bounds = (
+                    min(x) - 2 * max_diameter,
+                    max(x) + 10 * max_diameter
+                )
             if x2_bounds is None:
                 coords = self.floris.farm.flow_field.turbine_map.coords
                 max_diameter = self.floris.farm.flow_field.max_diameter
@@ -309,7 +309,10 @@ class FlorisInterface(LoggerBase):
                 coords = self.floris.farm.flow_field.turbine_map.coords
                 max_diameter = self.floris.farm.flow_field.max_diameter
                 y = [coord.x2 for coord in coords]
-                x1_bounds = (min(y) - 2 * max_diameter, max(y) + 2 * max_diameter)
+                x1_bounds = (
+                    min(y) - 2 * max_diameter,
+                    max(y) + 2 * max_diameter
+                )
             if x2_bounds is None:
                 hub_height = self.floris.farm.flow_field.turbine_map.turbines[
                     0
@@ -849,7 +852,8 @@ class FlorisInterface(LoggerBase):
             self.calculate_wake(yaw_angles=yaw_angles, no_wake=no_wake)
             return mean_farm_power
         else:
-            turb_powers = [turbine.power for turbine in self.floris.farm.turbines]
+            turb_powers = \
+                [turbine.power for turbine in self.floris.farm.turbines]
             return np.sum(turb_powers)
 
     def get_turbine_layout(self, z=False):

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -10,6 +10,8 @@
 # License for the specific language governing permissions and limitations under 
 # the License.
 
+import copy
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -1,13 +1,13 @@
 # Copyright 2020 NREL
 
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not 
-# use this file except in compliance with the License. You may obtain a copy of 
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
 # the License at http://www.apache.org/licenses/LICENSE-2.0
 
-# Unless required by applicable law or agreed to in writing, software 
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
-# License for the specific language governing permissions and limitations under 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
 # the License.
 
 import copy
@@ -140,11 +140,9 @@ class FlorisInterface(LoggerBase):
         wind_map = self.floris.farm.wind_map
         turbine_map = self.floris.farm.flow_field.turbine_map
         if turbulence_kinetic_energy is not None:
-            if wind_speed == None: wind_map.input_speed
-            turbulence_intensity = self.TKE_to_TI(
-                turbulence_kinetic_energy,
-                wind_speed
-            )
+            if wind_speed is None:
+                wind_map.input_speed
+            turbulence_intensity = self.TKE_to_TI(turbulence_kinetic_energy, wind_speed)
 
         if wind_layout or layout_array is not None:
             # Build turbine map and wind map (convenience layer for user)
@@ -297,10 +295,7 @@ class FlorisInterface(LoggerBase):
                 coords = self.floris.farm.flow_field.turbine_map.coords
                 max_diameter = self.floris.farm.flow_field.max_diameter
                 x = [coord.x1 for coord in coords]
-                x1_bounds = (
-                    min(x) - 2 * max_diameter,
-                    max(x) + 10 * max_diameter
-                )
+                x1_bounds = (min(x) - 2 * max_diameter, max(x) + 10 * max_diameter)
             if x2_bounds is None:
                 coords = self.floris.farm.flow_field.turbine_map.coords
                 max_diameter = self.floris.farm.flow_field.max_diameter
@@ -311,10 +306,7 @@ class FlorisInterface(LoggerBase):
                 coords = self.floris.farm.flow_field.turbine_map.coords
                 max_diameter = self.floris.farm.flow_field.max_diameter
                 y = [coord.x2 for coord in coords]
-                x1_bounds = (
-                    min(y) - 2 * max_diameter,
-                    max(y) + 2 * max_diameter
-                )
+                x1_bounds = (min(y) - 2 * max_diameter, max(y) + 2 * max_diameter)
             if x2_bounds is None:
                 hub_height = self.floris.farm.flow_field.turbine_map.turbines[
                     0
@@ -854,8 +846,7 @@ class FlorisInterface(LoggerBase):
             self.calculate_wake(yaw_angles=yaw_angles, no_wake=no_wake)
             return mean_farm_power
         else:
-            turb_powers = \
-                [turbine.power for turbine in self.floris.farm.turbines]
+            turb_powers = [turbine.power for turbine in self.floris.farm.turbines]
             return np.sum(turb_powers)
 
     def get_turbine_layout(self, z=False):
@@ -870,19 +861,16 @@ class FlorisInterface(LoggerBase):
             np.array: lists of x, y, and (optionally) z coordinates of
                       each turbine
         """
-        xcoords = np.array([
-            turbine.x1
-            for turbine in self.floris.farm.turbine_map.coords
-        ])
-        ycoords = np.array([
-            turbine.x2
-            for turbine in self.floris.farm.turbine_map.coords
-        ])
+        xcoords = np.array(
+            [turbine.x1 for turbine in self.floris.farm.turbine_map.coords]
+        )
+        ycoords = np.array(
+            [turbine.x2 for turbine in self.floris.farm.turbine_map.coords]
+        )
         if z:
-            zcoords = np.array([
-                turbine.x3
-                for turbine in self.floris.farm.turbine_map.coords
-            ])
+            zcoords = np.array(
+                [turbine.x3 for turbine in self.floris.farm.turbine_map.coords]
+            )
             return xcoords, ycoords, zcoords
         else:
             return xcoords, ycoords


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
Adds a check to make sure the length of the x and y coordinates being supplied for turbine layout are the same length.

**Related issue, if one exists**
#54 

**Impacted areas of the software**
`turbine_map.py` -> added check in `__init__`

**Additional supporting information**
Adding the check to `__init__` in `turbine_map.py` will catch length mismatches in the input json file and through changing the turbine layout with `floris_interface.reinitialize_flow_field`.

**Test results, if applicable**
A simple test shows that the check performs as desired.

```
>>> import floris.tools as wfct
>>> fi = wfct.floris_interface.FlorisInterface('example_input.json')
Using default gauss deflection multipler of 1.2
>>> fi.reinitialize_flow_field(layout_array=([0, 1000, 2000], [0, 0, 0]))
>>> fi.reinitialize_flow_field(layout_array=([0, 1000], [0, 0, 0]))
floris.simulation.turbine_map ERROR The number of turbine x locations (2) is not equal to the number of turbine y locations (3). Please check your layout array.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/cbay/floris/floris/tools/floris_interface.py", line 125, in reinitialize_flow_field
    for ii in range(len(layout_array[0]))])          
  File "/home/cbay/floris/floris/simulation/turbine_map.py", line 64, in __init__
    raise ValueError(err_msg)
ValueError: The number of turbine x locations (2) is not equal to the number of turbine y locations (3). Please check your layout array.
```