### PR TITLE
fig legacy json

### DIFF
--- a/examples/other_jsons/input_legacy.json
+++ b/examples/other_jsons/input_legacy.json
@@ -4,7 +4,7 @@
   "description": "Example FLORIS Input file",
   "logging": {
     "console": {
-      "enable": false,
+      "enable": true,
       "level": "INFO"
     },
     "file": {
@@ -236,6 +236,7 @@
           "gauss": {
             "dm": 1.2,
             "use_secondary_steering":false
+          }
           },
           "wake_turbulence_parameters": {
             "crespo_hernandez": {
@@ -245,7 +246,7 @@
               "downstream": -0.275
             }
           }
-        }
+        
     }
   }
 }


### PR DESCRIPTION
Found an error in brackets of legacy JSON, this fix repairs, but it was a little subtle.  The closing brackets were in wrong places, so it didn't find crespo-hernandez parameters and just used defaults, so also turning on console logging as this would also help
