### PR TITLE
Add legend_kwargs to WindRose.plot_wind_rose()

### DIFF
--- a/floris/tools/wind_rose.py
+++ b/floris/tools/wind_rose.py
@@ -1314,6 +1314,7 @@ class WindRose:
         color_map="viridis_r",
         ws_right_edges=np.array([5, 10, 15, 20, 25]),
         wd_bins=np.arange(0, 360, 15.0),
+        legend_kwargs={},
     ):
         """
         This method creates a wind rose plot showing the frequency of occurance
@@ -1332,6 +1333,8 @@ class WindRose:
                 np.array([5, 10, 15, 20, 25]).
             wd_bins (np.array, optional): The wind direction bin centers used
                 for plotting (deg). Defaults to np.arange(0, 360, 15.).
+            legend_kwargs (dict, optional): Keyword arguments to be passed to
+                ax.legend().
 
         Returns:
             :py:class:`matplotlib.pyplot.axes`: A figure axes object containing
@@ -1373,7 +1376,7 @@ class WindRose:
             # break
 
         # Configure the plot
-        ax.legend(reversed(rects), ws_labels)
+        ax.legend(reversed(rects), ws_labels, **legend_kwargs)
         ax.set_theta_direction(-1)
         ax.set_theta_offset(np.pi / 2.0)
         ax.set_theta_zero_location("N")


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
Add `legend_kwargs` to `WindRose.plot_wind_rose()`. For some reason, calling `ax.get_legend_handles_labels()` after the fact returns empty lists, which make it impossible to adjust the legend after calling plot_wind_rose().


**Test results, if applicable**
```python
wr = WindRose()
wr.make_wind_rose_from_user_data(frontrow_mean['wdir'],frontrow_mean['wspd'])
ax = wr.plot_wind_rose(ws_right_edges=np.arange(3,20,3),
                       legend_kwargs=dict(loc='upper left',bbox_to_anchor=(1,1)))
```
![download-12](https://user-images.githubusercontent.com/18267059/87823661-07eac300-c831-11ea-9f5a-fb7a3c026dac.png)

