### PR TITLE
Feature/legacy inputs

### DIFF
--- a/src/floris/tools/__init__.py
+++ b/src/floris/tools/__init__.py
@@ -36,7 +36,7 @@ Examples:
     'rews', 'sowfa_utilities', 'visualization', 'wind_rose']
 """
 
-from .floris_interface import FlorisInterface
+from .floris_interface import FlorisInterface, FlorisInterface_legacy_v24
 from .visualization import visualize_cut_plane, visualize_quiver, plot_turbines_with_fi, plot_rotor_values
 from .wind_rose import WindRose
 

--- a/src/floris/tools/floris_interface.py
+++ b/src/floris/tools/floris_interface.py
@@ -880,7 +880,7 @@ def _convert_v24_dictionary_to_v3(dict_legacy):
     dict_out = dict()  # Output dictionary
     dict_out["name"] = dict_legacy["name"] + " (auto-converted to v3)"
     dict_out["description"] = dict_legacy["description"]
-    dict_out["floris_version"] = dict_legacy["floris_version"] + " (legacy)"
+    dict_out["floris_version"] = "v3.0 (converted from legacy format v2)"
     dict_out["logging"] = dict_legacy["logging"]
 
     dict_out["solver"] = {
@@ -1020,16 +1020,7 @@ class FlorisInterface_legacy_v24(FlorisInterface):
                 configuration = json.load(legacy_dict_file)
 
         configuration = _convert_v24_dictionary_to_v3(configuration)
-        self.floris = Floris.from_dict(configuration)
-
-        # Assign configuration to self
-        self.configuration = configuration
-
-        # Store the heterogeneous map for use after reinitailization
-        self.het_map = het_map
-        # Assign the heterogeneous map to the flow field
-        # Needed for a direct call to fi.calculate_wake without fi.reinitialize
-        self.floris.flow_field.het_map = het_map
+        super().__init__(configuration, het_map=het_map)  # Initialize full class
 
 
 def generate_heterogeneous_wind_map(speed_ups, x, y, z=None):

--- a/src/floris/tools/floris_interface.py
+++ b/src/floris/tools/floris_interface.py
@@ -866,11 +866,11 @@ class FlorisInterface(LoggerBase):
 def _convert_v24_dictionary_to_v3(dict_legacy):
     """
     Converts a v2.4 floris input dictionary file to a v3.0-compatible
-    dictionary.
+    dictionary. See detailed instructions in the class 
+    FlorisInterface_legacy_v24.
 
     Args:
-        dict_legacy (dict): Dictionary or a path to a .json file in
-        the legacy floris v2.4 format.
+        dict_legacy (dict): Input dictionary in legacy floris v2.4 format.
 
     Returns:
         dict_out (dict): Converted dictionary containing the floris input
@@ -975,7 +975,35 @@ class FlorisInterface_legacy_v24(FlorisInterface):
     """
     FlorisInterface_legacy_v24 provides a wrapper around FlorisInterface
     which enables compatibility of the class with legacy floris v2.4 input
-    files.
+    files. The user can simply pass this class the path to a legacy v2.4
+    floris input file to this class and it'll convert it to a v3.0-compatible
+    input dictionary and load the floris v3.0 object.
+
+    After successfully loading the v3.0 Floris object, you can export the
+    input file using: fi.floris.to_file("converted_input_file_v3.yaml").
+
+    If you would like to manually convert the input dictionary without first
+    loading it in FLORIS, or if somehow the code fails to automatically
+    convert the input file to v3, you should follow the following steps:
+      1. Load the legacy v2.4 input floris JSON file as a dictionary
+      2. Pass the v2.4 dictionary to `_convert_v24_dictionary_to_v3(...)`.
+         That will return a v3.0-compatible input dictionary.
+      3. Save the converted configuration file to a YAML or JSON file.
+
+      For example:
+
+        import json, yaml
+        from floris.tools.floris_interface import _convert_v24_dictionary_to_v3
+
+        with open(<path_to_legacy_v24_input_file.json>) as legacy_dict_file:
+            configuration_v2 = json.load(legacy_dict_file)
+        configuration_v3 = _convert_v24_dictionary_to_v3(configuration_v2)
+        with open(r'converted_configuration_file_v3.yaml', 'w') as file:
+            yaml.dump(configuration_v3, file)
+
+    Args:
+        configuration (:py:obj:`dict`): The legacy v2.4 Floris configuration
+            dictionary or the file path to the JSON file.
     """
 
     def __init__(self, configuration: dict | str | Path, het_map=None):

