### PR TITLE
More robust file path creation

### DIFF
--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -74,7 +74,9 @@ class Farm(BaseClass):
         for i, val in enumerate(value):
             if type(val) is str:
                 _floris_dir = Path(__file__).parent.parent
-                fname = _floris_dir / "turbine_library" / f"{val}.yaml"
+                fname = os.path.join(_floris_dir,
+                                     "turbine_library",
+                                     "{}.yaml".format(val))
                 if not os.path.isfile(fname):
                     raise ValueError("User-selected turbine definition `{}` does not exist in pre-defined turbine library.".format(val))
                 self.turbine_definitions[i] = load_yaml(fname)


### PR DESCRIPTION
Using `os.path.join` is more robust than the `+` operator.
It will maybe solve the issue of @econdon16 (related issue #345).