### PR TITLE
Ensure Turbine.velocities is an array before attempting to drop NaNs, and some logging fixes

### DIFF
--- a/floris/logging_manager.py
+++ b/floris/logging_manager.py
@@ -100,17 +100,9 @@ def _setup_logger():
 
     file_name = "floris_{:%Y-%m-%d-%H_%M_%S}.log".format(datetime.now())
 
-    # TODO: understand why this doesnt work and fix it!
-    # if logger.hasHandlers():
-    #     print(logger.handlers, len(logger.handlers))
-    #     for i, handler in enumerate(logger.handlers):
-    #         print(i, handler)
-    #         logger.removeHandler(handler)
-    #     print(logger.handlers, len(logger.handlers))
-
     # Remove all existing handlers before adding new ones
-    while logger.hasHandlers():
-        logger.removeHandler(logger.handlers[0])
+    for h in logger.handlers.copy():
+        logger.removeHandler(h)
 
     # Configure and add the console handler
     if LOG_TO_CONSOLE:

--- a/floris/logging_manager.py
+++ b/floris/logging_manager.py
@@ -50,7 +50,8 @@ def configure_console_log(enabled=True, level="INFO"):
     global CONSOLE_LEVEL
     LOG_TO_CONSOLE = enabled
     CONSOLE_LEVEL = level
-    _setup_logger()
+    if enabled:
+        _setup_logger()
 
 
 def configure_file_log(enabled=True, level="INFO"):
@@ -78,7 +79,8 @@ def configure_file_log(enabled=True, level="INFO"):
     global FILE_LEVEL
     LOG_TO_FILE = enabled
     FILE_LEVEL = level
-    _setup_logger()
+    if enabled:
+        _setup_logger()
 
 
 def _setup_logger():

--- a/floris/logging_manager.py
+++ b/floris/logging_manager.py
@@ -91,8 +91,8 @@ def _setup_logger():
     Returns:
         logging.Logger: The root logger from the `logging` module.
     """
-    # Configure logging for the root logger
-    logger = logging.getLogger()
+    # Create a logger object for floris
+    logger = logging.getLogger(name="floris")
     logger.setLevel(logging.DEBUG)
     # level_styles = {'warning': {'color': 'red', 'bold': False}}
     fmt_console = "%(name)s %(levelname)s %(message)s"

--- a/floris/logging_manager.py
+++ b/floris/logging_manager.py
@@ -50,8 +50,7 @@ def configure_console_log(enabled=True, level="INFO"):
     global CONSOLE_LEVEL
     LOG_TO_CONSOLE = enabled
     CONSOLE_LEVEL = level
-    if enabled:
-        _setup_logger()
+    _setup_logger()
 
 
 def configure_file_log(enabled=True, level="INFO"):
@@ -79,8 +78,7 @@ def configure_file_log(enabled=True, level="INFO"):
     global FILE_LEVEL
     LOG_TO_FILE = enabled
     FILE_LEVEL = level
-    if enabled:
-        _setup_logger()
+    _setup_logger()
 
 
 def _setup_logger():

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -580,8 +580,8 @@ class Turbine(LoggerBase):
 
             >>> avg_vel = floris.farm.turbines[0].average_velocity()
         """
-        # remove all invalid numbers from interpolation
-        data = self.velocities[np.where(~np.isnan(self.velocities))]
+        # Remove all invalid numbers from interpolation
+        data = np.array(self.velocities)[~np.isnan(self.velocities)]
         avg_vel = np.cbrt(np.mean(data ** 3))
         if np.isnan(avg_vel):
             avg_vel = 0


### PR DESCRIPTION
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**

Numpy was being used to drop NaNs in `Turbine.velocities` to compute `average_velocity`, but Numpy slicing doesn't work on lists, which is apparently how these velocities were stored in the instance. This fix ensures `velocities` is the right type before dropping NaNs and computing average velocity.

Also fixed some of the logger handling, such that the root logger isn't used, to avoid conflicts with other apps. The bug removing handlers was also fixed.