--- a/src/floris/tools/floris_interface.py
+++ b/src/floris/tools/floris_interface.py
@@ -929,36 +929,6 @@ def _convert_v24_dictionary_to_v3(dict_legacy):
         "enable_secondary_steering": wdp["use_secondary_steering"],
         "enable_yaw_added_recovery": wvp["use_yaw_added_recovery"],
         "enable_transverse_velocities": wvp["calculate_VW_velocities"],
-        "wake_deflection_parameters": {
-            "gauss": {
-                "ad": 0.0,
-                "alpha": 0.58,
-                "bd": 0.0,
-                "beta": 0.077,
-                "dm": 1.0,
-                "ka": 0.38,
-                "kb": 0.004,
-            },
-            "jimenez": {
-
-            },
-        },
-        "wake_velocity_parameters": {
-            "cc": {
-            },
-            "gauss": {
-                "alpha": 0.58,
-                "beta": 0.077,
-                "ka": 0.38,
-                "kb": 0.004,
-            },
-            "jensen": {
-            },
-        },
-        "wake_turbulence_parameters" : {
-            "crespo_hernandez": {
-            },
-        },
     }
 
     # Copy over wake velocity parameters and remove unnecessary parameters

--- a/src/floris/tools/floris_interface.py
+++ b/src/floris/tools/floris_interface.py
@@ -863,6 +863,174 @@ class FlorisInterface(LoggerBase):
             return xcoords, ycoords
 
 
