### PR TITLE
renaming: power_opt to power_init in _get_initial_farm_power()

### DIFF
--- a/floris/tools/optimization/scipy/yaw_wind_rose.py
+++ b/floris/tools/optimization/scipy/yaw_wind_rose.py
@@ -198,9 +198,9 @@ class YawOptimizationWindRose(Optimization):
                         turbulence_intensity=self.ti[i],
                     )
 
-                # optimized power
+                # initial power
                 self.fi.calculate_wake()
-                power_opt = self.fi.get_turbine_power(
+                power_init = self.fi.get_turbine_power(
                     include_unc=self.include_unc,
                     unc_pmfs=self.unc_pmfs,
                     unc_options=self.unc_options,
@@ -217,15 +217,15 @@ class YawOptimizationWindRose(Optimization):
                         turbulence_intensity=self.ti[i],
                     )
                 self.fi.calculate_wake()
-                power_opt = self.fi.get_turbine_power(
+                power_init = self.fi.get_turbine_power(
                     include_unc=self.include_unc,
                     unc_pmfs=self.unc_pmfs,
                     unc_options=self.unc_options,
                 )
             else:
-                power_opt = self.nturbs * [0.0]
+                power_init = self.nturbs * [0.0]
 
-            self.initial_farm_powers.append(np.sum(power_opt))
+            self.initial_farm_powers.append(np.sum(power_init))
 
     def _get_power_for_yaw_angle_opt(self, yaw_angles):
         """


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
I guess someone forgot to rename variables during a copy/paste when introducing the function _get_initial_farm_power()
It doesn't make sense to call the variables here "_opt", therefore some renaming to avoid confusion.

**Related issue, if one exists**
-

**Impacted areas of the software**
none

**Additional supporting information**
It's my first pull request, so please let me know if something is not right :)

**Test results, if applicable**
I run examples/optimization/scipy/controls_optimization/optimize_yaw_wind_rose.py
