### PR TITLE
Add get_turbine_layout() to FlorisInterface

### DIFF
--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -881,7 +881,6 @@ class FlorisInterface(LoggerBase):
         else:
             return xcoords, ycoords
 
-
     def get_turbine_power(
         self,
         include_unc=False,

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -852,6 +852,35 @@ class FlorisInterface(LoggerBase):
             turb_powers = [turbine.power for turbine in self.floris.farm.turbines]
             return np.sum(turb_powers)
 
+    def get_turbine_layout(self, z=False):
+        """
+        Get turbine layout
+
+        Args:
+            z (bool): When *True*, return lists of x, y, and z coords,
+            otherwise, return x and y only. Defaults to *False*.
+
+        Returns:
+            lists: coordinates of each turbine
+        """
+        xcoords = [
+            turbine.x1
+            for turbine in self.floris.farm.turbine_map.coords
+        ]
+        ycoords = [
+            turbine.x2
+            for turbine in self.floris.farm.turbine_map.coords
+        ]
+        if z:
+            zcoords = [
+                turbine.x3
+                for turbine in self.floris.farm.turbine_map.coords
+            ]
+            return xcoords, ycoords, zcoords
+        else:
+            return xcoords, ycoords
+
+
     def get_turbine_power(
         self,
         include_unc=False,

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -150,7 +150,7 @@ class FlorisInterface(LoggerBase):
         if wind_layout or layout_array is not None:
             # Build turbine map and wind map (convenience layer for user)
             if layout_array is None:
-                layout_array = (self.layout_x, self.layout_y)
+                layout_array = self.get_turbine_layout()
             else:
                 turbine_map = TurbineMap(
                     layout_array[0],
@@ -1504,9 +1504,7 @@ class FlorisInterface(LoggerBase):
         for i, turbine in enumerate(self.floris.farm.turbines):
             D = turbine.rotor_diameter
             break
-        coords = self.floris.farm.turbine_map.coords
-        layout_x = np.array([c.x1 for c in coords])
-        layout_y = np.array([c.x2 for c in coords])
+        layout_x, layout_y = self.get_turbine_layout()
 
         turbineLoc = build_turbine_loc(layout_x, layout_y)
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -861,21 +861,22 @@ class FlorisInterface(LoggerBase):
             otherwise, return x and y only. Defaults to *False*.
 
         Returns:
-            lists: coordinates of each turbine
+            np.array: lists of x, y, and (optionally) z coordinates of
+                      each turbine
         """
-        xcoords = [
+        xcoords = np.array([
             turbine.x1
             for turbine in self.floris.farm.turbine_map.coords
-        ]
-        ycoords = [
+        ])
+        ycoords = np.array([
             turbine.x2
             for turbine in self.floris.farm.turbine_map.coords
-        ]
+        ])
         if z:
-            zcoords = [
+            zcoords = np.array([
                 turbine.x3
                 for turbine in self.floris.farm.turbine_map.coords
-            ]
+            ])
             return xcoords, ycoords, zcoords
         else:
             return xcoords, ycoords


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
Provide interface to programmatically retrieve turbine coordinates without having to dig through the floris farm turbine_map and unpack Vec3 objects.