+def _convert_v24_dictionary_to_v3(dict_legacy):
+    """
+    Converts a v2.4 floris input dictionary file to a v3.0-compatible
+    dictionary.
+
+    Args:
+        dict_legacy (dict): Dictionary or a path to a .json file in
+        the legacy floris v2.4 format.
+
+    Returns:
+        dict_out (dict): Converted dictionary containing the floris input
+        settings in v3.0-compatible format.
+    """
+    # Simple entries that can just be copied over
+    dict_out = dict()  # Output dictionary
+    dict_out["name"] = dict_legacy["name"] + " (auto-converted to v3)"
+    dict_out["description"] = dict_legacy["description"]
+    dict_out["floris_version"] = dict_legacy["floris_version"] + " (legacy)"
+    dict_out["logging"] = dict_legacy["logging"]
+
+    dict_out["solver"] = {
+        "type": "turbine_grid",
+        "turbine_grid_points": dict_legacy["turbine"]["properties"]["ngrid"],
+    }
+
+    fp = dict_legacy["farm"]["properties"]
+    tp = dict_legacy["turbine"]["properties"]
+    dict_out["farm"] = {
+        "layout_x": fp["layout_x"],
+        "layout_y": fp["layout_y"],
+    }
+
+    ref_height = fp["specified_wind_height"]
+    if ref_height < 0:
+        ref_height = tp["hub_height"]
+
+    dict_out["flow_field"] = {
+        "air_density": fp["air_density"],
+        "reference_wind_height": ref_height,
+        "turbulence_intensity": fp["turbulence_intensity"][0],
+        "wind_directions": [fp["wind_direction"]],
+        "wind_shear": fp["wind_shear"],
+        "wind_speeds": [fp["wind_speed"]],
+        "wind_veer": fp["wind_veer"],
+    }
+
+    wp = dict_legacy["wake"]["properties"]
+    velocity_model = wp["velocity_model"]
+    velocity_model_str = velocity_model
+    if velocity_model == "gauss_legacy":
+        velocity_model_str = "gauss"
+    deflection_model = wp["deflection_model"]
+    turbulence_model = wp["turbulence_model"]
+    wdp = wp["parameters"]["wake_deflection_parameters"][deflection_model]
+    wvp = wp["parameters"]["wake_velocity_parameters"][velocity_model]
+    wtp = wp["parameters"]["wake_turbulence_parameters"][turbulence_model]
+    dict_out["wake"] = {
+        "model_strings": {
+            "combination_model": wp["combination_model"],
+            "deflection_model": deflection_model,
+            "turbulence_model": turbulence_model,
+            "velocity_model": velocity_model_str,
+        },
+        "enable_secondary_steering": wdp["use_secondary_steering"],
+        "enable_yaw_added_recovery": wvp["use_yaw_added_recovery"],
+        "enable_transverse_velocities": wvp["calculate_VW_velocities"],
+        "wake_deflection_parameters": {
+            "gauss": {
+                "ad": 0.0,
+                "alpha": 0.58,
+                "bd": 0.0,
+                "beta": 0.077,
+                "dm": 1.0,
+                "ka": 0.38,
+                "kb": 0.004,
+            },
+            "jimenez": {
+
+            },
+        },
+        "wake_velocity_parameters": {
+            "cc": {
+            },
+            "gauss": {
+                "alpha": 0.58,
+                "beta": 0.077,
+                "ka": 0.38,
+                "kb": 0.004,
+            },
+            "jensen": {
+            },
+        },
+        "wake_turbulence_parameters" : {
+            "crespo_hernandez": {
+            },
+        },
+    }
+
+    # Copy over wake velocity parameters and remove unnecessary parameters
+    velocity_subdict = copy.deepcopy(wvp)
+    c = ["calculate_VW_velocities", "use_yaw_added_recovery", "eps_gain"]
+    for ci in [ci for ci in c if ci in velocity_subdict.keys()]:
+        velocity_subdict.pop(ci)
+
+    # Copy over wake deflection parameters and remove unnecessary parameters
+    deflection_subdict = copy.deepcopy(wdp)
+    c = ["use_secondary_steering"]
+    for ci in [ci for ci in c if ci in deflection_subdict.keys()]:
+        deflection_subdict.pop(ci)
+
+    # Copy over wake turbulence parameters and remove unnecessary parameters
+    turbulence_subdict = copy.deepcopy(wtp)
+
+    # Save parameter settings to wake dictionary
+    dict_out["wake"]["wake_velocity_parameters"] = {
+        velocity_model_str: velocity_subdict
+    }
+    dict_out["wake"]["wake_deflection_parameters"] = {
+        deflection_model: deflection_subdict
+    }
+    dict_out["wake"]["wake_turbulence_parameters"] = {
+        turbulence_model: turbulence_subdict
+    }
+
+    # Finally add turbine information
+    dict_out["turbine"] = {
+        "generator_efficiency": tp["generator_efficiency"],
+        "hub_height": tp["hub_height"],
+        "pP": tp["pP"],
+        "pT": tp["pT"],
+        "rotor_diameter": tp["rotor_diameter"],
+        "TSR": tp["TSR"],
+        "power_thrust_table": tp["power_thrust_table"],
+    }
+
+    return dict_out
+
+
+class FlorisInterface_legacy_v24(FlorisInterface):
+    """
+    FlorisInterface_legacy_v24 provides a wrapper around FlorisInterface
+    which enables compatibility of the class with legacy floris v2.4 input
+    files.
+    """
+
+    def __init__(self, configuration: dict | str | Path, het_map=None):
+
+        if not isinstance(configuration, (str, Path, dict)):
+            raise TypeError("The Floris `configuration` must of type 'dict', 'str', or 'Path'.")
+
+        print("Importing and converting legacy floris v2.4 input file...")
+        if isinstance(configuration, (str, Path)):
+            import json
+            with open(configuration) as legacy_dict_file:
+                configuration = json.load(legacy_dict_file)
+
+        configuration = _convert_v24_dictionary_to_v3(configuration)
+        self.floris = Floris.from_dict(configuration)
+
+        # Assign configuration to self
+        self.configuration = configuration
+
+        # Store the heterogeneous map for use after reinitailization
+        self.het_map = het_map
+        # Assign the heterogeneous map to the flow field
+        # Needed for a direct call to fi.calculate_wake without fi.reinitialize
+        self.floris.flow_field.het_map = het_map
+
 
 def generate_heterogeneous_wind_map(speed_ups, x, y, z=None):
     if z is not None:


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This feature adds a class that can import legacy v2.4 floris input files directly into v3.0.

