### PR TITLE
Fix URL to develop branch in documentation

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -45,7 +45,7 @@ The FLORIS repository consists of two primary branches:
 
 - `master <https://github.com/NREL/FLORIS/tree/master>`_ - Stable
   release corresponding to a specific version number.
-- `develop <https://github.com/NREL/FLORIS/tree/dev>`_ - Latest
+- `develop <https://github.com/NREL/FLORIS/tree/develop>`_ - Latest
   updates including bug fixes and improvements but possibly unstable.
 
 To download the source code, use `git clone`. Then, add it to


### PR DESCRIPTION
While reading the FLORIS documentation, I found that the Installation chapter has an issue in the hotlink to the development branch. It points to ".../dev", while the actual branch is called "develop" and the URL therefore gave "Page not found" error. Changing this to "develop" fixes the issue.


**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
Correcting the URL to the development branch in the documentation

**Related issue, if one exists**
-

**Impacted areas of the software**
Documentation

**Additional supporting information**
-

**Test results, if applicable**
-
