### PR TITLE
Add GitHub engagement guidelines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ FLORIS Wake Modeling and Wind Farm Controls Software
 ----------------------------------------------------
 
 FLORIS is a controls-focused wind farm simulation software incorporating
-steady-state engineering wake models into a performance focused Python
+steady-state engineering wake models into a performance-focused Python
 framework. It has been in active development at NREL since 2013 and the latest
 release is `FLORIS v2.4 <https://github.com/NREL/floris/releases/tag/v2.4>`_
 in July 2021. The ``v3`` branch of the repository
@@ -11,8 +11,9 @@ performance in AEP calculation and controls optimization.
 
 We are actively seeking beta testers for the new framework. If you are interested
 in using FLORIS to conduct studies of a wind farm or extending FLORIS to include
-your own wake model, please get in touch! Register for beta testing at https://forms.office.com/g/AmpAkJVvja
-and join the conversations at `GitHub Discussions <https://github.com/NREL/floris/discussions/categories/v3-design-discussion>`_.
+your own wake model, please get in touch! Register for beta testing by completing
+this form: https://forms.office.com/g/AmpAkJVvja and join the conversations at
+`GitHub Discussions <https://github.com/NREL/floris/discussions/categories/v3-design-discussion>`_.
 
 For more context and background on previous work in FLORIS, see the
 documentation at http://floris.readthedocs.io/.
@@ -81,6 +82,22 @@ directory. These are ordered from simplest to most complex. They demonstrate var
 use cases of FLORIS, and generally provide a good starting point for building a more
 complex simulation.
 
+
+Engaging on GitHub
+==================
+FLORIS leverages the following features of GitHub to coordinate support and development efforts:
+
+- `Discussions <https://github.com/NREL/floris/discussions>`_: Collaborate to develop ideas for new use cases, features, and software designs, and get support for usage questions
+- `Issues <https://github.com/NREL/floris/issues>`_: Report potential bugs and well-developed feature requests
+- `Projects <https://github.com/orgs/NREL/projects/18/>`_: Include current and future work on a timeline and assign a person to "own" it
+
+Generally, the first entry point for the community will be within one of the
+categories in Discussions.
+`Ideas <https://github.com/NREL/floris/discussions/categories/ideas>`_ is a great
+spot to develop a feature request.
+`Q&A <https://github.com/NREL/floris/discussions/categories/q-a>`_ is where to get usage support.
+`Show and tell <https://github.com/NREL/floris/discussions/categories/show-and-tell>`_ is a free-form
+space to show off the things you are doing with FLORIS.
 
 License
 =======


### PR DESCRIPTION
**Feature or improvement description**
This pull request adds guidelines for engaging with the FLORIS team via GitHub.