**Related issue, if one exists**
Issue #328.

**Impacted areas of the software**
The floris_interface class.

**Additional supporting information**
A perfect conversion cannot be guaranteed. Though, this functionality is very useful in upgrading older repositories to floris v3.0. It's advised for users to check the settings manually after conversion.

We could consider completely separating the conversion tool rather than directly inserting the converted dictionary in a `FlorisInterface` class.

**Test results, if applicable**
The function can used in a very simple manner.
```
from floris.tools import FlorisInterface_legacy_v24 as FlorisInterface
fi = FlorisInterface("inputs/legacy_example_input_v24.json")
```

and a `v3.0` input `.yaml` file can easily be exported using `fi.floris.to_file("configuration.yaml")`.

For example, with the old example input in v2.4:
```
{
  "description": "Example FLORIS Input file",
  "farm": {
    "description": "Example 2x2 Wind Farm",
    "name": "farm_example_2x2",
    "properties": {
      "__comment__": "specified_wind_height of -1 uses the first turbine's hub height; After initialization, specified_wind_height is a free parameter.",
      "air_density": 1.225,
      "layout_x": [
        0.0,
        630.0,
        1260.0
      ],
      "layout_y": [
        0.0,
        0.0,
        0.0
      ],
      "specified_wind_height": -1,
      "turbulence_intensity": [
        0.06
      ],
      "wind_direction": [
        270.0
      ],
      "wind_shear": 0.12,
      "wind_speed": [
        9.0
      ],
      "wind_veer": 0.0,
      "wind_x": [
        0
      ],
      "wind_y": [
        0
      ]
    },
    "type": "farm"
  },
  "floris_version": "v2.0.0",
  "logging": {
    "console": {
      "enable": true,
      "level": "INFO"
    },
    "file": {
      "enable": false,
      "level": "INFO"
    }
  },
  "name": "floris_input_file_Example",
  "turbine": {
    "description": "NREL 5MW",
    "name": "nrel_5mw",
    "properties": {
      "TSR": 8.0,
      "blade_count": 3,
      "blade_pitch": 0.0,
      "generator_efficiency": 1.0,
      "hub_height": 90.0,
      "ngrid": 5,
      "pP": 1.88,
      "pT": 1.88,
      "power_thrust_table": {
        "power": [
          0.0,
          0.0,
          0.1780851,
          0.28907459,
          0.34902166,
          0.3847278,
          0.40605878,
          0.4202279,
          0.42882274,
          0.43387274,
          0.43622267,
          0.43684468,
          0.43657497,
          0.43651053,
          0.4365612,
          0.43651728,
          0.43590309,
          0.43467276,
          0.43322955,
          0.43003137,
          0.37655587,
          0.33328466,
          0.29700574,
          0.26420779,
          0.23839379,
          0.21459275,
          0.19382354,
          0.1756635,
          0.15970926,
          0.14561785,
          0.13287856,
          0.12130194,
          0.11219941,
          0.10311631,
          0.09545392,
          0.08813781,
          0.08186763,
          0.07585005,
          0.07071926,
          0.06557558,
          0.06148104,
          0.05755207,
          0.05413366,
          0.05097969,
          0.04806545,
          0.04536883,
          0.04287006,
          0.04055141
        ],
        "thrust": [
          1.19187945,
          1.17284634,
          1.09860817,
          1.02889592,
          0.97373036,
          0.92826162,
          0.89210543,
          0.86100905,
          0.835423,
          0.81237673,
          0.79225789,
          0.77584769,
          0.7629228,
          0.76156073,
          0.76261984,
          0.76169723,
          0.75232027,
          0.74026851,
          0.72987175,
          0.70701647,
          0.54054532,
          0.45509459,
          0.39343381,
          0.34250785,
          0.30487242,
          0.27164979,
          0.24361964,
          0.21973831,
          0.19918151,
          0.18131868,
          0.16537679,
          0.15103727,
          0.13998636,
          0.1289037,
          0.11970413,
          0.11087113,
          0.10339901,
          0.09617888,
          0.09009926,
          0.08395078,
          0.0791188,
          0.07448356,
          0.07050731,
          0.06684119,
          0.06345518,
          0.06032267,
          0.05741999,
          0.05472609
        ],
        "wind_speed": [
          2.0,
          2.5,
          3.0,
          3.5,
          4.0,
          4.5,
          5.0,
          5.5,
          6.0,
          6.5,
          7.0,
          7.5,
          8.0,
          8.5,
          9.0,
          9.5,
          10.0,
          10.5,
          11.0,
          11.5,
          12.0,
          12.5,
          13.0,
          13.5,
          14.0,
          14.5,
          15.0,
          15.5,
          16.0,
          16.5,
          17.0,
          17.5,
          18.0,
          18.5,
          19.0,
          19.5,
          20.0,
          20.5,
          21.0,
          21.5,
          22.0,
          22.5,
          23.0,
          23.5,
          24.0,
          24.5,
          25.0,
          25.5
        ]
      },
      "rloc": 0.5,
      "rotor_diameter": 126.0,
      "tilt_angle": 0.0,
      "use_points_on_perimeter": false,
      "yaw_angle": 0.0
    },
    "type": "turbine"
  },
  "type": "floris_input",
  "wake": {
    "description": "wake",
    "name": "wake_default",
    "properties": {
      "combination_model": "sosfs",
      "deflection_model": "gauss",
      "parameters": {
        "wake_deflection_parameters": {
          "gauss": {
            "dm": 1.0,
            "eps_gain": 0.2,
            "use_secondary_steering": true
          }
        },
        "wake_turbulence_parameters": {
          "crespo_hernandez": {
            "ai": 0.8,
            "constant": 0.5,
            "downstream": -0.32,
            "initial": 0.1
          }
        },
        "wake_velocity_parameters": {
          "gauss_legacy": {
            "calculate_VW_velocities": true,
            "eps_gain": 0.2,
            "ka": 0.38,
            "kb": 0.004,
            "use_yaw_added_recovery": true
          }
        }
      },
      "turbulence_model": "crespo_hernandez",
      "velocity_model": "gauss_legacy"
    },
    "type": "wake"
  }
}
```

