### PR TITLE
Bugfix/plotting

### DIFF
--- a/examples/01_plot_wakes.py
+++ b/examples/01_plot_wakes.py
@@ -38,12 +38,12 @@ fi = FlorisInterface("inputs/gch.yaml")
 # placed on each rotor plane with 9 points in a 3x3 layout. This can
 # be plotted to show the wind conditions that each turbine is experiencing.
 # However, 9 points is very coarse for visualization so let's first
-# increase the rotor grid to 20x20 points.
+# increase the rotor grid to 10x10 points.
 
 # Create a solver settings dictionary with the new number of points
 solver_settings = {
   "type": "turbine_grid",
-  "turbine_grid_points": 20
+  "turbine_grid_points": 10
 }
 
 # Since we already have a FlorisInterface (fi), simply reinitialize it
@@ -64,9 +64,12 @@ plot_rotor_values(fi.floris.flow_field.u, wd_index=0, ws_index=0, n_rows=1, n_co
 # flow field.
 
 # Using the FlorisInterface functions, get 2D slices.
-horizontal_plane = fi.get_hor_plane(x_resolution=200, y_resolution=100)
-y_plane = fi.get_y_plane(x_resolution=200, z_resolution=100)
-cross_plane = fi.get_cross_plane(y_resolution=100, z_resolution=100)
+horizontal_plane = fi.calculate_horizontal_plane(x_resolution=200, y_resolution=100)
+y_plane = fi.calculate_y_plane(x_resolution=200, z_resolution=100)
+cross_plane = fi.calculate_cross_plane(y_resolution=100, z_resolution=100)
+
+fi.calculate_wake()
+print(fi.get_turbine_powers())
 
 # Create the plots
 fig, ax_list = plt.subplots(3, 1, figsize=(10, 8))

--- a/src/floris/tools/floris_interface.py
+++ b/src/floris/tools/floris_interface.py
@@ -252,7 +252,7 @@ class FlorisInterface(LoggerBase):
 
         return df
 
-    def get_hor_plane(
+    def calculate_horizontal_plane(
         self,
         height=None,
         x_resolution=200,
@@ -294,6 +294,11 @@ class FlorisInterface(LoggerBase):
             height = self.floris.turbine.hub_height
             self.logger.info("Default to hub height = %.1f for horizontal plane." % height)
 
+
+        # Store the turbine grid points for reinitialization
+        current_solver_settings = copy.deepcopy(self.floris.solver)
+
+        # Set the solver to a flow field planar grid
         solver_settings = {
             "type": "flow_field_planar_grid",
             "normal_vector": "z",
@@ -319,11 +324,18 @@ class FlorisInterface(LoggerBase):
             planar_coordinate=height,
         )
 
-        # Compute and return the cutplane
-        hor_plane = CutPlane(df, self.floris.grid.grid_resolution[0], self.floris.grid.grid_resolution[1])
-        return hor_plane
+        # Compute the cutplane
+        horizontal_plane = CutPlane(df, self.floris.grid.grid_resolution[0], self.floris.grid.grid_resolution[1])
 
-    def get_cross_plane(
+        # Reset the fi object back to the turbine grid configuration
+        self.reinitialize(
+            solver_settings=current_solver_settings
+        )
+        self.calculate_wake()
+
+        return horizontal_plane
+
+    def calculate_cross_plane(
         self,
         downstream_dist=None,
         y_resolution=200,
@@ -364,6 +376,11 @@ class FlorisInterface(LoggerBase):
         if downstream_dist is None:
             downstream_dist = 5 * 126.0
 
+
+        # Store the turbine grid points for reinitialization
+        current_solver_settings = copy.deepcopy(self.floris.solver)
+
+        # Set the solver to a flow field planar grid
         solver_settings = {
             "type": "flow_field_planar_grid",
             "normal_vector": "x",
@@ -389,11 +406,18 @@ class FlorisInterface(LoggerBase):
             planar_coordinate=downstream_dist,
         )
 
-        # Compute and return the cutplane
+        # Compute the cutplane
         cross_plane = CutPlane(df, y_resolution, z_resolution)
+
+        # Reset the fi object back to the turbine grid configuration
+        self.reinitialize(
+            solver_settings=current_solver_settings
+        )
+        self.calculate_wake()
+
         return cross_plane
 
-    def get_y_plane(
+    def calculate_y_plane(
         self,
         crossstream_dist=None,
         x_resolution=200,
@@ -434,6 +458,10 @@ class FlorisInterface(LoggerBase):
         if crossstream_dist is None:
             crossstream_dist = 0.0
 
+        # Store the turbine grid points for reinitialization
+        current_solver_settings = copy.deepcopy(self.floris.solver)
+
+        # Set the solver to a flow field planar grid
         solver_settings = {
             "type": "flow_field_planar_grid",
             "normal_vector": "y",
@@ -459,8 +487,15 @@ class FlorisInterface(LoggerBase):
             planar_coordinate=crossstream_dist,
         )
 
-        # Compute and return the cutplane
+        # Compute the cutplane
         y_plane = CutPlane(df, x_resolution, z_resolution)
+
+        # Reset the fi object back to the turbine grid configuration
+        self.reinitialize(
+            solver_settings=current_solver_settings
+        )
+        self.calculate_wake()
+
         return y_plane
         
     def check_wind_condition_for_viz(self, wd=None, ws=None):

--- a/src/floris/tools/optimization/pyoptsparse/yaw.py
+++ b/src/floris/tools/optimization/pyoptsparse/yaw.py
@@ -195,11 +195,11 @@ class Yaw:
         self.fi.calculate_wake(yaw_angles=yaw)
 
         # Initialize the horizontal cut
-        hor_plane = self.fi.get_hor_plane(x_resolution=400, y_resolution=100)
+        horizontal_plane = self.fi.calculate_horizontal_plane(x_resolution=400, y_resolution=100)
 
         # Plot and show
         fig, ax = plt.subplots()
-        visualize_cut_plane(hor_plane, ax=ax)
+        visualize_cut_plane(horizontal_plane, ax=ax)
         ax.set_title(
             "Optimal Yaw Offsets for U = "
             + str(self.wspd[0])

--- a/src/floris/tools/sowfa_utilities.py
+++ b/src/floris/tools/sowfa_utilities.py
@@ -206,7 +206,7 @@ class SowfaInterface(LoggerBase):
 
         return " "
 
-    def get_hor_plane(
+    def calculate_horizontal_plane(
         self, height, x_resolution=200, y_resolution=200, x_bounds=None, y_bounds=None
     ):
         """

--- a/src/floris/tools/visualization.py
+++ b/src/floris/tools/visualization.py
@@ -291,7 +291,7 @@ def plot_rotor_values(
         vmax = np.max(values[wd_index, ws_index])
 
         bounds = np.linspace(vmin, vmax, 31)
-        norm = mplcolors.BoundaryNorm(bounds, cmap.N)
+        norm = mplcolors.Normalize(vmin, vmax)
 
         ax.imshow(values[wd_index, ws_index, i].T, cmap=cmap, norm=norm, origin="lower")
 

--- a/src/floris/tools/visualization.py
+++ b/src/floris/tools/visualization.py
@@ -299,7 +299,8 @@ def plot_rotor_values(
         ax.set_yticks([])
         ax.set_title(t)
 
-    cbar_ax = fig.add_axes([0.05, 0.125, 0.03, 0.75])
+    fig.subplots_adjust(right=0.8)
+    cbar_ax = fig.add_axes([0.83, 0.25, 0.03, 0.5])
     cb = fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap), cax=cbar_ax)
 
     if save_path:


### PR DESCRIPTION
**Feature or improvement description**
This PR automatically sets the `FlorisInterface` object's solver settings back to the original settings after using any of the `calculate_horizontal_plane`, `calculate_cross_plane`, and `calculate_y_plane` calls.

**Related issue, if one exists**
#315 

**Impacted areas of the software**
`floris_interface.py`, examples, and any code using the updated methods within `floris_interface.py`

**Test results, if applicable**
Now when calling either `fi.calculate_wake()` or any call where you would expect to get turbine values after doing a visualization, the code works as intended and does not error.
