### PR TITLE
Calculate no-wake farm power in optimization

### DIFF
--- a/floris/tools/optimization/yaw_optimization/yaw_optimizer_wind_rose_serial.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimizer_wind_rose_serial.py
@@ -107,7 +107,7 @@ class YawOptimizationWindRose:
         self.yaw_opt.reinitialize_flow_field(
             wind_direction=[wd], wind_speed=[ws], turbulence_intensity=[ti]
         )
-        if ((ws >= self.minimum_ws) and (ws <= self.maximum_ws)):
+        if (ws >= self.minimum_ws) and (ws <= self.maximum_ws):
             opt_yaw_angles = self.yaw_opt.optimize()
         else:
             print("   Skipping optimization: outside of wind speed bounds.")
@@ -125,8 +125,7 @@ class YawOptimizationWindRose:
 
         # Calculate baseline power without wake losses
         self.yaw_opt.fi.calculate_wake(
-            yaw_angles=self.yaw_opt.yaw_angles_baseline,
-            no_wake=True,
+            yaw_angles=self.yaw_opt.yaw_angles_baseline, no_wake=True
         )
         power_turbs_base_nowakes = self.yaw_opt.fi.get_turbine_power(
             include_unc=self.yaw_opt.include_unc,
@@ -145,8 +144,7 @@ class YawOptimizationWindRose:
 
         # Calculate optimized power without wake losses
         self.yaw_opt.fi.calculate_wake(
-            yaw_angles=opt_yaw_angles,
-            no_wake=True,
+            yaw_angles=opt_yaw_angles, no_wake=True
         )
         power_turbs_opt_nowakes = self.yaw_opt.fi.get_turbine_power(
             include_unc=self.yaw_opt.include_unc,
@@ -165,13 +163,17 @@ class YawOptimizationWindRose:
                 "power_baseline": [np.sum(power_turbs_base)],
                 "power_baseline_nowakes": [np.sum(power_turbs_base_nowakes)],
                 "power_baseline_weighted": [np.dot(w, power_turbs_base)],
-                "power_baseline_weighted_nowakes": [np.dot(w, power_turbs_base_nowakes)],
+                "power_baseline_weighted_nowakes": [
+                    np.dot(w, power_turbs_base_nowakes)
+                ],
                 "turbine_power_baseline": [power_turbs_base],
                 "turbine_power_baseline_nowakes": [power_turbs_base_nowakes],
                 "power_opt": [np.sum(power_turbs_opt)],
                 "power_opt_nowakes": [np.sum(power_turbs_opt_nowakes)],
                 "power_opt_weighted": [np.dot(w, power_turbs_opt)],
-                "power_opt_weighted_nowakes": [np.dot(w, power_turbs_opt_nowakes)],
+                "power_opt_weighted_nowakes": [
+                    np.dot(w, power_turbs_opt_nowakes)
+                ],
                 "turbine_power_opt": [power_turbs_opt],
                 "turbine_power_opt_nowakes": [power_turbs_opt_nowakes],
                 "yaw_angles": [opt_yaw_angles],
@@ -198,18 +200,38 @@ class YawOptimizationWindRose:
                 included if self.ti_array is not None.
                 - **power_baseline** (*float*) - The total power produced by the
                 wind farm with the baseline yaw offsets (W).
+                - **power_baseline_nowakes** (*float*) - The total power produced
+                by the wind farm with the baseline yaw offsets when the wake losses
+                are assumed to be zero (W).
                 - **power_baseline_weighted** (*float*) - The total power produced
                 by the wind farm with the baseline yaw offsets weighted by the
                 turbine weights specified by the user (W).
+                - **power_baseline_weighted_nowakes** (*float*) - The total power
+                produced by the wind farm with the baseline yaw offsets when the
+                wake losses are assumed to be zero, and weighted by the turbine
+                weights specified by the user (W).
                 - **turbine_power_baseline** (*float*) - The power produced
                 by each turbine in the wind farm with the baseline yaw offsets (W).
-                - **power_opt** (*float*) - The total power produced by the
-                wind farm with optimal yaw offsets (W).
-                - **power_opt_weighted** (*float*) - The total power produced
-                by the wind farm with the optimal yaw offsets weighted by the
-                turbine weights specified by the user (W).
+                - **turbine_power_baseline_nowakes** (*float*) - The power produced
+                by each turbine in the wind farm with the baseline yaw offsets, and
+                when the wake losses are assumed to be zero (W).
+                - **power_opt** (*float*) - The total power produced by the wind
+                farm with optimal yaw offsets (W).
+                - **power_opt_nowakes** (*float*) - The total power produced by the
+                wind farm with optimal yaw offsets when the wake losses are assumed
+                to be zero (W).
+                - **power_opt_weighted** (*float*) - The total power produced by the
+                wind farm with the optimal yaw offsets weighted by the turbine
+                weights specified by the user (W).
+                - **power_opt_weighted_nowakes** (*float*) - The total power
+                produced by the wind farm with the optimal yaw offsets when the
+                wake losses are assumed to be zero, and weighted by the turbine
+                weights specified by the user (W).
                 - **turbine_power_opt** (*float*) - The power produced by each
                 turbine in the wind farm with the optimal yaw offsets (W).
+                - **turbine_power_opt_nowakes** (*float*) - The power produced by
+                each turbine in the wind farm when the wake losses are assumed to
+                be zero, and with the optimal yaw offsets (W).
                 - **yaw_angles** (*list* (*float*)) - A list containing
                 the optimal yaw offsets for maximizing total wind farm power
                 for each wind turbine (deg).

--- a/floris/tools/optimization/yaw_optimization/yaw_optimizer_wind_rose_serial.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimizer_wind_rose_serial.py
@@ -123,12 +123,36 @@ class YawOptimizationWindRose:
             unc_options=self.yaw_opt.unc_options,
         )
 
+        # Calculate baseline power without wake losses
+        self.yaw_opt.fi.calculate_wake(
+            yaw_angles=self.yaw_opt.yaw_angles_baseline,
+            no_wake=True,
+        )
+        power_turbs_base_nowakes = self.yaw_opt.fi.get_turbine_power(
+            include_unc=self.yaw_opt.include_unc,
+            unc_pmfs=self.yaw_opt.unc_pmfs,
+            unc_options=self.yaw_opt.unc_options,
+            no_wake=True,
+        )
+
         # Calculate optimized power
         self.yaw_opt.fi.calculate_wake(yaw_angles=opt_yaw_angles)
         power_turbs_opt = self.yaw_opt.fi.get_turbine_power(
             include_unc=self.yaw_opt.include_unc,
             unc_pmfs=self.yaw_opt.unc_pmfs,
             unc_options=self.yaw_opt.unc_options,
+        )
+
+        # Calculate optimized power without wake losses
+        self.yaw_opt.fi.calculate_wake(
+            yaw_angles=opt_yaw_angles,
+            no_wake=True,
+        )
+        power_turbs_opt_nowakes = self.yaw_opt.fi.get_turbine_power(
+            include_unc=self.yaw_opt.include_unc,
+            unc_pmfs=self.yaw_opt.unc_pmfs,
+            unc_options=self.yaw_opt.unc_options,
+            no_wake=True,
         )
 
         # Return a dataframe with outputs
@@ -139,11 +163,17 @@ class YawOptimizationWindRose:
                 "wd": [wd],
                 "ti": [ti],
                 "power_baseline": [np.sum(power_turbs_base)],
+                "power_baseline_nowakes": [np.sum(power_turbs_base_nowakes)],
                 "power_baseline_weighted": [np.dot(w, power_turbs_base)],
+                "power_baseline_weighted_nowakes": [np.dot(w, power_turbs_base_nowakes)],
                 "turbine_power_baseline": [power_turbs_base],
+                "turbine_power_baseline_nowakes": [power_turbs_base_nowakes],
                 "power_opt": [np.sum(power_turbs_opt)],
+                "power_opt_nowakes": [np.sum(power_turbs_opt_nowakes)],
                 "power_opt_weighted": [np.dot(w, power_turbs_opt)],
+                "power_opt_weighted_nowakes": [np.dot(w, power_turbs_opt_nowakes)],
                 "turbine_power_opt": [power_turbs_opt],
+                "turbine_power_opt_nowakes": [power_turbs_opt_nowakes],
                 "yaw_angles": [opt_yaw_angles],
             }
         )


