### PR TITLE
Add check that V/W velocities are calculated for GCH/YAR/SS

### DIFF
--- a/floris/simulation/wake_deflection/base_velocity_deflection.py
+++ b/floris/simulation/wake_deflection/base_velocity_deflection.py
@@ -68,6 +68,14 @@ class VelocityDeflection():
     def calculate_effective_yaw_angle(self, x_locations, y_locations,
                                       z_locations, turbine, coord, flow_field):
         if self.use_secondary_steering:
+            if not flow_field.wake.velocity_model.calculate_VW_velocities:
+                err_msg = "It appears that 'use_secondary_steering' is set " + \
+                "to True and 'calculate_VW_velocities' is set to False. " + \
+                "This configuration is not valid. Please set " + \
+                "'use_secondary_steering' to True if you wish to use " + \
+                "yaw-added recovery."
+                self.logger.error(err_msg, stack_info=True)
+                raise ValueError(err_msg)
             # turbine parameters
             Ct = turbine.Ct
             D = turbine.rotor_diameter

--- a/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
+++ b/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
@@ -68,6 +68,16 @@ class GaussianModel(VelocityDeficit):
         """
         # TODO
         """
+        if self.use_yaw_added_recovery:
+            print('bool: ', self.calculate_VW_velocities)
+            if not self.calculate_VW_velocities:
+                err_msg = "It appears that 'use_yaw_added_recovery' is set " + \
+                "to True and 'calculate_VW_velocities' is set to False. " + \
+                "This configuration is not valid. Please set " + \
+                "'calculate_VW_velocities' to True if you wish to use " + \
+                "yaw-added recovery."
+                self.logger.error(err_msg, stack_info=True)
+                raise ValueError(err_msg)
         if self.calculate_VW_velocities:
             V, W = self.calc_VW(coord, turbine, flow_field, x_locations,
                                 y_locations, z_locations)

