### PR TITLE
fix Jensen wake model to a circular wake deficit

### DIFF
--- a/floris/simulation/wake_velocity/jensen.py
+++ b/floris/simulation/wake_velocity/jensen.py
@@ -100,11 +100,8 @@ class Jensen(VelocityDeficit):
 
         boundary_line = m * x + b
 
-        y_upper = boundary_line + turbine_coord.x2 + deflection_field
-        y_lower = -1 * boundary_line + turbine_coord.x2 + deflection_field
-
-        z_upper = boundary_line + turbine.hub_height
-        z_lower = -1 * boundary_line + turbine.hub_height
+        y_center = np.zeros_like(boundary_line) + turbine_coord.x2 + deflection_field
+        z_center = np.zeros_like(boundary_line) + turbine.hub_height
 
         # calculate the wake velocity
         c = (
@@ -112,13 +109,11 @@ class Jensen(VelocityDeficit):
             / (2 * self.we * (x_locations - turbine_coord.x1) + turbine.rotor_diameter)
         ) ** 2
 
-        # filter points upstream and beyond the upper and
-        # lower bounds of the wake
+        # filter points upstream
         c[x_locations - turbine_coord.x1 < 0] = 0
-        c[y_locations > y_upper] = 0
-        c[y_locations < y_lower] = 0
-        c[z_locations > z_upper] = 0
-        c[z_locations < z_lower] = 0
+        # filter points beyond the wake boundary
+        mask = ((y_locations - y_center) ** 2 + (z_locations - z_center) ** 2) > (boundary_line ** 2)
+        c[mask] = 0
 
         return (
             2 * turbine.aI * c * flow_field.u_initial,


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
Fixes of the Jensen wake deficit (now circular instead of quadratic deficit function), see #222.

**Related issue, if one exists**
#222 

**Impacted areas of the software**
None.

**Additional supporting information**
None.

**Test results, if applicable**
pytest for folder "tests" has completed without errors.