### PR DESCRIPTION
<!-- Is this pull request ready to be merged?  Yes  -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Reintroduce the calculation of the baseline power production and optimized power production with the ``no_wake=True`` option in the yaw optimization codes. This directly addresses the issue raised in #271.

**Related issue, if one exists**
Issue #271.

**Impacted areas of the software**
Wake steering/Yaw optimization module.

**Additional supporting information**
This is really a very simple addition to the existing code framework. These changes will automatically reflect in the parallelized yaw solvers (e.g., the ``mpi4py`` yaw optimization class).

**Test results, if applicable**
Running the already existent example ``optimize_yaw_wind_rose.py`` will give the following dataframe contents for ``df_opt``:

```
df_opt
     ws     wd    ti  ...                                  turbine_power_opt                          turbine_power_opt_nowakes                                         yaw_angles
0   8.0    0.0  0.06  ...  [829061.7778876706, 835467.8799510659, 837135....  [1695368.645547269, 1695368.645547269, 1695368...                  [0.0, 0.0, 0.0, 25.0, 25.0, 25.0]
1   8.0   30.0  0.06  ...  [1695368.6450721975, 1695368.64507021, 1695368...  [1695368.645547269, 1695368.645547269, 1695368...                     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
2   8.0   60.0  0.06  ...  [1579837.873505156, 1579408.044448423, 1695368...  [1695368.645547269, 1695368.645547269, 1695368...  [0.0, 0.0, 0.0, 0.0, 10.032391703130289, 10.29...
3   8.0   90.0  0.06  ...  [1148361.310107234, 943673.0488298924, 1409447...  [1695368.645547269, 1498383.1348684682, 140944...  [0.0, 20.75869308601464, 25.0, 0.0, 20.4331034...
4   8.0  120.0  0.06  ...  [1695368.645547269, 1695368.645547269, 1695368...  [1695368.645547269, 1695368.645547269, 1695368...                     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
5   8.0  150.0  0.06  ...  [1695368.645547269, 1695368.645547269, 1695368...  [1695368.645547269, 1695368.645547269, 1695368...                     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
6   8.0  180.0  0.06  ...  [1409447.771337562, 1409447.771337562, 1409447...  [1409447.771337562, 1409447.771337562, 1409447...                  [25.0, 25.0, 25.0, 0.0, 0.0, 0.0]
7   8.0  210.0  0.06  ...  [1695368.645547269, 1695368.645547269, 1695368...  [1695368.645547269, 1695368.645547269, 1695368...                     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
8   8.0  240.0  0.06  ...  [1646960.1260944973, 1649412.4711480173, 16953...  [1646960.1260944973, 1649412.4711480264, 16953...  [10.296501842338152, 10.032391703135445, 0.0, ...
9   8.0  270.0  0.06  ...  [1409447.771337562, 943729.1869875423, 1148359...  [1409447.771337562, 1498467.2816153956, 169536...  [25.0, 20.754266018189107, 0.0, 25.0, 20.43957...
10  8.0  300.0  0.06  ...  [1695368.645547269, 1440470.0582335906, 143793...  [1695368.645547269, 1695368.645547269, 1695368...                     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
11  8.0  330.0  0.06  ...  [1695368.6450650557, 1695368.6450594952, 16953...  [1695368.645547269, 1695368.645547269, 1695368...                     [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

[12 rows x 16 columns]
```
and the following dataframe columns are present:
```
Index(['ws', 'wd', 'ti', 'power_baseline', 'power_baseline_nowakes',
       'power_baseline_weighted', 'power_baseline_weighted_nowakes',
       'turbine_power_baseline', 'turbine_power_baseline_nowakes', 'power_opt',
       'power_opt_nowakes', 'power_opt_weighted', 'power_opt_weighted_nowakes',
       'turbine_power_opt', 'turbine_power_opt_nowakes', 'yaw_angles'],
      dtype='object')
```

