### PR TITLE
Bug fix: Jensen model upstream mask

### DIFF
--- a/src/floris/simulation/wake_velocity/jensen.py
+++ b/src/floris/simulation/wake_velocity/jensen.py
@@ -114,7 +114,7 @@ class JensenVelocityDeficit(BaseModel):
         # np.nan_to_num
 
         # C should be 0 at the current turbine and everywhere in front of it
-        upstream_mask = np.array(dx <= 0.0, dtype=bool)
+        upstream_mask = np.array(dx <= 0.1, dtype=bool)
         # C should be 0 everywhere outside of the lateral and vertical bounds defined by the wake expansion parameter
         boundary_mask = np.array( np.sqrt(dy ** 2 + dz ** 2) > boundary_line, dtype=bool)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def print_test_values(average_velocities: list, thrusts: list, powers: list, axi
 WIND_DIRECTIONS = [
     270.0,
     360.0,
-    315.0, #293.0,
+    285.0,
     315.0,
 ]
 N_WIND_DIRECTIONS = len(WIND_DIRECTIONS)
@@ -88,6 +88,7 @@ Z_COORDS = [
     90.0
 ]
 N_TURBINES = len(X_COORDS)
+ROTOR_DIAMETER = 126.0
 TURBINE_GRID_RESOLUTION = 2
 
 

--- a/tests/reg_tests/gauss_regression_test.py
+++ b/tests/reg_tests/gauss_regression_test.py
@@ -694,11 +694,18 @@ def test_regression_secondary_steering(sample_inputs_fixture):
 def test_regression_small_grid_rotation(sample_inputs_fixture):
     """
     Where wake models are masked based on the x-location of a turbine, numerical precision
-    can cause masking to fail unexpectedly. Specifically,
+    can cause masking to fail unexpectedly. For example, in the configuration here one of
+    the turbines has these delta x values;
 
+    [[4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
+     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
+     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
+     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
+     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]]
 
-    This test ensures that at least in this particular configuration the masking
-    correctly filters grid points.
+    and therefore the masking statement is False when it should be True. This causes the current
+    turbine to be affected by its own wake. This test requires that at least in this particular
+    configuration the masking correctly filters grid points.
     """
     sample_inputs_fixture.floris["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
     sample_inputs_fixture.floris["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL

--- a/tests/reg_tests/gauss_regression_test.py
+++ b/tests/reg_tests/gauss_regression_test.py
@@ -689,3 +689,50 @@ def test_regression_secondary_steering(sample_inputs_fixture):
         )
 
     assert_results_arrays(test_results[0], secondary_steering_baseline)
+
+
+def test_regression_small_grid_rotation(sample_inputs_fixture):
+    """
+    Where wake models are masked based on the x-location of a turbine, numerical precision
+    can cause masking to fail unexpectedly. Specifically,
+
+
+    This test ensures that at least in this particular configuration the masking
+    correctly filters grid points.
+    """
+    sample_inputs_fixture.floris["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.floris["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+    X, Y = np.meshgrid(
+        6.0 * 126.0 * np.arange(0, 5, 1),
+        6.0 * 126.0 * np.arange(0, 5, 1)
+    )
+    X = X.flatten()
+    Y = Y.flatten()
+
+    sample_inputs_fixture.floris["farm"]["layout_x"] = X
+    sample_inputs_fixture.floris["farm"]["layout_y"] = Y
+
+    floris = Floris.from_dict(sample_inputs_fixture.floris)
+    floris.steady_state_atmospheric_condition()
+
+    # farm_avg_velocities = average_velocity(floris.flow_field.u)
+    velocities = floris.flow_field.u
+    yaw_angles = floris.farm.yaw_angles
+
+    farm_powers = power(
+        floris.flow_field.air_density,
+        velocities,
+        yaw_angles,
+        floris.turbine.pP,
+        floris.turbine.power_interp,
+    )
+
+    # A "column" is oriented parallel to the wind direction
+    # Columns 1 - 4 should have the same power profile
+    # Column 5 leading turbine is completely unwaked
+    # and the rest of the turbines have a partial wake from their immediate upstream turbine
+    assert np.allclose(farm_powers[2,0,0:5], farm_powers[2,0,5:10])
+    assert np.allclose(farm_powers[2,0,0:5], farm_powers[2,0,10:15])
+    assert np.allclose(farm_powers[2,0,0:5], farm_powers[2,0,15:20])
+    assert np.allclose(farm_powers[2,0,20], farm_powers[2,0,0])
+    assert np.allclose(farm_powers[2,0,21], farm_powers[2,0,21:25])

--- a/tests/reg_tests/jensen_jimenez_regression_test.py
+++ b/tests/reg_tests/jensen_jimenez_regression_test.py
@@ -14,7 +14,8 @@
 
 import numpy as np
 
-from tests.conftest import N_TURBINES, N_WIND_DIRECTIONS, N_WIND_SPEEDS, print_test_values, assert_results_arrays
+from tests.conftest import N_TURBINES, N_WIND_DIRECTIONS, N_WIND_SPEEDS, ROTOR_DIAMETER
+from tests.conftest import print_test_values, assert_results_arrays
 from floris.simulation import Ct, Floris, power, axial_induction, average_velocity
 
 
@@ -280,3 +281,48 @@ def test_regression_yaw(sample_inputs_fixture):
         )
 
     assert_results_arrays(test_results[0], yawed_baseline)
+
+
+def test_regression_small_grid_rotation(sample_inputs_fixture):
+    """
+    Where wake models are masked based on the x-location of a turbine, numerical precision
+    can cause masking to fail unexpectedly. Specifically,
+
+
+    This test ensures that at least in this particular configuration the masking
+    correctly filters grid points.
+    """
+    sample_inputs_fixture.floris["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.floris["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+    X, Y = np.meshgrid(
+        6.0 * 126.0 * np.arange(0, 5, 1),
+        6.0 * 126.0 * np.arange(0, 5, 1)
+    )
+    X = X.flatten()
+    Y = Y.flatten()
+
+    sample_inputs_fixture.floris["farm"]["layout_x"] = X
+    sample_inputs_fixture.floris["farm"]["layout_y"] = Y
+
+    floris = Floris.from_dict(sample_inputs_fixture.floris)
+    floris.steady_state_atmospheric_condition()
+
+    # farm_avg_velocities = average_velocity(floris.flow_field.u)
+    velocities = floris.flow_field.u
+    yaw_angles = floris.farm.yaw_angles
+
+    farm_powers = power(
+        floris.flow_field.air_density,
+        velocities,
+        yaw_angles,
+        floris.turbine.pP,
+        floris.turbine.power_interp,
+    )
+
+    # A "column" is oriented parallel to the wind direction
+    # Columns 1 - 4 should have the same power profile
+    # Column 5 is completely unwaked in this model
+    assert np.allclose(farm_powers[2,0,0:5], farm_powers[2,0,5:10])
+    assert np.allclose(farm_powers[2,0,0:5], farm_powers[2,0,10:15])
+    assert np.allclose(farm_powers[2,0,0:5], farm_powers[2,0,15:20])
+    assert np.allclose(farm_powers[2,0,20], farm_powers[2,0,20:25])

--- a/tests/reg_tests/jensen_jimenez_regression_test.py
+++ b/tests/reg_tests/jensen_jimenez_regression_test.py
@@ -286,11 +286,18 @@ def test_regression_yaw(sample_inputs_fixture):
 def test_regression_small_grid_rotation(sample_inputs_fixture):
     """
     Where wake models are masked based on the x-location of a turbine, numerical precision
-    can cause masking to fail unexpectedly. Specifically,
+    can cause masking to fail unexpectedly. For example, in the configuration here one of
+    the turbines has these delta x values;
 
+    [[4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
+     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
+     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
+     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
+     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]]
 
-    This test ensures that at least in this particular configuration the masking
-    correctly filters grid points.
+    and therefore the masking statement is False when it should be True. This causes the current
+    turbine to be affected by its own wake. This test requires that at least in this particular
+    configuration the masking correctly filters grid points.
     """
     sample_inputs_fixture.floris["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
     sample_inputs_fixture.floris["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL


### PR DESCRIPTION
**Feature or improvement description**
Where wake models are masked based on the x-location of a turbine, numerical precision can cause masking to fail unexpectedly. For example, in the configuration described in #311 one of turbines has these delta x values;

    [[4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]
     [4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13 4.54747351e-13]]

and therefore the masking statement is False when it should be True. This causes the current turbine to be affected by its own wake. The same bug was in the Gauss model but was previously fixed.

**Related issue, if one exists**
Resolves #311

**Impacted areas of the software**
Jensen velocity deficit model

**Additional supporting information**
Based on @rafmudaf's suggestion