### PR TITLE
Support heterogeneous wind speed inputs

### DIFF
--- a/examples/10_heterogeneous_inflow.py
+++ b/examples/10_heterogeneous_inflow.py
@@ -1,0 +1,107 @@
+# Copyright 2021 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# See https://floris.readthedocs.io for documentation
+
+
+import matplotlib.pyplot as plt
+
+from floris.tools import FlorisInterface
+from floris.tools.floris_interface import generate_heterogeneous_wind_map
+from floris.tools.visualization import visualize_cut_plane
+
+"""
+This example showcases the heterogeneous inflow capabilities of FLORIS.
+Heterogeneous flow can be defined in either 2- or 3-dimensions.
+
+For the 2-dimensional case, it can be seen that the freestream velocity
+only varies in the x direction. For the 3-dimensional case, it can be
+seen that the freestream velocity only varies in the z direction. This
+is because of how the speed ups for each case were defined. More complex
+inflow conditions can be defined.
+
+For each case, we are plotting three slices of the resulting flow field:
+1. Horizontal slice parallel to the ground and located at the hub height
+2. Vertical slice parallel with the direction of the wind
+3. Veritical slice parallel to to the turbine disc plane
+"""
+
+
+# Define the speed ups of the heterogeneous inflow, and their locations.
+# For the 2-dimensional case, this requires x and y locations.
+# The speed ups are multipliers of the ambient wind speed.
+speed_ups = [[2.0, 2.0, 1.0, 1.0]]
+x_locs = [-300.0, -300.0, 2600.0, 2600.0]
+y_locs = [ -300.0, 300.0, -300.0, 300.0]
+
+# Generate the linear interpolation to be used for the heterogeneous inflow.
+het_map_2d = generate_heterogeneous_wind_map(speed_ups, x_locs, y_locs)
+
+# Initialize FLORIS with the given input file via FlorisInterface.
+# Also, pass the heterogeneous map into the FlorisInterface.
+fi_2d = FlorisInterface("inputs/gch.yaml", het_map=het_map_2d)
+
+# Set shear to 0.0 to highlight the heterogeneous inflow
+fi_2d.reinitialize(wind_shear=0.0)
+
+# Using the FlorisInterface functions for generating plots, run FLORIS
+# and extract 2D planes of data.
+horizontal_plane_2d = fi_2d.get_hor_plane(x_resolution=200, y_resolution=100)
+y_plane_2d = fi_2d.get_y_plane(x_resolution=200, z_resolution=100)
+cross_plane_2d = fi_2d.get_cross_plane(y_resolution=100, z_resolution=100, downstream_dist=500.0)
+
+# Create the plots
+fig, ax_list = plt.subplots(3, 1, figsize=(10, 8))
+ax_list = ax_list.flatten()
+visualize_cut_plane(horizontal_plane_2d, ax=ax_list[0], title="Horizontal", color_bar=True)
+ax_list[0].set_xlabel('x'); ax_list[0].set_ylabel('y')
+visualize_cut_plane(y_plane_2d, ax=ax_list[1], title="Streamwise profile", color_bar=True)
+ax_list[1].set_xlabel('x'); ax_list[1].set_ylabel('z')
+visualize_cut_plane(cross_plane_2d, ax=ax_list[2], title="Spanwise profile at 500m downstream", color_bar=True)
+ax_list[2].set_xlabel('y'); ax_list[2].set_ylabel('z')
+
+
+# Define the speed ups of the heterogeneous inflow, and their locations.
+# For the 3-dimensional case, this requires x, y, and z locations.
+# The speed ups are multipliers of the ambient wind speed.
+speed_ups = [[1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 2.0, 2.0]]
+x_locs = [-300.0, -300.0, -300.0, -300.0, 2600.0, 2600.0, 2600.0, 2600.0]
+y_locs = [-300.0, 300.0, -300.0, 300.0, -300.0, 300.0, -300.0, 300.0]
+z_locs = [540.0, 540.0, 0.0, 0.0, 540.0, 540.0, 0.0, 0.0]
+
+# Generate the linear interpolation to be used for the heterogeneous inflow.
+het_map_3d = generate_heterogeneous_wind_map(speed_ups, x_locs, y_locs, z_locs)
+
+# Initialize FLORIS with the given input file via FlorisInterface.
+# Also, pass the heterogeneous map into the FlorisInterface.
+fi_3d = FlorisInterface("inputs/gch.yaml", het_map=het_map_3d)
+
+# Set shear to 0.0 to highlight the heterogeneous inflow
+fi_3d.reinitialize(wind_shear=0.0)
+
+# Using the FlorisInterface functions for generating plots, run FLORIS
+# and extract 2D planes of data.
+horizontal_plane_3d = fi_3d.get_hor_plane(x_resolution=200, y_resolution=100)
+y_plane_3d = fi_3d.get_y_plane(x_resolution=200, z_resolution=100)
+cross_plane_3d = fi_3d.get_cross_plane(y_resolution=100, z_resolution=100)
+
+# Create the plots
+fig, ax_list = plt.subplots(3, 1, figsize=(10, 8))
+ax_list = ax_list.flatten()
+visualize_cut_plane(horizontal_plane_3d, ax=ax_list[0], title="Horizontal", color_bar=True)
+ax_list[0].set_xlabel('x'); ax_list[0].set_ylabel('y')
+visualize_cut_plane(y_plane_3d, ax=ax_list[1], title="Streamwise profile", color_bar=True)
+ax_list[1].set_xlabel('x'); ax_list[1].set_ylabel('z')
+visualize_cut_plane(cross_plane_3d, ax=ax_list[2], title="Spanwise profile at 500m downstream", color_bar=True)
+ax_list[2].set_xlabel('y'); ax_list[2].set_ylabel('z')
+
+plt.show()

