### PR TITLE
Fixed orientation for plots

### DIFF
--- a/examples/17_fixed_orientation.py
+++ b/examples/17_fixed_orientation.py
@@ -34,8 +34,6 @@ if __name__ == "__main__":
         # Get horizontal plane
         hor_plane = fi.calculate_horizontal_plane(
             height=90.0,
-            # x_bounds=[250.0, 1750.0],
-            # y_bounds=[-250.0, 250.0],
             yaw_angles=None,
             north_up=True,
         )

--- a/examples/17_fixed_orientation.py
+++ b/examples/17_fixed_orientation.py
@@ -1,3 +1,17 @@
+# Copyright 2021 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# See https://floris.readthedocs.io for documentation
+
 import matplotlib.pyplot as plt
 
 from floris.tools import FlorisInterface

--- a/examples/17_fixed_orientation.py
+++ b/examples/17_fixed_orientation.py
@@ -1,0 +1,34 @@
+import matplotlib.pyplot as plt
+
+from floris.tools import FlorisInterface
+from floris.tools.visualization import visualize_cut_plane
+
+
+if __name__ == "__main__":
+    # Data
+    fi = FlorisInterface("inputs/gch.yaml")
+    wind_directions = [225.0, 270.0, 315.0]
+    layout = [[500.0, 1000.0, 1500.0], [0.0, 0.0, 0.0]]
+
+    # For each wind direction
+    for wd in wind_directions:
+
+        # Compute wakes
+        fi.reinitialize(layout=layout, wind_directions=[wd], wind_speeds=[7.0])
+        fi.calculate_wake(yaw_angles=None)
+
+        # Get horizontal plane
+        hor_plane = fi.calculate_horizontal_plane(
+            height=90.0,
+            # x_bounds=[250.0, 1750.0],
+            # y_bounds=[-250.0, 250.0],
+            yaw_angles=None,
+            north_up=True,
+        )
+
+        # Plot and save figure
+        figure = plt.figure()
+        render_ax = figure.add_subplot(111)
+        im = visualize_cut_plane(hor_plane, ax=render_ax)
+        render_ax.set_title("wind_direction={}°".format(wd))
+        plt.show()

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -271,6 +271,7 @@ class FlorisInterface(LoggerBase):
         wd=None,
         ws=None,
         yaw_angles=None,
+        north_up=False,
     ):
         """
         Shortcut method to instantiate a :py:class:`~.tools.cut_plane.CutPlane`
@@ -287,6 +288,7 @@ class FlorisInterface(LoggerBase):
                 Defaults to None.
             y_bounds (tuple, optional): Limits of output array (in m).
                 Defaults to None.
+            north_up (bool): if True, plots will have the same orientation.
 
         Returns:
             :py:class:`~.tools.cut_plane.CutPlane`: containing values
@@ -327,6 +329,22 @@ class FlorisInterface(LoggerBase):
             normal_vector="z",
             planar_coordinate=height,
         )
+
+        # If fixed orientation
+        if north_up:
+
+            # Get points
+            points = df[["x1", "x2"]].to_numpy()
+
+            # Compute rotation matrix
+            rad = np.deg2rad(wd - 270.0)
+            rotation_matrix = np.array([[np.cos(rad), np.sin(rad)],
+                                        [-np.sin(rad), np.cos(rad)]])
+
+            # Rotate points
+            points = np.dot(points, rotation_matrix.T)
+            points = np.squeeze(points, axis=1)
+            df[["x1", "x2"]] = points
 
         # Compute the cutplane
         horizontal_plane = CutPlane(df, self.floris.grid.grid_resolution[0], self.floris.grid.grid_resolution[1])


### PR DESCRIPTION
> NOT READY TO BE MERGED

## What

I try to implement the option to allow plots with fixed orientation.
Related issue: #357.

## Done

I added a boolean argument `north_up` to the `calculate_horizontal_plane`.
I created a related example `17_fixed_orientation.py`.
Plots can now have a fixed orientation.

## TODO

An image is better than words here.
So I am not sure about what to do to have a valid flow field on all the figure.
![tmp](https://user-images.githubusercontent.com/34685648/157267320-5fa8981b-3aae-43a9-8f92-992320794052.png)