### PR TITLE
Add error call for old "set_rotor_diameter" function

### DIFF
--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -1506,18 +1506,11 @@ class FlorisInterface(LoggerBase):
 
     def set_rotor_diameter(self, rotor_diameter):
         """
-        Assign rotor diameter to turbines.
-
-        Args:
-            rotor_diameter (float): The rotor diameter(s) to be
-            applied to the turbines in meters.
+        This function has been replaced and no longer works correctly, assigning an error
         """
-        if isinstance(rotor_diameter, float) or isinstance(rotor_diameter, int):
-            rotor_diameter = [rotor_diameter] * len(self.floris.farm.turbines)
-        else:
-            rotor_diameter = rotor_diameter
-        for i, turbine in enumerate(self.floris.farm.turbines):
-            turbine.rotor_diameter = rotor_diameter[i]
+        raise Exception(
+            "function set_rotor_diameter has been removed.  Please use the function change_turbine going forward.  See examples/change_turbine for syntax"
+        )
 
     def show_model_parameters(
         self,


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __ IS__ READY TO MERGE

**Feature or improvement description**
Provide a helpful error to a now un-used function which doesn't do what it says

**Impacted areas of the software**
floris_interface.py

**Additional supporting information**
<Add any other context about the problem here.>

**Test results, if applicable**
from python:
import floris.tools as wfct
 fi = wfct.floris_interface.FlorisInterface('example_input.json')
fi.set_rotor_diameter(15)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/pfleming/Desktop/git_tools/FLORIS/floris/tools/floris_interface.py", line 1512, in set_rotor_diameter
    "function set_rotor_diameter has been removed.  Please use the function change_turbine going forward.  See examples/change_turbine for syntax"
Exception: function set_rotor_diameter has been removed.  Please use the function change_turbine going forward.  See examples/change_turbine for syntax

