### PR TITLE
Correcting bound for boundary constraint; removing hard-coded rotor diameter

### DIFF
--- a/floris/tools/optimization/pyoptsparse/layout.py
+++ b/floris/tools/optimization/pyoptsparse/layout.py
@@ -101,7 +101,7 @@ class Layout:
         return optProb
 
     def add_con_group(self, optProb):
-        optProb.addConGroup("boundary_con", self.nturbs, lower=0.0)
+        optProb.addConGroup("boundary_con", self.nturbs, upper=0.0)
         optProb.addConGroup("spacing_con", 1, upper=0.0)
 
         return optProb
@@ -205,5 +205,4 @@ class Layout:
 
     @property
     def rotor_diameter(self):
-        # return self.fi.floris.farm.turbine_map.turbines[0].rotor_diameter
-        return 126.0
+        return self.fi.floris.farm.rotor_diameters[0][0][0]


### PR DESCRIPTION
**Feature or improvement description**
Bugfix that properly sets the boundary for the boundary constraint in the layout optimization. Also removes a hard-coded value for the rotor diameter.

**Related issue, if one exists**
Closes #363

**Impacted areas of the software**
`tools/optimization/layout.py`