As an additional check, in the baseline case all yaw angles should be ``0.0`` and since all turbines are identical, their baseline power values should be equal when no wakes are modeled. Indeed, for ``df_opt["power_baseline_nowakes"]`` I find:
```
0     1.017221e+07
1     1.017221e+07
2     1.017221e+07
3     1.017221e+07
4     1.017221e+07
5     1.017221e+07
6     1.017221e+07
7     1.017221e+07
8     1.017221e+07
9     1.017221e+07
10    1.017221e+07
11    1.017221e+07
Name: power_baseline_nowakes, dtype: float64
```

For ``df_opt["power_opt_nowakes"]``, I find:
```
df_opt["power_opt_nowakes"]
0     9.314449e+06
1     1.017221e+07
2     1.007785e+07
3     9.212539e+06
4     1.017221e+07
5     1.017221e+07
6     9.314449e+06
7     1.017221e+07
8     1.007785e+07
9     9.212503e+06
10    1.017221e+07
11    1.017221e+07
Name: power_opt_nowakes, dtype: float64
```
Which also makes sense. All values are very close, but some are slightly lower than others because certain turbines are steered up to 25 degrees away from the inflow wind direction. Wakes are not modeled so there is no benefit from wake steering, and therefore the farm shows slightly lower power values.

I would like to ask @scottryn to verify that this solution meets his needs.

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