--- a/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
+++ b/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
@@ -69,7 +69,6 @@ class GaussianModel(VelocityDeficit):
         # TODO
         """
         if self.use_yaw_added_recovery:
-            print('bool: ', self.calculate_VW_velocities)
             if not self.calculate_VW_velocities:
                 err_msg = "It appears that 'use_yaw_added_recovery' is set " + \
                 "to True and 'calculate_VW_velocities' is set to False. " + \


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
Adds a check to make sure `calculate_VW_velocities` is enabled if either `use_yaw_added_recovery` and/or `use_secondary_steering` is enabled. If it is not, and error is raised.

**Related issue, if one exists**
None.

**Impacted areas of the software**
`gaussian_model_base.py`
`base_velocity_deflection.py`

**Additional supporting information**
None.

**Test results, if applicable**
To test the check, set your input file to have any of these combos:

__Input__:
```
        "wake_velocity_parameters": {
          "gauss_legacy": {
            "calculate_VW_velocities": false,
            "use_yaw_added_recovery": true
          }
        },
        "wake_deflection_parameters": {
          "gauss": {
            "use_secondary_steering":true
```
__Output__:
```
user@computer:~/floris/examples/_getting_started$ python example_00_open_and_vis_floris.py 
floris.simulation.wake_deflection.gauss ERROR It appears that 'use_secondary_steering' is set to True and 'calculate_VW_velocities' is set to False. This configuration is not valid. Please set 'use_secondary_steering' to True if you wish to use yaw-added recovery.
Traceback (most recent call last):
  File "example_00_open_and_vis_floris.py", line 24, in <module>
    fi.calculate_wake()
  File "/home/user/floris/floris/tools/floris_interface.py", line 70, in calculate_wake
    track_n_upstream_wakes=track_n_upstream_wakes
  File "/home/user/floris/floris/simulation/flow_field.py", line 632, in calculate_wake
    rotated_x, rotated_y, rotated_z, turbine, coord, self)
  File "/home/user/floris/floris/simulation/flow_field.py", line 288, in _compute_turbine_wake_deflection
    flow_field)
  File "/home/user/floris/floris/simulation/wake_deflection/gauss.py", line 115, in function
    z_locations, turbine, coord, flow_field)
  File "/home/user/floris/floris/simulation/wake_deflection/base_velocity_deflection.py", line 78, in calculate_effective_yaw_angle
    raise ValueError(err_msg)
ValueError: It appears that 'use_secondary_steering' is set to True and 'calculate_VW_velocities' is set to False. This configuration is not valid. Please set 'use_secondary_steering' to True if you wish to use yaw-added recovery.
```

__Input__:
```
        "wake_velocity_parameters": {
          "gauss_legacy": {
            "calculate_VW_velocities": false,
            "use_yaw_added_recovery": false
          }
        },
        "wake_deflection_parameters": {
          "gauss": {
            "use_secondary_steering":true
```
__Output__:
```
user@computer:~/floris/examples/_getting_started$ python example_00_open_and_vis_floris.py 
floris.simulation.wake_deflection.gauss ERROR It appears that 'use_secondary_steering' is set to True and 'calculate_VW_velocities' is set to False. This configuration is not valid. Please set 'use_secondary_steering' to True if you wish to use yaw-added recovery.
Traceback (most recent call last):
  File "example_00_open_and_vis_floris.py", line 24, in <module>
    fi.calculate_wake()
  File "/home/user/floris/floris/tools/floris_interface.py", line 70, in calculate_wake
    track_n_upstream_wakes=track_n_upstream_wakes
  File "/home/user/floris/floris/simulation/flow_field.py", line 632, in calculate_wake
    rotated_x, rotated_y, rotated_z, turbine, coord, self)
  File "/home/user/floris/floris/simulation/flow_field.py", line 288, in _compute_turbine_wake_deflection
    flow_field)
  File "/home/user/floris/floris/simulation/wake_deflection/gauss.py", line 115, in function
    z_locations, turbine, coord, flow_field)
  File "/home/user/floris/floris/simulation/wake_deflection/base_velocity_deflection.py", line 78, in calculate_effective_yaw_angle
    raise ValueError(err_msg)
ValueError: It appears that 'use_secondary_steering' is set to True and 'calculate_VW_velocities' is set to False. This configuration is not valid. Please set 'use_secondary_steering' to True if you wish to use yaw-added recovery.
```

__Input__:
```
        "wake_velocity_parameters": {
          "gauss_legacy": {
            "calculate_VW_velocities": false,
            "use_yaw_added_recovery": true
          }
        },
        "wake_deflection_parameters": {
          "gauss": {
            "use_secondary_steering":false
```
__Output__:
```
user@computer:~/floris/examples/_getting_started$ python example_00_open_and_vis_floris.py 
floris.simulation.wake_velocity.gaussianModels.gauss_legacy ERROR It appears that 'use_yaw_added_recovery' is set to True and 'calculate_VW_velocities' is set to False. This configuration is not valid. Please set 'calculate_VW_velocities' to True if you wish to use yaw-added recovery.
Traceback (most recent call last):
  File "example_00_open_and_vis_floris.py", line 24, in <module>
    fi.calculate_wake()
  File "/home/user/floris/floris/tools/floris_interface.py", line 70, in calculate_wake
    track_n_upstream_wakes=track_n_upstream_wakes
  File "/home/user/floris/floris/simulation/flow_field.py", line 638, in calculate_wake
    self
  File "/home/user/floris/floris/simulation/flow_field.py", line 254, in _compute_turbine_velocity_deficit
    z
  File "/home/user/floris/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py", line 80, in calculate_VW
    raise ValueError(err_msg)
ValueError: It appears that 'use_yaw_added_recovery' is set to True and 'calculate_VW_velocities' is set to False. This configuration is not valid. Please set 'calculate_VW_velocities' to True if you wish to use yaw-added recovery.
```