### PR TITLE
GCH updates

### DIFF
--- a/floris/simulation/wake_deflection/base_velocity_deflection.py
+++ b/floris/simulation/wake_deflection/base_velocity_deflection.py
@@ -129,6 +129,7 @@ class VelocityDeflection(LoggerBase):
             D = turbine.rotor_diameter
             HH = turbine.hub_height
             aI = turbine.aI
+            yaw_turbine = turbine.yaw_angle
             TSR = turbine.tsr
             V = flow_field.v
             Uinf = np.mean(flow_field.wind_map.grid_wind_speed)
@@ -152,7 +153,7 @@ class VelocityDeflection(LoggerBase):
             rC = yLocs ** 2 + zC ** 2
 
             # find wake deflection from CRV
-            test_gamma = np.linspace(-45, 45, 91)
+            test_gamma = np.arange(-90, 90, 1)
             avg_V = np.mean(V[idx])
             minYaw = 10000
             target_yaw_ix = None
@@ -170,15 +171,17 @@ class VelocityDeflection(LoggerBase):
                     * ((HH - D / 2) / flow_field.specified_wind_height)
                     ** flow_field.wind_shear
                 ) / Uinf
+                
+                # In order to be consistent with Shapiro "Modelling yawed wind turbine wakes: a lifting line approach"
+                # since Ct already accounts for the yaw angle of the turbine
                 Gamma_top = (
-                    (np.pi / 8) * D * vel_top * Uinf * Ct * sind(yaw) * cosd(yaw)
+                    (1 / 2) * D * vel_top * Uinf * Ct * cosd(yaw_turbine) * sind(yaw)
                 )
                 Gamma_bottom = (
-                    -(np.pi / 8) * D * vel_bottom * Uinf * Ct * sind(yaw) * cosd(yaw)
+                    -(1 / 2) * D * vel_bottom * Uinf * Ct * cosd(yaw_turbine) * sind(yaw)
                 )
                 Gamma_wake_rotation = (
-                    0.25
-                    * 2
+                    2
                     * np.pi
                     * D
                     * (aI - aI ** 2)

--- a/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
+++ b/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
@@ -203,13 +203,13 @@ class GaussianModel(VelocityDeficit):
             * ((HH - D / 2) / flow_field.specified_wind_height) ** flow_field.wind_shear
         ) / Uinf
         Gamma_top = (
-            scale * (np.pi / 8) * D * vel_top * Uinf * Ct * sind(yaw) * cosd(yaw)
+            scale * (1 / 2) * D * vel_top * Uinf * Ct * sind(yaw) * cosd(yaw)
         )
         Gamma_bottom = (
-            -scale * (np.pi / 8) * D * vel_bottom * Uinf * Ct * sind(yaw) * cosd(yaw)
+            -scale * (1 / 2) * D * vel_bottom * Uinf * Ct * sind(yaw) * cosd(yaw)
         )
         Gamma_wake_rotation = (
-            0.25 * 2 * np.pi * D * (aI - aI ** 2) * turbine.average_velocity / TSR
+            2 * np.pi * D * (aI - aI ** 2) * turbine.average_velocity / TSR
         )
 
         # compute the spanwise and vertical velocities induced by yaw


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
- The circulation strength is updated to be consistent with equation 2.5 in Shapiro “Modelling yawed wind turbine wakes: a lifting line approach”

- Since `turbine.Ct` already accounts for the yaw angle applied by the turbine, the effective circulation is slightly changed. The yaw angle of the turbine only influences the thrust coefficient, while the effective yaw angle influences the projection with `sind(yaw_test)`. 

- The boundaries of the effective yaw angle can then be increased


**Impacted areas of the software**
The modifications would mainly influence the wake deflection in case of yaw steering

**Additional supporting information**
The issue in that in the current version, the circulation is proportional to `Ct(yaw=0)*cosd(yaw)*cosd(yaw_effective)`