### PR TITLE
Add no_wake option to floris calculations

### DIFF
--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -124,7 +124,7 @@ class Floris(logging_manager.LoggerBase, FromDictMixin):
     
 
     # @profile
-    def steady_state_atmospheric_condition(self):
+    def steady_state_atmospheric_condition(self, no_wake=False):
 
         # Initialize field quanitities; doing this immediately prior to doing
         # the calculation step allows for manipulating inputs in a script
@@ -139,7 +139,10 @@ class Floris(logging_manager.LoggerBase, FromDictMixin):
         # <<interface>>
         # start = time.time()
 
-        if vel_model=="cc":
+        if no_wake:
+            # Skip wake calculations
+            elapsed_time = 0.0
+        elif vel_model=="cc":
             elapsed_time = cc_solver(
                 self.farm,
                 self.flow_field,

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -81,7 +81,7 @@ class FlorisInterface(LoggerBase):
     def calculate_wake(
         self,
         yaw_angles: NDArrayFloat | list[float] | None = None,
-        # no_wake: bool = False,
+        no_wake: bool = False,
         # points: NDArrayFloat | list[float] | None = None,
         # track_n_upstream_wakes: bool = False,
     ) -> None:
@@ -111,7 +111,7 @@ class FlorisInterface(LoggerBase):
         if yaw_angles is not None:
             self.floris.farm.yaw_angles = yaw_angles
 
-        self.floris.steady_state_atmospheric_condition()
+        self.floris.steady_state_atmospheric_condition(no_wake=no_wake)
 
     def reinitialize(
         self,


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
This PR reintroduces the `no_wake` feature that skips the wake deficit and deflection calculations. FLORIS v3.0 actually works beautifully for the `no_wake` option so little changes are needed to the code.

**Related issue, if one exists**
#361 and this feature will be useful to address #365 and #369 

**Impacted areas of the software**
FLORIS simulations

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
Example `04_sweep_wind_directions.py` yields:
![image](https://user-images.githubusercontent.com/22119448/157068894-17836380-b2ec-4828-b41b-ab4d1068aade.png)

Updating line 58 to
```
fi.calculate_wake(yaw_angles=yaw_angles, no_wake=True)
```
then returns
![image](https://user-images.githubusercontent.com/22119448/157068994-828462bd-5e28-48ba-90bd-a8453f0b6bdc.png)


<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->