### PR TITLE
Temporarily remove Cp from turbine properties

### DIFF
--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -597,33 +597,51 @@ class Turbine(LoggerBase):
 
         return avg_vel
 
-    @property
-    def Cp(self):
-        """
-        This property returns the power coeffcient of a turbine.
+    # NOTE: Temporarily comment out because not used anywhere
+    # When placing back, need to infer Cp from power since that
+    # is where interpolation happens. TODO: Open research question
+    # whether Cp should include yaw correction or not; or is it just
+    # necessary to label it as such?
+    # @property
+    # def Cp(self):
+    #     """
+    #     This property returns the power coeffcient of a turbine.
 
-        This property returns the coefficient of power of the turbine
-        using the rotor swept area average velocity, interpolated from
-        the coefficient of power table. The average velocity is
-        calculated as the cube root of the mean cubed velocity in the
-        rotor area.
+    #     This property returns the coefficient of power of the turbine
+    #     using the rotor swept area average velocity, interpolated from
+    #     the coefficient of power table. The average velocity is
+    #     calculated as the cube root of the mean cubed velocity in the
+    #     rotor area.
 
-        **Note:** The velocity is scalled to an effective velocity by the yaw.
+    #     **Note:** The velocity is scalled to an effective velocity by the yaw.
 
-        Returns:
-            float: The power coefficient of a turbine at the current
-            operating conditions.
+    #     Returns:
+    #         float: The power coefficient of a turbine at the current
+    #         operating conditions.
 
-        Examples:
-            To get the power coefficient value for a turbine:
+    #     Examples:
+    #         To get the power coefficient value for a turbine:
 
-            >>> Cp = floris.farm.turbines[0].Cp()
-        """
-        # Compute the yaw effective velocity
-        pW = self.pP / 3.0  # Convert from pP to pW
-        yaw_effective_velocity = self.average_velocity * cosd(self.yaw_angle) ** pW
+    #         >>> Cp = floris.farm.turbines[0].Cp()
+    #     """
+    #     # Compute the yaw effective velocity
+    #     pW = self.pP / 3.0  # Convert from pP to w
+    #     pV = self.pT / 3.0  # convert from pT to w
+    #     yaw_effective_velocity = (
+    #         self.average_velocity
+    #         * (cosd(self.yaw_angle) ** pW)
+    #         * (cosd(self.tilt_angle) ** pV)
+    #     )
 
-        return self._fCp(yaw_effective_velocity)
+    #     P_avail = (
+    #         0.5
+    #         * self.air_density
+    #         * np.pi
+    #         * (self.rotor_diameter / 2) ** 2
+    #         * yaw_effective_velocity ** 3
+    #     )
+
+    #     return self.power / P_avail
 
     @property
     def Ct(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,14 +15,19 @@
 
 import pytest
 
+
 def turbines_to_array(turbine_list: list):
-    return [ [t.Cp, t.Ct, t.power, t.aI, t.average_velocity] for t in turbine_list ]
+    return [[t.Ct, t.power, t.aI, t.average_velocity] for t in turbine_list]
+
 
 def print_test_values(turbine_list: list):
     for t in turbine_list:
         print(
-            "({:.7f}, {:.7f}, {:.7f}, {:.7f}, {:.7f}),".format(t.Cp, t.Ct, t.power, t.aI, t.average_velocity)
+            "({:.7f}, {:.7f}, {:.7f}, {:.7f}),".format(
+                t.Ct, t.power, t.aI, t.average_velocity
+            )
         )
+
 
 @pytest.fixture
 def sample_inputs_fixture():
@@ -180,7 +185,7 @@ class SampleInputs:
                         "gauss": {
                             "dm": 1.0,
                             "eps_gain": 0.2,
-                            "use_secondary_steering": False
+                            "use_secondary_steering": False,
                         }
                     },
                     "wake_velocity_parameters": {
@@ -189,9 +194,9 @@ class SampleInputs:
                             "eps_gain": 0.2,
                             "ka": 0.38,
                             "kb": 0.004,
-                            "use_yaw_added_recovery": False
+                            "use_yaw_added_recovery": False,
                         }
-                    }
+                    },
                 },
             },
         }
@@ -201,13 +206,7 @@ class SampleInputs:
             "turbine": self.turbine,
             "wake": self.wake,
             "logging": {
-                "console": {
-                    "enable": True,
-                    "level": 1
-                },
-                "file": {
-                    "enable": False,
-                    "level": 1
-                }
-            }
+                "console": {"enable": True, "level": 1},
+                "file": {"enable": False, "level": 1},
+            },
         }