--- a/src/floris/simulation/flow_field.py
+++ b/src/floris/simulation/flow_field.py
@@ -46,14 +46,14 @@ class FlowField(FromDictMixin):
     v: NDArrayFloat = field(init=False, default=np.array([]))
     w: NDArrayFloat = field(init=False, default=np.array([]))
     speed_ups: NDArrayFloat = field(init=False, default=np.array([]))
-    het_map: list = field(init=False, default=[])
+    het_map: list = field(init=False, default=None)
 
     turbulence_intensity_field: NDArrayFloat = field(init=False, default=np.array([]))
 
     def __attrs_post_init__(self) -> None:
         # If no hetergeneous inflow defined, then set all speeds ups to 1.0
         if np.size(self.speed_ups) == 0:
-            self.speed_ups = np.ones_like(self.wind_directions)
+            self.speed_ups = np.ones_like(self.wind_directions)[:, None, None, None, None]
 
     @wind_speeds.validator
     def wind_speeds_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:

--- a/src/floris/tools/visualization.py
+++ b/src/floris/tools/visualization.py
@@ -170,7 +170,8 @@ def visualize_cut_plane(
     line_contour_cut_plane(cut_plane, ax=ax, levels=levels, colors="w", linewidths=0.8, alpha=0.3)
 
     if color_bar:
-        plt.colorbar(im, ax=ax)
+        cbar = plt.colorbar(im, ax=ax)
+        cbar.set_label('m/s')
 
     # Set the title
     ax.set_title(title)


### PR DESCRIPTION
**Feature or improvement description**
This pull request adds heterogeneous inflow capabilities and an example to FLORIS v3. This includes both 2- and 3-dimensional flow definitions. The heterogeneous flows are defined as an array of speed ups which are multipliers of the ambient wind speed. The dimensions of this speed up array are the number of wind directions by the number of defined speed up points. In addition to the speed ups, the locations of the speed ups are required (for 2d, x and y locations, and for 3d, x, y, and z locations). Note: the example uses the `gch.yaml` input file, as it won't work with the `cc.yaml` input file until plotting is implemented for the CC model.

**Related issue, if one exists**
#282 

**Impacted areas of the software**
Changes are limited to `flow_field.py` and `floris_interface.py`.

**Additional supporting information**
If FLORIS is asked to compute a speed up outside of the defined area of the heterogeneous interpolant map, the speed up that is returned is equal to 1.0, so the user must make sure that they have defined inflows over the full area that they want heterogeneous flow for.

Also, the heterogeneous map is stored on the `FlorisInterface` object as well as the `FlowField` object. This is because the map is used in the flow field, when the flow field is initialized with the specified grid. However, upon reinitialization (e.g. a `fi.reinitialize()` call), the map is lost from the flow field object, and thus requires re-assigning from the stored version on the `FlorisInterface` object. The reason to store the map on the `FlowField` object was made to prevent having to pass the map through the calculation call each time (starting in `FlorisInterface`, the map would have to be passed to every call of a solver, which would then pass it to `initialize_flow_field`).

**Test results, if applicable**
The example produces the following figures. The 1st figure shows a 2d inflow definition where the flow varies in the x direction only. The 2nd figure shows a 3d inflow definition where the flow varies only in the z direction.

![2d_het_flow](https://user-images.githubusercontent.com/12664940/151444413-e0126101-d833-4e46-90a3-1d04d5c0cdd1.png)

![3d_het_flow](https://user-images.githubusercontent.com/12664940/151444433-0af5e740-c15e-4729-8e1e-2d2c8639cd32.png)


