### PR TITLE
revert wrap functions to work with arrays

### DIFF
--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -149,7 +149,7 @@ def tand(angle):
     return np.tan(np.radians(angle))
 
 
-def wrap_180(angle):
+def wrap_180(x):
     """
     If the given angle is less than -180 or greater than or equal to
     180 degrees, correct it to lie within the range (-180, 180].
@@ -157,14 +157,12 @@ def wrap_180(angle):
     Returns:
         The corrected angle
     """
-    if angle <= -180.0:
-        return angle + 360.0
-    if angle > 180.0:
-        return angle - 360.0
-    return angle
+    x = np.where(x <= -180., x + 360., x)
+    x = np.where(x > 180., x - 360., x)
+    return (x)
 
 
-def wrap_360(angle):
+def wrap_360(x):
     """
     If the given angle is less than 0 or greater than or equal to
     360 degrees, correct it to lie within the range (0, 360].
@@ -172,11 +170,9 @@ def wrap_360(angle):
     Returns:
         The corrected angle
     """
-    if angle <= 0.0:
-        return angle + 360.0
-    if angle > 360.0:
-        return angle - 360.0
-    return angle
+    x = np.where(x < 0., x + 360., x)
+    x = np.where(x >= 360., x - 360., x)
+    return (x)
 
 
 class LogClass:

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -154,6 +154,8 @@ def wrap_180(x):
     If the given angle is less than -180 or greater than or equal to
     180 degrees, correct it to lie within the range (-180, 180].
 
+    x can be a scalar or numpy array
+
     Returns:
         The corrected angle
     """
@@ -166,6 +168,8 @@ def wrap_360(x):
     """
     If the given angle is less than 0 or greater than or equal to
     360 degrees, correct it to lie within the range (0, 360].
+
+    x can be a scalar or numpy array
 
     Returns:
         The corrected angle

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -39,17 +39,17 @@ def test_tand():
 
 
 def test_wrap_180():
-    assert floris.utilities.wrap_180(-180) == 180
-    assert floris.utilities.wrap_180(180) == 180
-    assert floris.utilities.wrap_180(-181) == 179
-    assert floris.utilities.wrap_180(-179) == -179
-    assert floris.utilities.wrap_180(179) == 179
-    assert floris.utilities.wrap_180(181) == -179
+    assert floris.utilities.wrap_180(-180.0) == 180.0
+    assert floris.utilities.wrap_180(180.0) == 180.0
+    assert floris.utilities.wrap_180(-181.0) == 179.0
+    assert floris.utilities.wrap_180(-179.0) == -179.0
+    assert floris.utilities.wrap_180(179.0) == 179.0
+    assert floris.utilities.wrap_180(181.0) == -179.0
 
 def test_wrap_360():
-    assert floris.utilities.wrap_360(0) == 360
-    assert floris.utilities.wrap_360(360) == 360
-    assert floris.utilities.wrap_360(-1) == 359
-    assert floris.utilities.wrap_360(1) == 1
-    assert floris.utilities.wrap_360(359) == 359
-    assert floris.utilities.wrap_360(361) == 1
+    assert floris.utilities.wrap_360(0.0) == 0.0
+    assert floris.utilities.wrap_360(360.0) == 0.0
+    assert floris.utilities.wrap_360(-1.0) == 359.0
+    assert floris.utilities.wrap_360(1.0) == 1.0
+    assert floris.utilities.wrap_360(359.0) == 359.0
+    assert floris.utilities.wrap_360(361.0) == 1.0


### PR DESCRIPTION
Hey Raf, I think you edited these functions, but they threw errors in my code when I passed in arrays, so I was hoping to revert these two if that's ok?