--- a/tests/flow_field_unit_test.py
+++ b/tests/flow_field_unit_test.py
@@ -86,7 +86,6 @@ def test_2x_calculate_wake(flow_field_fixture):
     flow_field_fixture.calculate_wake()
     for i, turbine in enumerate(flow_field_fixture.turbine_map.turbines):
         calculate_wake_results[1][i] = {
-            "Cp": turbine.Cp,
             "Ct": turbine.Ct,
             "power": turbine.power,
             "aI": turbine.aI,
@@ -97,7 +96,6 @@ def test_2x_calculate_wake(flow_field_fixture):
     flow_field_fixture.calculate_wake()
     for i, turbine in enumerate(flow_field_fixture.turbine_map.turbines):
         calculate_wake_results[2][i] = {
-            "Cp": turbine.Cp,
             "Ct": turbine.Ct,
             "power": turbine.power,
             "aI": turbine.aI,

--- a/tests/reg_tests/change_model_regression_test.py
+++ b/tests/reg_tests/change_model_regression_test.py
@@ -49,7 +49,6 @@ def test_gauss_to_curl_to_gauss(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
 
     # Change the model to Curl, rerun calculate_wake, and compare to Curl
     floris.farm.set_wake_model("curl")
@@ -66,7 +65,6 @@ def test_gauss_to_curl_to_gauss(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
 
     # Change back to Gauss, rerun calculate_wake, and compare to gauss
     floris.farm.set_wake_model("gauss_legacy")
@@ -83,4 +81,3 @@ def test_gauss_to_curl_to_gauss(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])

--- a/tests/reg_tests/curl_regression_test.py
+++ b/tests/reg_tests/curl_regression_test.py
@@ -25,21 +25,21 @@ VELOCITY_MODEL = "curl"
 DEFLECTION_MODEL = "curl"
 
 baseline = [
-    (0.4632711, 0.7655987, 1808879.0573334, 0.2579249, 7.9700630),
-    (0.4542347, 0.8315292, 790095.3264943, 0.2947740, 6.0555893),
-    (0.4463487, 0.8568269, 585359.6178647, 0.3108089, 5.5408759),
+    (0.7655987, 1808879.0573334, 0.2579249, 7.9700630),
+    (0.8315292, 790095.3264943, 0.2947740, 6.0555893),
+    (0.8568269, 585359.6178647, 0.3108089, 5.5408759),
 ]
 
 yawed_baseline = [
-    (0.4632738, 0.7626853, 1795186.5605035, 0.2559142, 7.9700630),
-    (0.4547445, 0.8295616, 807715.7153082, 0.2935790, 6.0979495),
-    (0.4479135, 0.8538732, 598723.1123378, 0.3088673, 5.5865154),
+    (0.7626853, 1795186.5605035, 0.2559142, 7.9700630),
+    (0.8295616, 807715.7153082, 0.2935790, 6.0979495),
+    (0.8538732, 598723.1123378, 0.3088673, 5.5865154),
 ]
 
 wd315_baseline = [
-    (0.4632711, 0.7655987, 1808879.0573334, 0.2579249, 7.9700630),
-    (0.4632711, 0.7655987, 1808879.0573334, 0.2579249, 7.9700630),
-    (0.4632711, 0.7655987, 1808879.0573334, 0.2579249, 7.9700630),
+    (0.7655987, 1808879.0573334, 0.2579249, 7.9700630),
+    (0.7655987, 1808879.0573334, 0.2579249, 7.9700630),
+    (0.7655987, 1808879.0573334, 0.2579249, 7.9700630),
 ]
 
 
@@ -66,7 +66,6 @@ def test_regression_tandem(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
 
 
 def test_regression_rotation(sample_inputs_fixture):
@@ -88,7 +87,6 @@ def test_regression_rotation(sample_inputs_fixture):
     floris.farm.flow_field.calculate_wake()
     turbine = floris.farm.turbine_map.turbines[0]
     unwaked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -96,7 +94,6 @@ def test_regression_rotation(sample_inputs_fixture):
     )
     turbine = floris.farm.turbine_map.turbines[1]
     first_waked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -104,7 +101,6 @@ def test_regression_rotation(sample_inputs_fixture):
     )
     turbine = floris.farm.turbine_map.turbines[2]
     second_waked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -134,25 +130,22 @@ def test_regression_rotation(sample_inputs_fixture):
     floris.farm.flow_field.calculate_wake()
 
     turbine = floris.farm.turbine_map.turbines[0]
-    assert approx(turbine.Cp) == unwaked_baseline[0]
-    assert approx(turbine.Ct) == unwaked_baseline[1]
-    assert approx(turbine.power) == unwaked_baseline[2]
-    assert approx(turbine.aI) == unwaked_baseline[3]
-    assert approx(turbine.average_velocity) == unwaked_baseline[4]
+    assert approx(turbine.Ct) == unwaked_baseline[0]
+    assert approx(turbine.power) == unwaked_baseline[1]
+    assert approx(turbine.aI) == unwaked_baseline[2]
+    assert approx(turbine.average_velocity) == unwaked_baseline[3]
 
     turbine = floris.farm.turbine_map.turbines[1]
-    assert approx(turbine.Cp) == first_waked_baseline[0]
-    assert approx(turbine.Ct) == first_waked_baseline[1]
-    assert approx(turbine.power) == first_waked_baseline[2]
-    assert approx(turbine.aI) == first_waked_baseline[3]
-    assert approx(turbine.average_velocity) == first_waked_baseline[4]
+    assert approx(turbine.Ct) == first_waked_baseline[0]
+    assert approx(turbine.power) == first_waked_baseline[1]
+    assert approx(turbine.aI) == first_waked_baseline[2]
+    assert approx(turbine.average_velocity) == first_waked_baseline[3]
 
     turbine = floris.farm.turbine_map.turbines[2]
-    assert approx(turbine.Cp, rel=1e-5) == second_waked_baseline[0]
-    assert approx(turbine.Ct, rel=1e-5) == second_waked_baseline[1]
-    assert approx(turbine.power, rel=1e-5) == second_waked_baseline[2]
-    assert approx(turbine.aI, rel=1e-5) == second_waked_baseline[3]
-    assert approx(turbine.average_velocity, rel=1e-5) == second_waked_baseline[4]
+    assert approx(turbine.Ct, rel=1e-5) == second_waked_baseline[0]
+    assert approx(turbine.power, rel=1e-5) == second_waked_baseline[1]
+    assert approx(turbine.aI, rel=1e-5) == second_waked_baseline[2]
+    assert approx(turbine.average_velocity, rel=1e-5) == second_waked_baseline[3]
 
 
 def test_regression_yaw(sample_inputs_fixture):
@@ -182,7 +175,6 @@ def test_regression_yaw(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
 
 
 def test_regression_multiple_calc_wake(sample_inputs_fixture):
@@ -205,7 +197,6 @@ def test_regression_multiple_calc_wake(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
 
     floris.farm.flow_field.calculate_wake()
     test_results = turbines_to_array(floris.farm.turbine_map.turbines)
@@ -216,7 +207,6 @@ def test_regression_multiple_calc_wake(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
 
     floris.farm.flow_field.calculate_wake()
     test_results = turbines_to_array(floris.farm.turbine_map.turbines)
@@ -227,7 +217,6 @@ def test_regression_multiple_calc_wake(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
 
 
 def test_change_wind_direction(sample_inputs_fixture):
@@ -254,7 +243,6 @@ def test_change_wind_direction(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
 
     floris.farm.wind_map.input_direction = [315.0]
     floris.farm.wind_map.calculate_wind_direction()
@@ -273,4 +261,3 @@ def test_change_wind_direction(sample_inputs_fixture):
         assert test_results[i][1] == approx(wd315_baseline[i][1])
         assert test_results[i][2] == approx(wd315_baseline[i][2])
         assert test_results[i][3] == approx(wd315_baseline[i][3])
-        assert test_results[i][4] == approx(wd315_baseline[i][4])

--- a/tests/reg_tests/gauss_regression_test.py
+++ b/tests/reg_tests/gauss_regression_test.py
@@ -26,33 +26,33 @@ VELOCITY_MODEL = "gauss_legacy"
 DEFLECTION_MODEL = "gauss"
 
 baseline = [
-    (0.4632696, 0.7655527, 1816305.2933644, 0.2579012, 7.9803783),
-    (0.4515806, 0.8417746, 698345.8349634, 0.3011122, 5.8350192),
-    (0.4528670, 0.8368088, 742815.3620867, 0.2980154, 5.9419260),
+    (0.7655527, 1816305.2933644, 0.2579012, 7.9803783),
+    (0.8417746, 698345.8349634, 0.3011122, 5.8350192),
+    (0.8368088, 742815.3620867, 0.2980154, 5.9419260),
 ]
 
 yawed_baseline = [
-    (0.4632723, 0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
-    (0.4519965, 0.8401693, 712721.8017101, 0.3001058, 5.8695797),
-    (0.4529146, 0.8366251, 744460.9541522, 0.2979017, 5.9458821),
+    (0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
+    (0.8401693, 712721.8017101, 0.3001058, 5.8695797),
+    (0.8366251, 744460.9541522, 0.2979017, 5.9458821),
 ]
 
 gch_baseline = [
-    (0.4632723, 0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
-    (0.4522286, 0.8392733, 720745.6467388, 0.2995463, 5.8888694),
-    (0.4532284, 0.8354140, 755306.6488337, 0.2971540, 5.9719556),
+    (0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
+    (0.8392733, 720745.6467388, 0.2995463, 5.8888694),
+    (0.8354140, 755306.6488337, 0.2971540, 5.9719556),
 ]
 
 yaw_added_recovery_baseline = [
-    (0.4632723, 0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
-    (0.4522285, 0.8392735, 720743.5433910, 0.2995465, 5.8888643),
-    (0.4531591, 0.8356813, 752912.7537170, 0.2973188, 5.9662006),
+    (0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
+    (0.8392735, 720743.5433910, 0.2995465, 5.8888643),
+    (0.8356813, 752912.7537170, 0.2973188, 5.9662006),
 ]
 
 secondary_steering_baseline = [
-    (0.4632723, 0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
-    (0.4519965, 0.8401691, 712723.9446334, 0.3001057, 5.8695848),
-    (0.4529852, 0.8363526, 746901.3150465, 0.2977332, 5.9517488),
+    (0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
+    (0.8401691, 712723.9446334, 0.3001057, 5.8695848),
+    (0.8363526, 746901.3150465, 0.2977332, 5.9517488),
 ]
 
 # Note: compare the yawed vs non-yawed results. The upstream turbine
@@ -84,7 +84,6 @@ def test_regression_tandem(sample_inputs_fixture):
         assert test_results[i][1] == approx(check[i][1])
         assert test_results[i][2] == approx(check[i][2])
         assert test_results[i][3] == approx(check[i][3])
-        assert test_results[i][4] == approx(check[i][4])
 
 
 def test_regression_rotation(sample_inputs_fixture):
@@ -106,7 +105,6 @@ def test_regression_rotation(sample_inputs_fixture):
     floris.farm.flow_field.calculate_wake()
     turbine = floris.farm.turbine_map.turbines[0]
     unwaked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -114,7 +112,6 @@ def test_regression_rotation(sample_inputs_fixture):
     )
     turbine = floris.farm.turbine_map.turbines[1]
     first_waked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -122,7 +119,6 @@ def test_regression_rotation(sample_inputs_fixture):
     )
     turbine = floris.farm.turbine_map.turbines[2]
     second_waked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -152,25 +148,22 @@ def test_regression_rotation(sample_inputs_fixture):
     floris.farm.flow_field.calculate_wake()
 
     turbine = floris.farm.turbine_map.turbines[0]
-    assert approx(turbine.Cp) == unwaked_baseline[0]
-    assert approx(turbine.Ct) == unwaked_baseline[1]
-    assert approx(turbine.power) == unwaked_baseline[2]
-    assert approx(turbine.aI) == unwaked_baseline[3]
-    assert approx(turbine.average_velocity) == unwaked_baseline[4]
+    assert approx(turbine.Ct) == unwaked_baseline[0]
+    assert approx(turbine.power) == unwaked_baseline[1]
+    assert approx(turbine.aI) == unwaked_baseline[2]
+    assert approx(turbine.average_velocity) == unwaked_baseline[3]
 
     turbine = floris.farm.turbine_map.turbines[1]
-    assert approx(turbine.Cp) == first_waked_baseline[0]
-    assert approx(turbine.Ct) == first_waked_baseline[1]
-    assert approx(turbine.power) == first_waked_baseline[2]
-    assert approx(turbine.aI) == first_waked_baseline[3]
-    assert approx(turbine.average_velocity) == first_waked_baseline[4]
+    assert approx(turbine.Ct) == first_waked_baseline[0]
+    assert approx(turbine.power) == first_waked_baseline[1]
+    assert approx(turbine.aI) == first_waked_baseline[2]
+    assert approx(turbine.average_velocity) == first_waked_baseline[3]
 
     turbine = floris.farm.turbine_map.turbines[2]
-    assert approx(turbine.Cp) == second_waked_baseline[0]
-    assert approx(turbine.Ct) == second_waked_baseline[1]
-    assert approx(turbine.power) == second_waked_baseline[2]
-    assert approx(turbine.aI) == second_waked_baseline[3]
-    assert approx(turbine.average_velocity) == second_waked_baseline[4]
+    assert approx(turbine.Ct) == second_waked_baseline[0]
+    assert approx(turbine.power) == second_waked_baseline[1]
+    assert approx(turbine.aI) == second_waked_baseline[2]
+    assert approx(turbine.average_velocity) == second_waked_baseline[3]
 
 
 def test_regression_yaw(sample_inputs_fixture):
@@ -200,7 +193,6 @@ def test_regression_yaw(sample_inputs_fixture):
         assert test_results[i][1] == approx(check[i][1])
         assert test_results[i][2] == approx(check[i][2])
         assert test_results[i][3] == approx(check[i][3])
-        assert test_results[i][4] == approx(check[i][4])
 
 
 def test_regression_gch(sample_inputs_fixture):
@@ -231,7 +223,6 @@ def test_regression_gch(sample_inputs_fixture):
         assert test_results[i][1] == approx(check[i][1])
         assert test_results[i][2] == approx(check[i][2])
         assert test_results[i][3] == approx(check[i][3])
-        assert test_results[i][4] == approx(check[i][4])
 
     # With GCH on, the results should change
     floris.farm.wake.deflection_model.use_secondary_steering = True
@@ -251,7 +242,6 @@ def test_regression_gch(sample_inputs_fixture):
         assert test_results[i][1] == approx(check[i][1])
         assert test_results[i][2] == approx(check[i][2])
         assert test_results[i][3] == approx(check[i][3])
-        assert test_results[i][4] == approx(check[i][4])
 
 
 def test_regression_yaw_added_recovery(sample_inputs_fixture):
@@ -285,7 +275,6 @@ def test_regression_yaw_added_recovery(sample_inputs_fixture):
         assert test_results[i][1] == approx(check[i][1])
         assert test_results[i][2] == approx(check[i][2])
         assert test_results[i][3] == approx(check[i][3])
-        assert test_results[i][4] == approx(check[i][4])
 
 
 def test_regression_secondary_steering(sample_inputs_fixture):
@@ -319,4 +308,3 @@ def test_regression_secondary_steering(sample_inputs_fixture):
         assert test_results[i][1] == approx(check[i][1])
         assert test_results[i][2] == approx(check[i][2])
         assert test_results[i][3] == approx(check[i][3])
-        assert test_results[i][4] == approx(check[i][4])

--- a/tests/reg_tests/jensen_jimenez_regression_test.py
+++ b/tests/reg_tests/jensen_jimenez_regression_test.py
@@ -13,37 +13,44 @@
 # See https://floris.readthedocs.io for documentation
 
 import copy
+
 from pytest import approx
 
 from tests.conftest import print_test_values, turbines_to_array
 from floris.simulation import Floris, TurbineMap
+
 
 DEBUG = False
 VELOCITY_MODEL = "jensen"
 DEFLECTION_MODEL = "jimenez"
 
 baseline = [
-    (0.4632696, 0.7655527, 1816305.2933644, 0.2579012, 7.9803783),
-    (0.4553818, 0.8271015, 829746.3737886, 0.2920946, 6.1509123),
-    (0.4495573, 0.8495846, 628405.8676588, 0.3060829, 5.6668802)
+    (0.7655527, 1816305.2933644, 0.2579012, 7.9803783),
+    (0.8271015, 829746.3737886, 0.2920946, 6.1509123),
+    (0.8495846, 628405.8676588, 0.3060829, 5.6668802),
 ]
 
 yawed_baseline = [
-    (0.4632723, 0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
-    (0.4555534, 0.8264390, 835678.4341263, 0.2916968, 6.1651732),
-    (0.4496306, 0.8493018, 630938.4582092, 0.3059007, 5.6729686)
+    (0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
+    (0.8264390, 835678.4341263, 0.2916968, 6.1651732),
+    (0.8493018, 630938.4582092, 0.3059007, 5.6729686),
 ]
 
 # Note: compare the yawed vs non-yawed results. The upstream turbine
 # power should be lower in the yawed case. The following turbine
 # powers should higher in the yawed case.
 
+
 def test_regression_tandem(sample_inputs_fixture):
     """
     Tandem turbines
     """
-    sample_inputs_fixture.floris["wake"]["properties"]["velocity_model"] = VELOCITY_MODEL
-    sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = DEFLECTION_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "velocity_model"
+    ] = VELOCITY_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "deflection_model"
+    ] = DEFLECTION_MODEL
     floris = Floris(input_dict=sample_inputs_fixture.floris)
     floris.farm.flow_field.calculate_wake()
 
@@ -57,15 +64,19 @@ def test_regression_tandem(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
+
 
 def test_regression_rotation(sample_inputs_fixture):
     """
     Turbines in tandem and rotated.
     The result from 270 degrees should match the results from 360 degrees.
     """
-    sample_inputs_fixture.floris["wake"]["properties"]["velocity_model"] = VELOCITY_MODEL
-    sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = DEFLECTION_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "velocity_model"
+    ] = VELOCITY_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "deflection_model"
+    ] = DEFLECTION_MODEL
     floris = Floris(input_dict=sample_inputs_fixture.floris)
     fresh_turbine = copy.deepcopy(floris.farm.turbine_map.turbines[0])
     wind_map = floris.farm.wind_map
@@ -74,7 +85,6 @@ def test_regression_rotation(sample_inputs_fixture):
     floris.farm.flow_field.calculate_wake()
     turbine = floris.farm.turbine_map.turbines[0]
     unwaked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -82,7 +92,6 @@ def test_regression_rotation(sample_inputs_fixture):
     )
     turbine = floris.farm.turbine_map.turbines[1]
     first_waked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -90,7 +99,6 @@ def test_regression_rotation(sample_inputs_fixture):
     )
     turbine = floris.farm.turbine_map.turbines[2]
     second_waked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -103,7 +111,8 @@ def test_regression_rotation(sample_inputs_fixture):
     new_map = TurbineMap(
         [0.0, 0.0, 0.0],
         [
-            10 * sample_inputs_fixture.floris["turbine"]["properties"]["rotor_diameter"],
+            10
+            * sample_inputs_fixture.floris["turbine"]["properties"]["rotor_diameter"],
             5 * sample_inputs_fixture.floris["turbine"]["properties"]["rotor_diameter"],
             0.0,
         ],
@@ -119,32 +128,34 @@ def test_regression_rotation(sample_inputs_fixture):
     floris.farm.flow_field.calculate_wake()
 
     turbine = floris.farm.turbine_map.turbines[0]
-    assert approx(turbine.Cp) == unwaked_baseline[0]
-    assert approx(turbine.Ct) == unwaked_baseline[1]
-    assert approx(turbine.power) == unwaked_baseline[2]
-    assert approx(turbine.aI) == unwaked_baseline[3]
-    assert approx(turbine.average_velocity) == unwaked_baseline[4]
+    assert approx(turbine.Ct) == unwaked_baseline[0]
+    assert approx(turbine.power) == unwaked_baseline[1]
+    assert approx(turbine.aI) == unwaked_baseline[2]
+    assert approx(turbine.average_velocity) == unwaked_baseline[3]
 
     turbine = floris.farm.turbine_map.turbines[1]
-    assert approx(turbine.Cp) == first_waked_baseline[0]
-    assert approx(turbine.Ct) == first_waked_baseline[1]
-    assert approx(turbine.power) == first_waked_baseline[2]
-    assert approx(turbine.aI) == first_waked_baseline[3]
-    assert approx(turbine.average_velocity) == first_waked_baseline[4]
+    assert approx(turbine.Ct) == first_waked_baseline[0]
+    assert approx(turbine.power) == first_waked_baseline[1]
+    assert approx(turbine.aI) == first_waked_baseline[2]
+    assert approx(turbine.average_velocity) == first_waked_baseline[3]
 
     turbine = floris.farm.turbine_map.turbines[2]
-    assert approx(turbine.Cp) == second_waked_baseline[0]
-    assert approx(turbine.Ct) == second_waked_baseline[1]
-    assert approx(turbine.power) == second_waked_baseline[2]
-    assert approx(turbine.aI) == second_waked_baseline[3]
-    assert approx(turbine.average_velocity) == second_waked_baseline[4]
+    assert approx(turbine.Ct) == second_waked_baseline[0]
+    assert approx(turbine.power) == second_waked_baseline[1]
+    assert approx(turbine.aI) == second_waked_baseline[2]
+    assert approx(turbine.average_velocity) == second_waked_baseline[3]
+
 
 def test_regression_yaw(sample_inputs_fixture):
     """
     Tandem turbines with the upstream turbine yawed
     """
-    sample_inputs_fixture.floris["wake"]["properties"]["velocity_model"] = VELOCITY_MODEL
-    sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = DEFLECTION_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "velocity_model"
+    ] = VELOCITY_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "deflection_model"
+    ] = DEFLECTION_MODEL
     floris = Floris(input_dict=sample_inputs_fixture.floris)
 
     # yaw the upstream turbine 5 degrees
@@ -162,4 +173,3 @@ def test_regression_yaw(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])

--- a/tests/reg_tests/multizone_jimenez_regression_test.py
+++ b/tests/reg_tests/multizone_jimenez_regression_test.py
@@ -13,37 +13,44 @@
 # See https://floris.readthedocs.io for documentation
 
 import copy
+
 from pytest import approx
 
 from tests.conftest import print_test_values, turbines_to_array
 from floris.simulation import Floris, TurbineMap
+
 
 DEBUG = False
 VELOCITY_MODEL = "multizone"
 DEFLECTION_MODEL = "jimenez"
 
 baseline = [
-    (0.4632696, 0.7655527, 1816305.2933644, 0.2579012, 7.9803783),
-    (0.4403730, 0.8681066, 534325.7405792, 0.3184143, 5.3665830),
-    (0.3857132, 0.9477858, 247452.0393393, 0.3857479, 4.2843826)
+    (0.7655527, 1816305.2933644, 0.2579012, 7.9803783),
+    (0.8681066, 534325.7405792, 0.3184143, 5.3665830),
+    (0.9477858, 247452.0393393, 0.3857479, 4.2843826),
 ]
 
 yawed_baseline = [
-    (0.4632723, 0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
-    (0.4421980, 0.8646618, 549911.3056840, 0.3160583, 5.4198115),
-    (0.4022330, 0.9307933, 279868.4185378, 0.3684641, 4.4569688)
+    (0.7626396, 1802595.0749161, 0.2558908, 7.9803783),
+    (0.8646618, 549911.3056840, 0.3160583, 5.4198115),
+    (0.9307933, 279868.4185378, 0.3684641, 4.4569688),
 ]
 
 # Note: compare the yawed vs non-yawed results. The upstream turbine
 # power should be lower in the yawed case. The following turbine
 # powers should higher in the yawed case.
 
+
 def test_regression_tandem(sample_inputs_fixture):
     """
     Tandem turbines
     """
-    sample_inputs_fixture.floris["wake"]["properties"]["velocity_model"] = VELOCITY_MODEL
-    sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = DEFLECTION_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "velocity_model"
+    ] = VELOCITY_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "deflection_model"
+    ] = DEFLECTION_MODEL
     floris = Floris(input_dict=sample_inputs_fixture.floris)
     floris.farm.flow_field.calculate_wake()
 
@@ -57,15 +64,19 @@ def test_regression_tandem(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])
+
 
 def test_regression_rotation(sample_inputs_fixture):
     """
     Turbines in tandem and rotated.
     The result from 270 degrees should match the results from 360 degrees.
     """
-    sample_inputs_fixture.floris["wake"]["properties"]["velocity_model"] = VELOCITY_MODEL
-    sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = DEFLECTION_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "velocity_model"
+    ] = VELOCITY_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "deflection_model"
+    ] = DEFLECTION_MODEL
     floris = Floris(input_dict=sample_inputs_fixture.floris)
     fresh_turbine = copy.deepcopy(floris.farm.turbine_map.turbines[0])
     wind_map = floris.farm.wind_map
@@ -74,7 +85,6 @@ def test_regression_rotation(sample_inputs_fixture):
     floris.farm.flow_field.calculate_wake()
     turbine = floris.farm.turbine_map.turbines[0]
     unwaked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -82,7 +92,6 @@ def test_regression_rotation(sample_inputs_fixture):
     )
     turbine = floris.farm.turbine_map.turbines[1]
     first_waked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -90,7 +99,6 @@ def test_regression_rotation(sample_inputs_fixture):
     )
     turbine = floris.farm.turbine_map.turbines[2]
     second_waked_baseline = (
-        turbine.Cp,
         turbine.Ct,
         turbine.power,
         turbine.aI,
@@ -103,7 +111,8 @@ def test_regression_rotation(sample_inputs_fixture):
     new_map = TurbineMap(
         [0.0, 0.0, 0.0],
         [
-            10 * sample_inputs_fixture.floris["turbine"]["properties"]["rotor_diameter"],
+            10
+            * sample_inputs_fixture.floris["turbine"]["properties"]["rotor_diameter"],
             5 * sample_inputs_fixture.floris["turbine"]["properties"]["rotor_diameter"],
             0.0,
         ],
@@ -119,32 +128,34 @@ def test_regression_rotation(sample_inputs_fixture):
     floris.farm.flow_field.calculate_wake()
 
     turbine = floris.farm.turbine_map.turbines[0]
-    assert approx(turbine.Cp) == unwaked_baseline[0]
-    assert approx(turbine.Ct) == unwaked_baseline[1]
-    assert approx(turbine.power) == unwaked_baseline[2]
-    assert approx(turbine.aI) == unwaked_baseline[3]
-    assert approx(turbine.average_velocity) == unwaked_baseline[4]
+    assert approx(turbine.Ct) == unwaked_baseline[0]
+    assert approx(turbine.power) == unwaked_baseline[1]
+    assert approx(turbine.aI) == unwaked_baseline[2]
+    assert approx(turbine.average_velocity) == unwaked_baseline[3]
 
     turbine = floris.farm.turbine_map.turbines[1]
-    assert approx(turbine.Cp) == first_waked_baseline[0]
-    assert approx(turbine.Ct) == first_waked_baseline[1]
-    assert approx(turbine.power) == first_waked_baseline[2]
-    assert approx(turbine.aI) == first_waked_baseline[3]
-    assert approx(turbine.average_velocity) == first_waked_baseline[4]
+    assert approx(turbine.Ct) == first_waked_baseline[0]
+    assert approx(turbine.power) == first_waked_baseline[1]
+    assert approx(turbine.aI) == first_waked_baseline[2]
+    assert approx(turbine.average_velocity) == first_waked_baseline[3]
 
     turbine = floris.farm.turbine_map.turbines[2]
-    assert approx(turbine.Cp) == second_waked_baseline[0]
-    assert approx(turbine.Ct) == second_waked_baseline[1]
-    assert approx(turbine.power) == second_waked_baseline[2]
-    assert approx(turbine.aI) == second_waked_baseline[3]
-    assert approx(turbine.average_velocity) == second_waked_baseline[4]
+    assert approx(turbine.Ct) == second_waked_baseline[0]
+    assert approx(turbine.power) == second_waked_baseline[1]
+    assert approx(turbine.aI) == second_waked_baseline[2]
+    assert approx(turbine.average_velocity) == second_waked_baseline[3]
+
 
 def test_regression_yaw(sample_inputs_fixture):
     """
     Tandem turbines with the upstream turbine yawed
     """
-    sample_inputs_fixture.floris["wake"]["properties"]["velocity_model"] = VELOCITY_MODEL
-    sample_inputs_fixture.floris["wake"]["properties"]["deflection_model"] = DEFLECTION_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "velocity_model"
+    ] = VELOCITY_MODEL
+    sample_inputs_fixture.floris["wake"]["properties"][
+        "deflection_model"
+    ] = DEFLECTION_MODEL
     floris = Floris(input_dict=sample_inputs_fixture.floris)
 
     # yaw the upstream turbine 5 degrees
@@ -162,4 +173,3 @@ def test_regression_yaw(sample_inputs_fixture):
         assert test_results[i][1] == approx(baseline[i][1])
         assert test_results[i][2] == approx(baseline[i][2])
         assert test_results[i][3] == approx(baseline[i][3])
-        assert test_results[i][4] == approx(baseline[i][4])


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
This PR comments out the Cp property of the turbine class and removes the Cp values from the tests. Currently, it is an open question as to whether this Cp value should include yaw and turbulence correction factors, and in order to prevent confusion among users, it is being temporarily removed.

**Related issue, if one exists**
None.

**Impacted areas of the software**
`turbine.py`
tests

**Additional supporting information**
None.

**Test results, if applicable**
None.
