### PR TITLE
Numeric params

### DIFF
--- a/floris/simulation/wake_deflection/gauss.py
+++ b/floris/simulation/wake_deflection/gauss.py
@@ -399,7 +399,7 @@ class Gauss(VelocityDeflection):
 
     @ka.setter
     def ka(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for ka: {}, " + "expected float."
             ).format(value)
@@ -434,7 +434,7 @@ class Gauss(VelocityDeflection):
 
     @kb.setter
     def kb(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for kb: {}, " + "expected float."
             ).format(value)
@@ -470,7 +470,7 @@ class Gauss(VelocityDeflection):
 
     @alpha.setter
     def alpha(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for alpha: {}, " + "expected float."
             ).format(value)
@@ -507,7 +507,7 @@ class Gauss(VelocityDeflection):
 
     @beta.setter
     def beta(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for beta: {}, " + "expected float."
             ).format(value)
@@ -545,7 +545,7 @@ class Gauss(VelocityDeflection):
 
     @ad.setter
     def ad(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for ad: {}, " + "expected float."
             ).format(value)
@@ -582,7 +582,7 @@ class Gauss(VelocityDeflection):
 
     @bd.setter
     def bd(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for bd: {}, " + "expected float."
             ).format(value)
@@ -650,7 +650,7 @@ class Gauss(VelocityDeflection):
 
     @eps_gain.setter
     def eps_gain(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = "Value of eps_gain must be type " + "float; {} given.".format(
                 type(value)
             )

--- a/floris/simulation/wake_deflection/jimenez.py
+++ b/floris/simulation/wake_deflection/jimenez.py
@@ -129,7 +129,7 @@ class Jimenez(VelocityDeflection):
 
     @kd.setter
     def kd(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for kd: {}, " + "expected float."
             ).format(value)
@@ -164,7 +164,7 @@ class Jimenez(VelocityDeflection):
 
     @ad.setter
     def ad(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for ad: {}, " + "expected float."
             ).format(value)
@@ -199,7 +199,7 @@ class Jimenez(VelocityDeflection):
 
     @bd.setter
     def bd(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for bd: {}, " + "expected float."
             ).format(value)

--- a/floris/simulation/wake_turbulence/crespo_hernandez.py
+++ b/floris/simulation/wake_turbulence/crespo_hernandez.py
@@ -120,7 +120,7 @@ class CrespoHernandez(WakeTurbulence):
 
     @ti_initial.setter
     def ti_initial(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for " + "initial: {}, expected float."
             ).format(value)
@@ -156,7 +156,7 @@ class CrespoHernandez(WakeTurbulence):
 
     @ti_constant.setter
     def ti_constant(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for " + "constant: {}, expected float."
             ).format(value)
@@ -193,7 +193,7 @@ class CrespoHernandez(WakeTurbulence):
 
     @ti_ai.setter
     def ti_ai(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for " + "ai: {}, expected float."
             ).format(value)
@@ -229,7 +229,7 @@ class CrespoHernandez(WakeTurbulence):
 
     @ti_downstream.setter
     def ti_downstream(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for " + "downstream: {}, expected float."
             ).format(value)

--- a/floris/simulation/wake_velocity/curl.py
+++ b/floris/simulation/wake_velocity/curl.py
@@ -546,7 +546,7 @@ class Curl(VelocityDeficit):
 
     @initial_deficit.setter
     def initial_deficit(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for " + "initial_deficit: {}, expected float."
             ).format(value)
@@ -582,7 +582,7 @@ class Curl(VelocityDeficit):
 
     @dissipation.setter
     def dissipation(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for " + "dissipation: {}, expected float."
             ).format(value)
@@ -619,7 +619,7 @@ class Curl(VelocityDeficit):
 
     @veer_linear.setter
     def veer_linear(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for " + "veer_linear: {}, expected float."
             ).format(value)

--- a/floris/simulation/wake_velocity/gaussianModels/blondel.py
+++ b/floris/simulation/wake_velocity/gaussianModels/blondel.py
@@ -288,7 +288,7 @@ class Blondel(GaussianModel):
 
     @a_s.setter
     def a_s(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for a_s: {}, " + "expected float."
             ).format(value)
@@ -324,7 +324,7 @@ class Blondel(GaussianModel):
 
     @b_s.setter
     def b_s(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for b_s: {}, " + "expected float."
             ).format(value)
@@ -360,7 +360,7 @@ class Blondel(GaussianModel):
 
     @c_s1.setter
     def c_s1(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for c_s1: {}, " + "expected float."
             ).format(value)
@@ -396,7 +396,7 @@ class Blondel(GaussianModel):
 
     @c_s2.setter
     def c_s2(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for c_s2: {}, " + "expected float."
             ).format(value)
@@ -432,7 +432,7 @@ class Blondel(GaussianModel):
 
     @b_f1.setter
     def b_f1(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for b_f1: {}, " + "expected float."
             ).format(value)
@@ -468,7 +468,7 @@ class Blondel(GaussianModel):
 
     @b_f2.setter
     def b_f2(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for b_f2: {}, " + "expected float."
             ).format(value)
@@ -504,7 +504,7 @@ class Blondel(GaussianModel):
 
     @b_f3.setter
     def b_f3(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for b_f3: {}, " + "expected float."
             ).format(value)
@@ -540,7 +540,7 @@ class Blondel(GaussianModel):
 
     @c_f.setter
     def c_f(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for c_f: {}, " + "expected float."
             ).format(value)

--- a/floris/simulation/wake_velocity/gaussianModels/gauss.py
+++ b/floris/simulation/wake_velocity/gaussianModels/gauss.py
@@ -254,7 +254,7 @@ class Gauss(GaussianModel):
 
     @ka.setter
     def ka(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for ka: {}, " + "expected float."
             ).format(value)
@@ -289,7 +289,7 @@ class Gauss(GaussianModel):
 
     @kb.setter
     def kb(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for kb: {}, " + "expected float."
             ).format(value)
@@ -325,7 +325,7 @@ class Gauss(GaussianModel):
 
     @alpha.setter
     def alpha(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for alpha: {}, " + "expected float."
             ).format(value)
@@ -362,7 +362,7 @@ class Gauss(GaussianModel):
 
     @beta.setter
     def beta(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for beta: {}, " + "expected float."
             ).format(value)

--- a/floris/simulation/wake_velocity/gaussianModels/gauss_legacy.py
+++ b/floris/simulation/wake_velocity/gaussianModels/gauss_legacy.py
@@ -245,7 +245,7 @@ class LegacyGauss(GaussianModel):
 
     @ka.setter
     def ka(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for ka: {}, " + "expected float."
             ).format(value)
@@ -280,7 +280,7 @@ class LegacyGauss(GaussianModel):
 
     @kb.setter
     def kb(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for kb: {}, " + "expected float."
             ).format(value)
@@ -316,7 +316,7 @@ class LegacyGauss(GaussianModel):
 
     @alpha.setter
     def alpha(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for alpha: {}, " + "expected float."
             ).format(value)
@@ -353,7 +353,7 @@ class LegacyGauss(GaussianModel):
 
     @beta.setter
     def beta(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for beta: {}, " + "expected float."
             ).format(value)

--- a/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
+++ b/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
@@ -464,7 +464,7 @@ class GaussianModel(VelocityDeficit):
 
     @eps_gain.setter
     def eps_gain(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = "Value of eps_gain must be type " + "float; {} given.".format(
                 type(value)
             )

--- a/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
+++ b/floris/simulation/wake_velocity/gaussianModels/gaussian_model_base.py
@@ -406,7 +406,7 @@ class GaussianModel(VelocityDeficit):
         if type(value) is not bool:
             err_msg = (
                 "Value of calculate_VW_velocities must be type "
-                + "float; {} given.".format(type(value))
+                + "bool; {} given.".format(type(value))
             )
             self.logger.error(err_msg, stack_info=True)
             raise ValueError(err_msg)

--- a/floris/simulation/wake_velocity/jensen.py
+++ b/floris/simulation/wake_velocity/jensen.py
@@ -143,7 +143,7 @@ class Jensen(VelocityDeficit):
 
     @we.setter
     def we(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for we: {}, " + "expected float."
             ).format(value)

--- a/floris/simulation/wake_velocity/multizone.py
+++ b/floris/simulation/wake_velocity/multizone.py
@@ -268,7 +268,7 @@ class MultiZone(VelocityDeficit):
 
     @we.setter
     def we(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for we: {}, " + "expected float."
             ).format(value)
@@ -303,7 +303,7 @@ class MultiZone(VelocityDeficit):
 
     @aU.setter
     def aU(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for aU: {}, " + "expected float."
             ).format(value)
@@ -338,7 +338,7 @@ class MultiZone(VelocityDeficit):
 
     @bU.setter
     def bU(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for bU: {}, " + "expected float."
             ).format(value)

--- a/floris/simulation/wake_velocity/turbopark.py
+++ b/floris/simulation/wake_velocity/turbopark.py
@@ -174,7 +174,7 @@ class TurbOPark(VelocityDeficit):
 
     @A.setter
     def A(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for A: {}, " + "expected float."
             ).format(value)
@@ -208,7 +208,7 @@ class TurbOPark(VelocityDeficit):
 
     @c1.setter
     def c1(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for c1: {}, " + "expected float."
             ).format(value)
@@ -242,7 +242,7 @@ class TurbOPark(VelocityDeficit):
 
     @c2.setter
     def c2(self, value):
-        if type(value) is not float:
+        if type(value) is not float and type(value) is not int:
             err_msg = (
                 "Invalid value type given for c2: {}, " + "expected float."
             ).format(value)


### PR DESCRIPTION
**Feature or improvement description**
This pull request allows numeric wake parameters to be set with an integer value. The setter-methods cast the integer to float. Currently, the setter-methods do not allow numeric parameters to be set with integer values.

While developing the Dash app, we found that the parameter dictionaries do not automatically cast integers to floats. While we could have done this on the Dash side, it seems like the true intent of the setter-methods is to filter out non-numeric values rather than anything but float.

cc @LizzJS

**Related issue, if one exists**
None

**Impacted areas of the software**
Wake model setter-methods for parameters.

**Additional supporting information**
None