### PR TITLE
Bugfixes and performance enhancements for the curled wake model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Citation
 If FLORIS played a role in your research, please cite it. This software can be
 cited as:
 
-   FLORIS. Version 2.3.0 (2021). Available at https://github.com/NREL/floris.
+   FLORIS. Version 2.2.5 (2021). Available at https://github.com/NREL/floris.
 
 For LaTeX users:
 
@@ -59,7 +59,7 @@ For LaTeX users:
 
     @misc{FLORIS_2021,
     author = {NREL},
-    title = {{FLORIS. Version 2.3.0},
+    title = {{FLORIS. Version 2.2.5},
     year = {2021},
     publisher = {GitHub},
     journal = {GitHub repository},

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Citation
 If FLORIS played a role in your research, please cite it. This software can be
 cited as:
 
-   FLORIS. Version 2.2.5 (2021). Available at https://github.com/NREL/floris.
+   FLORIS. Version 2.3.0 (2021). Available at https://github.com/NREL/floris.
 
 For LaTeX users:
 
@@ -59,7 +59,7 @@ For LaTeX users:
 
     @misc{FLORIS_2021,
     author = {NREL},
-    title = {{FLORIS. Version 2.2.5},
+    title = {{FLORIS. Version 2.3.0},
     year = {2021},
     publisher = {GitHub},
     journal = {GitHub repository},

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,7 +70,7 @@ Citation
 If FLORIS played a role in your research, please cite it. This software can be
 cited as:
 
-   FLORIS. Version 2.3.0 (2021). Available at https://github.com/NREL/floris.
+   FLORIS. Version 2.2.5 (2021). Available at https://github.com/NREL/floris.
 
 For LaTeX users:
 
@@ -78,7 +78,7 @@ For LaTeX users:
 
     @misc{FLORIS_2021,
     author = {NREL},
-    title = {{FLORIS. Version 2.3.0},
+    title = {{FLORIS. Version 2.2.5}},
     year = {2021},
     publisher = {GitHub},
     journal = {GitHub repository},

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,7 +70,7 @@ Citation
 If FLORIS played a role in your research, please cite it. This software can be
 cited as:
 
-   FLORIS. Version 2.2.5 (2021). Available at https://github.com/NREL/floris.
+   FLORIS. Version 2.3.0 (2021). Available at https://github.com/NREL/floris.
 
 For LaTeX users:
 
@@ -78,7 +78,7 @@ For LaTeX users:
 
     @misc{FLORIS_2021,
     author = {NREL},
-    title = {{FLORIS. Version 2.2.5}},
+    title = {{FLORIS. Version 2.3.0}},
     year = {2021},
     publisher = {GitHub},
     journal = {GitHub repository},

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,7 +78,7 @@ For LaTeX users:
 
     @misc{FLORIS_2021,
     author = {NREL},
-    title = {{FLORIS. Version 2.3.0}},
+    title = {FLORIS. Version 2.3.0},
     year = {2021},
     publisher = {GitHub},
     journal = {GitHub repository},

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -153,6 +153,8 @@ class Farm:
             with_resolution=self.flow_field.wake.velocity_model.model_grid_resolution
         )
 
+        self.turbine_map.reinitialize_turbines()
+
     def set_yaw_angles(self, yaw_angles):
         """
         Sets the yaw angles for all turbines on the

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -246,6 +246,11 @@ class FlowField:
         self.v = self.v_initial.copy()
         self.w = self.w_initial.copy()
 
+    def reset_uvw(self):
+        self.u = self.u_initial.copy()
+        self.v = self.v_initial.copy()
+        self.w = self.w_initial.copy()
+
     def _compute_turbine_velocity_deficit(
         self, x, y, z, turbine, coord, deflection, flow_field
     ):
@@ -548,6 +553,9 @@ class FlowField:
                 track of the number of upstream wakes a turbine is
                 experiencing. Defaults to *False*.
         """
+        if self.wake.velocity_model.model_grid_resolution is not None:
+            self.reset_uvw()
+
         if points is not None:
             # add points to flow field grid points
             self._compute_initialized_domain(points=points)

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -274,7 +274,7 @@ class Turbine(LoggerBase):
 
         # TODO:
         # # PREVIOUS METHOD========================
-        # # UNCOMMENT IF ANY ISSUE UNCOVERED WITH NEW MOETHOD
+        # # UNCOMMENT IF ANY ISSUE UNCOVERED WITH NEW METHOD
         # x_grid = x
         # y_grid = y
         # z_grid = z
@@ -304,10 +304,6 @@ class Turbine(LoggerBase):
             x_array = np.ones_like(y_array) * coord.x1
             grid_array = np.column_stack([x_array, y_array, z_array])
 
-            # ii = np.argmin(distance_matrix(flow_grid_points, grid_array), axis=0)
-            # ii = np.zeros(25).astype(int)
-            # for i in range(len(ii)):
-            #     ii[i] = np.argmin(np.sum((flow_grid_points - grid_array[i,:]) ** 2, axis=1))
             ii = np.array(
                 [
                     np.argmin(
@@ -316,12 +312,10 @@ class Turbine(LoggerBase):
                     for i in range(len(grid_array))
                 ]
             )
-            # ii = ii.astype(int)
             self.flow_field_point_indices = ii
         else:
             ii = self.flow_field_point_indices
 
-        # return np.array(data)
         if additional_wind_speed is not None:
             return (
                 np.array(u_at_turbine.flatten()[ii]),

--- a/floris/simulation/turbine_map.py
+++ b/floris/simulation/turbine_map.py
@@ -179,6 +179,10 @@ class TurbineMap(LoggerBase):
 
         return wake_list
 
+    def reinitialize_turbines(self):
+        for turbine in self.turbines:
+            turbine.initialize_turbine()
+
     @property
     def turbines(self):
         """

--- a/floris/simulation/wake_deflection/gauss.py
+++ b/floris/simulation/wake_deflection/gauss.py
@@ -345,25 +345,6 @@ class Gauss(VelocityDeflection):
             return turbine.yaw_angle
 
     @property
-    def use_secondary_steering(self):
-        """
-        Flag to use secondary steering on the wake deflection using methods
-        developed in :cite:`bvd-King2019Controls`.
-
-        **Note:** This is a virtual property used to "get" or "set" a value.
-
-        Args:
-            value (bool): Value to set.
-
-        Returns:
-            float: Value currently set.
-
-        Raises:
-            ValueError: Invalid value.
-        """
-        return self._use_secondary_steering
-
-    @property
     def ka(self):
         """
         Parameter used to determine the linear relationship between the
@@ -580,6 +561,25 @@ class Gauss(VelocityDeflection):
                     "Current value of bd, {0}, is not equal to tuned " + "value of {1}."
                 ).format(value, __class__.default_parameters["bd"])
             )
+
+    @property
+    def use_secondary_steering(self):
+        """
+        Flag to use secondary steering on the wake deflection using methods
+        developed in :cite:`bvd-King2019Controls`.
+
+        **Note:** This is a virtual property used to "get" or "set" a value.
+
+        Args:
+            value (bool): Value to set.
+
+        Returns:
+            float: Value currently set.
+
+        Raises:
+            ValueError: Invalid value.
+        """
+        return self._use_secondary_steering
 
     @use_secondary_steering.setter
     def use_secondary_steering(self, value):

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -236,6 +236,11 @@ class FlorisInterface(LoggerBase):
                 )
                 wind_map.input_direction = wind_direction
                 wind_map.calculate_wind_direction()
+                if (
+                    self.floris.farm.flow_field.wake.velocity_model.model_grid_resolution
+                    is not None
+                ):
+                    self.floris.farm.turbine_map.reinitialize_turbines()
 
             # redefine wind_map in Farm object
             self.floris.farm.wind_map = wind_map
@@ -250,6 +255,9 @@ class FlorisInterface(LoggerBase):
             with_resolution=with_resolution,
             wind_map=self.floris.farm.wind_map,
         )
+
+    def reinitialize_turbines(self):
+        self.floris.farm.turbine_map.reinitialize_turbines()
 
     def get_plane_of_points(
         self,
@@ -289,7 +297,7 @@ class FlorisInterface(LoggerBase):
 
             # If this is a gridded model, must extract from full flow field
             self.logger.info(
-                "Model identified as %s requires use of underlying grid print"
+                "Model identified as %s requires use of underlying grid points"
                 % self.floris.farm.flow_field.wake.velocity_model.model_string
             )
 
@@ -1385,7 +1393,7 @@ class FlorisInterface(LoggerBase):
         """
         for turbine in self.floris.farm.turbines:
             turbine.use_points_on_perimeter = use_points_on_perimeter
-            turbine._initialize_turbine()
+            turbine.initialize_turbine()
 
     def set_gch(self, enable=True):
         """

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -25,7 +25,7 @@ from scipy.stats import norm
 
 from floris.simulation import Floris, Turbine, WindMap, TurbineMap
 
-from .cut_plane import CutPlane, get_plane_from_flow_data
+from .cut_plane import CutPlane, change_resolution, get_plane_from_flow_data
 from .flow_data import FlowData
 from ..utilities import Vec3
 from .visualization import visualize_cut_plane
@@ -530,7 +530,16 @@ class FlorisInterface(LoggerBase):
         )
 
         # Compute and return the cutplane
-        return CutPlane(df)
+        hor_plane = CutPlane(df)
+        if self.floris.farm.wake.velocity_model.model_grid_resolution is not None:
+            hor_plane = change_resolution(
+                hor_plane,
+                resolution=(
+                    self.floris.farm.wake.velocity_model.model_grid_resolution.x1,
+                    self.floris.farm.wake.velocity_model.model_grid_resolution.x2,
+                ),
+            )
+        return hor_plane
 
     def get_cross_plane(
         self, x_loc, y_resolution=200, z_resolution=200, y_bounds=None, z_bounds=None

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -256,9 +256,6 @@ class FlorisInterface(LoggerBase):
             wind_map=self.floris.farm.wind_map,
         )
 
-    def reinitialize_turbines(self):
-        self.floris.farm.turbine_map.reinitialize_turbines()
-
     def get_plane_of_points(
         self,
         x1_resolution=200,

--- a/tests/reg_tests/change_model_regression_test.py
+++ b/tests/reg_tests/change_model_regression_test.py
@@ -16,11 +16,13 @@
 from pytest import approx
 
 from tests.conftest import print_test_values, turbines_to_array
-from tests.reg_tests.gauss_regression_test import baseline as gauss_baseline
-from tests.reg_tests.curl_regression_test import baseline as curl_baseline
 from floris.simulation import Floris
+from tests.reg_tests.curl_regression_test import baseline as curl_baseline
+from tests.reg_tests.gauss_regression_test import baseline as gauss_baseline
+
 
 DEBUG = False
+
 
 def test_gauss_to_curl_to_gauss(sample_inputs_fixture):
     """
@@ -29,7 +31,9 @@ def test_gauss_to_curl_to_gauss(sample_inputs_fixture):
     Then, switch back to Gauss
     """
     # Establish that the Gauss test passes
-    sample_inputs_fixture.floris["wake"]["properties"]["velocity_model"] = "gauss"
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "velocity_model"
+    ] = "gauss_legacy"
     sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = "gauss"
     floris = Floris(input_dict=sample_inputs_fixture.floris)
     floris.farm.flow_field.calculate_wake()
@@ -65,7 +69,7 @@ def test_gauss_to_curl_to_gauss(sample_inputs_fixture):
         assert test_results[i][4] == approx(baseline[i][4])
 
     # Change back to Gauss, rerun calculate_wake, and compare to gauss
-    floris.farm.set_wake_model("gauss")
+    floris.farm.set_wake_model("gauss_legacy")
     floris.farm.flow_field.calculate_wake()
 
     test_results = turbines_to_array(floris.farm.turbine_map.turbines)

--- a/tests/reg_tests/curl_regression_test.py
+++ b/tests/reg_tests/curl_regression_test.py
@@ -38,7 +38,31 @@ yawed_baseline = [
 # power should be lower in the yawed case. The following turbine
 # powers should higher in the yawed case.
 
-def test_regression_tandem(sample_inputs_fixture):
+    def __init__(self):
+        sample_inputs = SampleInputs()
+        sample_inputs.floris["wake"]["properties"]["velocity_model"] = "curl"
+        sample_inputs.floris["wake"]["properties"]["deflection_model"] = "curl"
+        self.input_dict = sample_inputs.floris
+        self.debug = True
+
+    def baseline(self, turbine_index):
+        baseline = [
+            (0.4365911, 0.7636967, 1689187.1164557, 0.2569448, 7.9700630),
+            (0.4294209, 0.8326933, 731401.6677331, 0.2954843, 6.0592226),
+            (0.4209117, 0.8589734, 547760.8043000, 0.3122325, 5.5397800),
+        ]
+        return baseline[turbine_index]
+
+    def yawed_baseline(self, turbine_index):
+        baseline = [
+            (0.4366014, 0.7607906, 1677789.6107559, 0.2549496, 7.9700630),
+            (0.4298470, 0.8307488, 748494.6942714, 0.2942993, 6.1014089),
+            (0.4216931, 0.8566472, 563529.9139905, 0.3106902, 5.5852387),
+        ]
+        return baseline[turbine_index]
+
+
+def test_regression_tandem():
     """
     Tandem turbines
     """
@@ -46,20 +70,71 @@ def test_regression_tandem(sample_inputs_fixture):
     sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = DEFLECTION_MODEL
     floris = Floris(input_dict=sample_inputs_fixture.floris)
     floris.farm.flow_field.calculate_wake()
+    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
+        if test_class.debug:
+            print(
+                "({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(
+                    turbine.Cp,
+                    turbine.Ct,
+                    turbine.power,
+                    turbine.aI,
+                    turbine.average_velocity,
+                )
+            )
+        baseline = test_class.baseline(i)
+        assert pytest.approx(turbine.Cp) == baseline[0]
+        assert pytest.approx(turbine.Ct) == baseline[1]
+        assert pytest.approx(turbine.power) == baseline[2]
+        assert pytest.approx(turbine.aI) == baseline[3]
+        assert pytest.approx(turbine.average_velocity) == baseline[4]
 
-    test_results = turbines_to_array(floris.farm.turbine_map.turbines)
 
-    if DEBUG:
-        print_test_values(floris.farm.turbine_map.turbines)
+def test_regression_multiple_calc_wake():
+    """
+    Tandem turbines
+    """
+    test_class = CurlRegressionTest()
+    floris = Floris(input_dict=test_class.input_dict)
+    floris.farm.flow_field.calculate_wake()
+    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
+        if test_class.debug:
+            print(
+                "({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(
+                    turbine.Cp,
+                    turbine.Ct,
+                    turbine.power,
+                    turbine.aI,
+                    turbine.average_velocity,
+                )
+            )
+        baseline = test_class.baseline(i)
+        assert pytest.approx(turbine.Cp) == baseline[0]
+        assert pytest.approx(turbine.Ct) == baseline[1]
+        assert pytest.approx(turbine.power) == baseline[2]
+        assert pytest.approx(turbine.aI) == baseline[3]
+        assert pytest.approx(turbine.average_velocity) == baseline[4]
 
-    for i in range(len(floris.farm.turbine_map.turbines)):
-        assert test_results[i][0] == approx(baseline[i][0])
-        assert test_results[i][1] == approx(baseline[i][1])
-        assert test_results[i][2] == approx(baseline[i][2])
-        assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
+    floris.farm.flow_field.calculate_wake()
+    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
+        if test_class.debug:
+            print(
+                "({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f})".format(
+                    turbine.Cp,
+                    turbine.Ct,
+                    turbine.power,
+                    turbine.aI,
+                    turbine.average_velocity,
+                )
+            )
+        baseline = test_class.baseline(i)
+        assert pytest.approx(turbine.Cp) == baseline[0]
+        assert pytest.approx(turbine.Ct) == baseline[1]
+        assert pytest.approx(turbine.power) == baseline[2]
+        assert pytest.approx(turbine.aI) == baseline[3]
+        assert pytest.approx(turbine.average_velocity) == baseline[4]
 
-def test_regression_rotation(sample_inputs_fixture):
+
+def test_regression_rotation():
     """
     Turbines in tandem and rotated.
     The result from 270 degrees should match the results from 360 degrees.
@@ -148,7 +223,8 @@ def test_regression_yaw(sample_inputs_fixture):
     floris = Floris(input_dict=sample_inputs_fixture.floris)
 
     # yaw the upstream turbine 5 degrees
-    floris.farm.turbines[0].yaw_angle = 5.0
+    rotation_angle = 5.0
+    floris.farm.set_yaw_angles([rotation_angle, 0.0, 0.0])
     floris.farm.flow_field.calculate_wake()
 
     test_results = turbines_to_array(floris.farm.turbine_map.turbines)

--- a/tests/reg_tests/curl_regression_test.py
+++ b/tests/reg_tests/curl_regression_test.py
@@ -69,51 +69,6 @@ def test_regression_tandem(sample_inputs_fixture):
         assert test_results[i][4] == approx(baseline[i][4])
 
 
-def test_regression_multiple_calc_wake(sample_inputs_fixture):
-    """
-    Verify turbine values stay the same with repeated (3x) calculate_wake calls.
-    """
-    sample_inputs_fixture.floris["wake"]["properties"][
-        "velocity_model"
-    ] = VELOCITY_MODEL
-    sample_inputs_fixture.floris["wake"]["properties"][
-        "deflection_model"
-    ] = DEFLECTION_MODEL
-    floris = Floris(input_dict=sample_inputs_fixture.floris)
-    floris.farm.flow_field.calculate_wake()
-    test_results = turbines_to_array(floris.farm.turbine_map.turbines)
-    if DEBUG:
-        print_test_values(floris.farm.turbine_map.turbines)
-    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
-        assert test_results[i][0] == approx(baseline[i][0])
-        assert test_results[i][1] == approx(baseline[i][1])
-        assert test_results[i][2] == approx(baseline[i][2])
-        assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
-
-    floris.farm.flow_field.calculate_wake()
-    test_results = turbines_to_array(floris.farm.turbine_map.turbines)
-    if DEBUG:
-        print_test_values(floris.farm.turbine_map.turbines)
-    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
-        assert test_results[i][0] == approx(baseline[i][0])
-        assert test_results[i][1] == approx(baseline[i][1])
-        assert test_results[i][2] == approx(baseline[i][2])
-        assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
-
-    floris.farm.flow_field.calculate_wake()
-    test_results = turbines_to_array(floris.farm.turbine_map.turbines)
-    if DEBUG:
-        print_test_values(floris.farm.turbine_map.turbines)
-    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
-        assert test_results[i][0] == approx(baseline[i][0])
-        assert test_results[i][1] == approx(baseline[i][1])
-        assert test_results[i][2] == approx(baseline[i][2])
-        assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
-
-
 def test_regression_rotation(sample_inputs_fixture):
     """
     Turbines in tandem and rotated.
@@ -193,11 +148,11 @@ def test_regression_rotation(sample_inputs_fixture):
     assert approx(turbine.average_velocity) == first_waked_baseline[4]
 
     turbine = floris.farm.turbine_map.turbines[2]
-    assert approx(turbine.Cp) == second_waked_baseline[0]
-    assert approx(turbine.Ct) == second_waked_baseline[1]
-    assert approx(turbine.power) == second_waked_baseline[2]
-    assert approx(turbine.aI) == second_waked_baseline[3]
-    assert approx(turbine.average_velocity) == second_waked_baseline[4]
+    assert approx(turbine.Cp, rel=1e-5) == second_waked_baseline[0]
+    assert approx(turbine.Ct, rel=1e-5) == second_waked_baseline[1]
+    assert approx(turbine.power, rel=1e-5) == second_waked_baseline[2]
+    assert approx(turbine.aI, rel=1e-5) == second_waked_baseline[3]
+    assert approx(turbine.average_velocity, rel=1e-5) == second_waked_baseline[4]
 
 
 def test_regression_yaw(sample_inputs_fixture):
@@ -223,6 +178,51 @@ def test_regression_yaw(sample_inputs_fixture):
 
     for i in range(len(floris.farm.turbine_map.turbines)):
         baseline = yawed_baseline
+        assert test_results[i][0] == approx(baseline[i][0])
+        assert test_results[i][1] == approx(baseline[i][1])
+        assert test_results[i][2] == approx(baseline[i][2])
+        assert test_results[i][3] == approx(baseline[i][3])
+        assert test_results[i][4] == approx(baseline[i][4])
+
+
+def test_regression_multiple_calc_wake(sample_inputs_fixture):
+    """
+    Verify turbine values stay the same with repeated (3x) calculate_wake calls.
+    """
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "velocity_model"
+    ] = VELOCITY_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "deflection_model"
+    ] = DEFLECTION_MODEL
+    floris = Floris(input_dict=sample_inputs_fixture.floris)
+    floris.farm.flow_field.calculate_wake()
+    test_results = turbines_to_array(floris.farm.turbine_map.turbines)
+    if DEBUG:
+        print_test_values(floris.farm.turbine_map.turbines)
+    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
+        assert test_results[i][0] == approx(baseline[i][0])
+        assert test_results[i][1] == approx(baseline[i][1])
+        assert test_results[i][2] == approx(baseline[i][2])
+        assert test_results[i][3] == approx(baseline[i][3])
+        assert test_results[i][4] == approx(baseline[i][4])
+
+    floris.farm.flow_field.calculate_wake()
+    test_results = turbines_to_array(floris.farm.turbine_map.turbines)
+    if DEBUG:
+        print_test_values(floris.farm.turbine_map.turbines)
+    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
+        assert test_results[i][0] == approx(baseline[i][0])
+        assert test_results[i][1] == approx(baseline[i][1])
+        assert test_results[i][2] == approx(baseline[i][2])
+        assert test_results[i][3] == approx(baseline[i][3])
+        assert test_results[i][4] == approx(baseline[i][4])
+
+    floris.farm.flow_field.calculate_wake()
+    test_results = turbines_to_array(floris.farm.turbine_map.turbines)
+    if DEBUG:
+        print_test_values(floris.farm.turbine_map.turbines)
+    for i, turbine in enumerate(floris.farm.turbine_map.turbines):
         assert test_results[i][0] == approx(baseline[i][0])
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])


### PR DESCRIPTION
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
This PR addresses some issues that were recently identified with using the curled wake model in the latest version of FLORIS. In particular, repeated calls to `calculate_wake` were resulting in zero turbine powers. This was addressed by reinitializing the `u`, `v`, and `w` velocity fields (previously handled by calling `reinitialize_flow_field` before each `calculate_wake` call). This PR also includes a performance improvement for the curled wake model in how the turbine velocity values are matched with flow field velocity values in `tubine.py/calculate_swept_area_velocities`. Related, this matching is updated for the curled wake model when the wind direction is changed. The turbines are now correctly reinitialized when the `set_wake_model` method is used to switch to the curled wake model when a `fi` was originally instantiated with a different wake velocity model. An addition was made to `get_hor_plane` to address an issue with plotting the curled wake model at different wind directions.

**Related issue, if one exists**
None.

**Impacted areas of the software**
`floris/simulation/farm.py`
`floris/simulation/flow_field.py`
`floris/simulation/turbine.py`
`floris/simulation/turbine_map.py`
`floris/tools/floris_interface.py`

**Additional supporting information**
None.

**Test results, if applicable**
Added new test cases to `tests/reg_tests/curl_regression_test.py` to catch these issues in the future.