We find that the converted configuration dictionary becomes:
```
description: Example FLORIS Input file
farm:
  layout_x:
  - 0.0
  - 630.0
  - 1260.0
  layout_y:
  - 0.0
  - 0.0
  - 0.0
floris_version: v2.0.0 (legacy)
flow_field:
  air_density: 1.225
  reference_wind_height: 90
  turbulence_intensity: 0.06
  wind_directions:
  - - 270.0
  wind_shear: 0.12
  wind_speeds:
  - - 9.0
  wind_veer: 0.0
logging:
  console:
    enable: true
    level: INFO
  file:
    enable: false
    level: INFO
name: floris_input_file_Example (auto-converted to v3)
solver:
  turbine_grid_points: 5
  type: turbine_grid
turbine:
  TSR: 8.0
  generator_efficiency: 1.0
  hub_height: 90.0
  pP: 1.88
  pT: 1.88
  power_thrust_table:
    power:
    - 0.0
    - 0.0
    - 0.1780851
    - 0.28907459
    - 0.34902166
    - 0.3847278
    - 0.40605878
    - 0.4202279
    - 0.42882274
    - 0.43387274
    - 0.43622267
    - 0.43684468
    - 0.43657497
    - 0.43651053
    - 0.4365612
    - 0.43651728
    - 0.43590309
    - 0.43467276
    - 0.43322955
    - 0.43003137
    - 0.37655587
    - 0.33328466
    - 0.29700574
    - 0.26420779
    - 0.23839379
    - 0.21459275
    - 0.19382354
    - 0.1756635
    - 0.15970926
    - 0.14561785
    - 0.13287856
    - 0.12130194
    - 0.11219941
    - 0.10311631
    - 0.09545392
    - 0.08813781
    - 0.08186763
    - 0.07585005
    - 0.07071926
    - 0.06557558
    - 0.06148104
    - 0.05755207
    - 0.05413366
    - 0.05097969
    - 0.04806545
    - 0.04536883
    - 0.04287006
    - 0.04055141
    thrust:
    - 1.19187945
    - 1.17284634
    - 1.09860817
    - 1.02889592
    - 0.97373036
    - 0.92826162
    - 0.89210543
    - 0.86100905
    - 0.835423
    - 0.81237673
    - 0.79225789
    - 0.77584769
    - 0.7629228
    - 0.76156073
    - 0.76261984
    - 0.76169723
    - 0.75232027
    - 0.74026851
    - 0.72987175
    - 0.70701647
    - 0.54054532
    - 0.45509459
    - 0.39343381
    - 0.34250785
    - 0.30487242
    - 0.27164979
    - 0.24361964
    - 0.21973831
    - 0.19918151
    - 0.18131868
    - 0.16537679
    - 0.15103727
    - 0.13998636
    - 0.1289037
    - 0.11970413
    - 0.11087113
    - 0.10339901
    - 0.09617888
    - 0.09009926
    - 0.08395078
    - 0.0791188
    - 0.07448356
    - 0.07050731
    - 0.06684119
    - 0.06345518
    - 0.06032267
    - 0.05741999
    - 0.05472609
    wind_speed:
    - 2.0
    - 2.5
    - 3.0
    - 3.5
    - 4.0
    - 4.5
    - 5.0
    - 5.5
    - 6.0
    - 6.5
    - 7.0
    - 7.5
    - 8.0
    - 8.5
    - 9.0
    - 9.5
    - 10.0
    - 10.5
    - 11.0
    - 11.5
    - 12.0
    - 12.5
    - 13.0
    - 13.5
    - 14.0
    - 14.5
    - 15.0
    - 15.5
    - 16.0
    - 16.5
    - 17.0
    - 17.5
    - 18.0
    - 18.5
    - 19.0
    - 19.5
    - 20.0
    - 20.5
    - 21.0
    - 21.5
    - 22.0
    - 22.5
    - 23.0
    - 23.5
    - 24.0
    - 24.5
    - 25.0
    - 25.5
  rotor_diameter: 126.0
wake:
  enable_secondary_steering: true
  enable_transverse_velocities: true
  enable_yaw_added_recovery: true
  model_strings:
    combination_model: sosfs
    deflection_model: gauss
    turbulence_model: crespo_hernandez
    velocity_model: gauss
  wake_deflection_parameters:
    gauss:
      dm: 1.0
      eps_gain: 0.2
  wake_turbulence_parameters:
    crespo_hernandez:
      ai: 0.8
      constant: 0.5
      downstream: -0.32
      initial: 0.1
  wake_velocity_parameters:
    gauss:
      ka: 0.38
      kb: 0.004

```


<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
