### PR TITLE
Fixing yaw position when calculating power with wind direction uncertainty

### DIFF
--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -875,7 +875,8 @@ class FlorisInterface(LoggerBase):
                     ] * unc_pmfs["yaw_unc_pmf"][
                         i_yaw
                     ] * self.get_farm_power_for_yaw_angle(
-                        list(np.array(yaw_angles) + delta_yaw), no_wake=no_wake
+                        list(np.array(yaw_angles) - delta_wd + delta_yaw),
+                        no_wake=no_wake,
                     )
 
             # reinitialize with original values
@@ -1049,7 +1050,7 @@ class FlorisInterface(LoggerBase):
 
                 for i_yaw, delta_yaw in enumerate(unc_pmfs["yaw_unc"]):
                     self.calculate_wake(
-                        yaw_angles=list(np.array(yaw_angles) + delta_yaw),
+                        yaw_angles=list(np.array(yaw_angles) - delta_wd + delta_yaw),
                         no_wake=no_wake,
                     )
                     mean_farm_power = mean_farm_power + unc_pmfs["wd_unc_pmf"][


### PR DESCRIPTION

<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull request fixes the power calculations when wind direction uncertainty is included, addressing the problem where wind direction uncertainty wasn't changing an upstream turbine's power, pointed out by @Bartdoekemeijer. Previously, when wind direction uncertainty was included, the yaw position would change to track the deviations in wind direction. This fix causes the intended behavior, with the absolute yaw position staying constant while wind direction varies.   

**Related issue, if one exists**
This PR fixes issue #246 

**Impacted areas of the software**
Code changed in "floris/tools/floris_interface.py"

Will affect the results of the following optimization modules when `include_unc` is set to True:
"floris/tools/optimization/scipy/yaw.py"
"floris/tools/optimization/scipy/yaw_wind_rose.py"
"floris/tools/optimization/scipy/yaw_wind_rose_parallel.py"

Will therefore also change the results of the following example scripts using the optimization classes when `include_unc` is set to True:
"examples/optimization/scipy/controls_optimization/optimize_yaw_wind_rose_parallel.py"
"examples/optimization/scipy/controls_optimization/optimize_yaw_robust.py"
"examples/optimization/scipy/controls_optimization/optimize_yaw_wind_rose_robust.py"

**Test results, if applicable**
After running the example code provided in issue #246, the results now show wind direction uncertainty changing the upstream turbine's power, as expected.

```
Turbine powers (uncertainty=False): [2413659.065169422, 502484.84736824286]
Turbine powers (uncertainty=True): [2407984.1073978315, 675764.0365194784]
``` 

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
