### PR TITLE
Save and reset the state of Floris during plotting

### DIFF
--- a/src/floris/tools/floris_interface.py
+++ b/src/floris/tools/floris_interface.py
@@ -289,11 +289,11 @@ class FlorisInterface(LoggerBase):
         if ws is None:
             ws = self.floris.flow_field.wind_speeds
         self.check_wind_condition_for_viz(wd=wd, ws=ws)
+
         # If height not provided, use the hub height
         if height is None:
             height = self.floris.turbine.hub_height
             self.logger.info("Default to hub height = %.1f for horizontal plane." % height)
-
 
         # Store the current state for reinitialization
         floris_dict = self.floris.as_dict()
@@ -372,14 +372,14 @@ class FlorisInterface(LoggerBase):
             wd = self.floris.flow_field.wind_directions
         if ws is None:
             ws = self.floris.flow_field.wind_speeds
+
         self.check_wind_condition_for_viz(wd=wd, ws=ws)
         # If downstream distance is not provided, use the default
         if downstream_dist is None:
             downstream_dist = 5 * 126.0
 
-
-        # Store the turbine grid points for reinitialization
-        current_solver_settings = copy.deepcopy(self.floris.solver)
+        # Store the current state for reinitialization
+        floris_dict = self.floris.as_dict()
 
         # Set the solver to a flow field planar grid
         solver_settings = {
@@ -411,9 +411,9 @@ class FlorisInterface(LoggerBase):
         cross_plane = CutPlane(df, y_resolution, z_resolution)
 
         # Reset the fi object back to the turbine grid configuration
-        self.reinitialize(
-            solver_settings=current_solver_settings
-        )
+        self.floris = Floris.from_dict(floris_dict)
+        self.floris.flow_field.het_map = self.het_map
+
         # Run the simulation again for futher postprocessing (i.e. now we can get farm power)
         self.calculate_wake()
 
@@ -456,12 +456,13 @@ class FlorisInterface(LoggerBase):
         if ws is None:
             ws = self.floris.flow_field.wind_speeds
         self.check_wind_condition_for_viz(wd=wd, ws=ws)
+
         # If crossstream distance is not provided, use the default
         if crossstream_dist is None:
             crossstream_dist = 0.0
 
-        # Store the turbine grid points for reinitialization
-        current_solver_settings = copy.deepcopy(self.floris.solver)
+        # Store the current state for reinitialization
+        floris_dict = self.floris.as_dict()
 
         # Set the solver to a flow field planar grid
         solver_settings = {
@@ -493,9 +494,9 @@ class FlorisInterface(LoggerBase):
         y_plane = CutPlane(df, x_resolution, z_resolution)
 
         # Reset the fi object back to the turbine grid configuration
-        self.reinitialize(
-            solver_settings=current_solver_settings
-        )
+        self.floris = Floris.from_dict(floris_dict)
+        self.floris.flow_field.het_map = self.het_map
+
         # Run the simulation again for futher postprocessing (i.e. now we can get farm power)
         self.calculate_wake()
 

--- a/src/floris/tools/floris_interface.py
+++ b/src/floris/tools/floris_interface.py
@@ -295,8 +295,8 @@ class FlorisInterface(LoggerBase):
             self.logger.info("Default to hub height = %.1f for horizontal plane." % height)
 
 
-        # Store the turbine grid points for reinitialization
-        current_solver_settings = copy.deepcopy(self.floris.solver)
+        # Store the current state for reinitialization
+        floris_dict = self.floris.as_dict()
 
         # Set the solver to a flow field planar grid
         solver_settings = {
@@ -328,9 +328,9 @@ class FlorisInterface(LoggerBase):
         horizontal_plane = CutPlane(df, self.floris.grid.grid_resolution[0], self.floris.grid.grid_resolution[1])
 
         # Reset the fi object back to the turbine grid configuration
-        self.reinitialize(
-            solver_settings=current_solver_settings
-        )
+        self.floris = Floris.from_dict(floris_dict)
+        self.floris.flow_field.het_map = self.het_map
+
         # Run the simulation again for futher postprocessing (i.e. now we can get farm power)
         self.calculate_wake()
 


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
In the `FlorisInterface.calculate_XX_plane()` functions, save the current state of `Floris()` and reset to this after doing the wake calculation for plotting. This allows the user to continue to use the existing `FlorisInterface` object for further analysis.

**Related issue, if one exists**
#315

**Impacted areas of the software**
`FlorisInterface.calculate_horizontal_plane`
`FlorisInterface.calculate_cross_plane`
`FlorisInterface.calculate_y_plane`
