### PR TITLE
Bound Ct to [0.0001, 0.9999]

### DIFF
--- a/src/floris/simulation/turbine.py
+++ b/src/floris/simulation/turbine.py
@@ -166,7 +166,7 @@ def Ct(
 
     average_velocities = average_velocity(velocities)
     thrust_coefficient = fCt(average_velocities)
-    thrust_coefficient = np.clip(thrust_coefficient, 0.0, 1.0)
+    thrust_coefficient = np.clip(thrust_coefficient, 0.0001, 0.9999)
     effective_thrust = thrust_coefficient * cosd(yaw_angle)
     return effective_thrust
 


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
The thrust interpolation function was bound to [0.0001, 0.9999] but the Ct calculated from the velocities was bound to [0, 1]. In some models, the upper limit of 1 causes a divide-by-zero error.