### PR TITLE
Fix for repeated calls to calculate_wake returning incorrect values.

### DIFF
--- a/examples/10_optimize_yaw.py
+++ b/examples/10_optimize_yaw.py
@@ -42,8 +42,8 @@ def load_floris():
     # Specify wind farm layout and update in the floris object
     N = 5  # number of turbines per row and per column
     X, Y = np.meshgrid(
-        5.0 * fi.floris.farm.rotor_diameters[0][0][0] * np.arange(0, N, 1),
-        5.0 * fi.floris.farm.rotor_diameters[0][0][0] * np.arange(0, N, 1),
+        5.0 * fi.floris.farm.rotor_diameters_sorted[0][0][0] * np.arange(0, N, 1),
+        5.0 * fi.floris.farm.rotor_diameters_sorted[0][0][0] * np.arange(0, N, 1),
     )
     fi.reinitialize(layout=(X.flatten(), Y.flatten()))
 

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -39,9 +39,12 @@ class FlowField(FromDictMixin):
     n_wind_speeds: int = field(init=False)
     n_wind_directions: int = field(init=False)
 
-    u_initial: NDArrayFloat = field(init=False, default=np.array([]))
-    v_initial: NDArrayFloat = field(init=False, default=np.array([]))
-    w_initial: NDArrayFloat = field(init=False, default=np.array([]))
+    u_initial_sorted: NDArrayFloat = field(init=False, default=np.array([]))
+    v_initial_sorted: NDArrayFloat = field(init=False, default=np.array([]))
+    w_initial_sorted: NDArrayFloat = field(init=False, default=np.array([]))
+    u_sorted: NDArrayFloat = field(init=False, default=np.array([]))
+    v_sorted: NDArrayFloat = field(init=False, default=np.array([]))
+    w_sorted: NDArrayFloat = field(init=False, default=np.array([]))
     u: NDArrayFloat = field(init=False, default=np.array([]))
     v: NDArrayFloat = field(init=False, default=np.array([]))
     w: NDArrayFloat = field(init=False, default=np.array([]))
@@ -70,7 +73,7 @@ class FlowField(FromDictMixin):
         # determined by this line. Since the right-most dimension on grid.z is storing the values
         # for height, using it here to apply the shear law makes that dimension store the vertical
         # wind profile.
-        wind_profile_plane = (grid.z / self.reference_wind_height) ** self.wind_shear
+        wind_profile_plane = (grid.z_sorted / self.reference_wind_height) ** self.wind_shear
 
         # If no hetergeneous inflow defined, then set all speeds ups to 1.0
         if self.het_map is None:
@@ -80,9 +83,9 @@ class FlowField(FromDictMixin):
         # grid locations are determined in either 2 or 3 dimensions.
         else:
             if len(self.het_map[0][0].points[0]) == 2:
-                speed_ups = self.calculate_speed_ups(self.het_map, grid.x, grid.y)
+                speed_ups = self.calculate_speed_ups(self.het_map, grid.x_sorted, grid.y_sorted)
             elif len(self.het_map[0][0].points[0]) == 3:
-                speed_ups = self.calculate_speed_ups(self.het_map, grid.x, grid.y, grid.z)
+                speed_ups = self.calculate_speed_ups(self.het_map, grid.x_sorted, grid.y_sorted, grid.z_sorted)
 
         # Create the sheer-law wind profile
         # This array is of shape (# wind directions, # wind speeds, grid.template_array)
@@ -90,18 +93,18 @@ class FlowField(FromDictMixin):
         # here to do broadcasting from left to right (transposed), and then transpose back.
         # The result is an array the wind speed and wind direction dimensions on the left side
         # of the shape and the grid.template array on the right
-        self.u_initial = (self.wind_speeds[None, :].T * wind_profile_plane.T).T * speed_ups
-        self.v_initial = np.zeros(np.shape(self.u_initial), dtype=self.u_initial.dtype)
-        self.w_initial = np.zeros(np.shape(self.u_initial), dtype=self.u_initial.dtype)
+        self.u_initial_sorted = (self.wind_speeds[None, :].T * wind_profile_plane.T).T * speed_ups
+        self.v_initial_sorted = np.zeros(np.shape(self.u_initial_sorted), dtype=self.u_initial_sorted.dtype)
+        self.w_initial_sorted = np.zeros(np.shape(self.u_initial_sorted), dtype=self.u_initial_sorted.dtype)
 
-        self.u = self.u_initial.copy()
-        self.v = self.v_initial.copy()
-        self.w = self.w_initial.copy()
+        self.u_sorted = self.u_initial_sorted.copy()
+        self.v_sorted = self.v_initial_sorted.copy()
+        self.w_sorted = self.w_initial_sorted.copy()
 
     def finalize(self, unsorted_indices):
-        self.u = np.take_along_axis(self.u, unsorted_indices, axis=2)
-        self.v = np.take_along_axis(self.v, unsorted_indices, axis=2)
-        self.w = np.take_along_axis(self.w, unsorted_indices, axis=2)
+        self.u = np.take_along_axis(self.u_sorted, unsorted_indices, axis=2)
+        self.v = np.take_along_axis(self.v_sorted, unsorted_indices, axis=2)
+        self.w = np.take_along_axis(self.w_sorted, unsorted_indices, axis=2)
 
     def calculate_speed_ups(self, het_map, x, y, z=None):
         if z is not None:

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -66,9 +66,12 @@ class Grid(ABC):
     n_wind_speeds: int = field(init=False)
     n_wind_directions: int = field(init=False)
     turbine_coordinates_array: NDArrayFloat = field(init=False)
-    x: NDArrayFloat = field(init=False)
-    y: NDArrayFloat = field(init=False)
-    z: NDArrayFloat = field(init=False)
+    x: NDArrayFloat = field(init=False, default=[])
+    y: NDArrayFloat = field(init=False, default=[])
+    z: NDArrayFloat = field(init=False, default=[])
+    x_sorted: NDArrayFloat = field(init=False)
+    y_sorted: NDArrayFloat = field(init=False)
+    z_sorted: NDArrayFloat = field(init=False)
 
     def __attrs_post_init__(self) -> None:
         self.turbine_coordinates_array = np.array([c.elements for c in self.turbine_coordinates])
@@ -164,11 +167,11 @@ class TurbineGrid(Grid):
 
         In a y-z plane on the rotor swept area, the -2 dimension is a column of points and the -1 dimension is the row number.
         So the following line prints the 0'th column of the the 0'th turbine's grid:
-        print(grid.y[0,0,0,0,:])
-        print(grid.z[0,0,0,0,:])
+        print(grid.y_sorted[0,0,0,0,:])
+        print(grid.z_sorted[0,0,0,0,:])
         And this line prints a single point
-        print(grid.y[0,0,0,0,0])
-        print(grid.z[0,0,0,0,0])
+        print(grid.y_sorted[0,0,0,0,0])
+        print(grid.z_sorted[0,0,0,0,0])
         Note that the x coordinates are all the same for the rotor plane.
 
         """
@@ -222,16 +225,16 @@ class TurbineGrid(Grid):
         self.unsorted_indices = self.sorted_indices.argsort(axis=2)
 
         # Put the turbines into the final arrays in their sorted order
-        self.x = np.take_along_axis(_x, self.sorted_indices, axis=2)
-        self.y = np.take_along_axis(_y, self.sorted_indices, axis=2)
-        self.z = np.take_along_axis(_z, self.sorted_indices, axis=2)
+        self.x_sorted = np.take_along_axis(_x, self.sorted_indices, axis=2)
+        self.y_sorted = np.take_along_axis(_y, self.sorted_indices, axis=2)
+        self.z_sorted = np.take_along_axis(_z, self.sorted_indices, axis=2)
 
     def finalize(self):
         # Replace the turbines in their unsorted order so that
         # we can report values in a sane way.
-        self.x = np.take_along_axis(self.x, self.unsorted_indices, axis=2)
-        self.y = np.take_along_axis(self.y, self.unsorted_indices, axis=2)
-        self.z = np.take_along_axis(self.z, self.unsorted_indices, axis=2)
+        self.x = np.take_along_axis(self.x_sorted, self.unsorted_indices, axis=2)
+        self.y = np.take_along_axis(self.y_sorted, self.unsorted_indices, axis=2)
+        self.z = np.take_along_axis(self.z_sorted, self.unsorted_indices, axis=2)
 
 
 @define
@@ -283,9 +286,9 @@ class FlowFieldGrid(Grid):
             indexing="ij"
         )
 
-        self.x = x_points[None, None, :, :, :]
-        self.y = y_points[None, None, :, :, :]
-        self.z = z_points[None, None, :, :, :]
+        self.x_sorted = x_points[None, None, :, :, :]
+        self.y_sorted = y_points[None, None, :, :, :]
+        self.z_sorted = z_points[None, None, :, :, :]
 
     def finalize(self):
         pass
@@ -347,9 +350,9 @@ class FlowFieldPlanarGrid(Grid):
                 indexing="ij"
             )
 
-            self.x = x_points[None, None, :, :, :]
-            self.y = y_points[None, None, :, :, :]
-            self.z = z_points[None, None, :, :, :]
+            self.x_sorted = x_points[None, None, :, :, :]
+            self.y_sorted = y_points[None, None, :, :, :]
+            self.z_sorted = z_points[None, None, :, :, :]
 
         elif self.normal_vector == "x":  # Rules of thumb for cross plane
             if self.x1_bounds is None:
@@ -365,9 +368,9 @@ class FlowFieldPlanarGrid(Grid):
                 indexing="ij"
             )
 
-            self.x = x_points[None, None, :, :, :]
-            self.y = y_points[None, None, :, :, :]
-            self.z = z_points[None, None, :, :, :]
+            self.x_sorted = x_points[None, None, :, :, :]
+            self.y_sorted = y_points[None, None, :, :, :]
+            self.z_sorted = z_points[None, None, :, :, :]
 
         elif self.normal_vector == "y":  # Rules of thumb for y plane
             if self.x1_bounds is None:
@@ -383,9 +386,9 @@ class FlowFieldPlanarGrid(Grid):
                 indexing="ij"
             )
 
-            self.x = x_points[None, None, :, :, :]
-            self.y = y_points[None, None, :, :, :]
-            self.z = z_points[None, None, :, :, :]
+            self.x_sorted = x_points[None, None, :, :, :]
+            self.y_sorted = y_points[None, None, :, :, :]
+            self.z_sorted = z_points[None, None, :, :, :]
 
         # self.sorted_indices = self.x.argsort(axis=2)
         # self.unsorted_indices = self.sorted_indices.argsort(axis=2)

--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -57,9 +57,9 @@ def sequential_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, mode
     deficit_model_args = model_manager.velocity_model.prepare_function(grid, flow_field)
 
     # This is u_wake
-    wake_field = np.zeros_like(flow_field.u_initial)
-    v_wake = np.zeros_like(flow_field.v_initial)
-    w_wake = np.zeros_like(flow_field.w_initial)
+    wake_field = np.zeros_like(flow_field.u_initial_sorted)
+    v_wake = np.zeros_like(flow_field.v_initial_sorted)
+    w_wake = np.zeros_like(flow_field.w_initial_sorted)
 
     turbine_turbulence_intensity = flow_field.turbulence_intensity * np.ones((flow_field.n_wind_directions, flow_field.n_wind_speeds, farm.n_turbines, 1, 1))
     ambient_turbulence_intensity = flow_field.turbulence_intensity
@@ -68,37 +68,37 @@ def sequential_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, mode
     for i in range(grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(grid.x[:, :, i:i+1], axis=(3, 4))
+        x_i = np.mean(grid.x_sorted[:, :, i:i+1], axis=(3, 4))
         x_i = x_i[:, :, :, None, None]
-        y_i = np.mean(grid.y[:, :, i:i+1], axis=(3, 4))        
+        y_i = np.mean(grid.y_sorted[:, :, i:i+1], axis=(3, 4))        
         y_i = y_i[:, :, :, None, None]
-        z_i = np.mean(grid.z[:, :, i:i+1], axis=(3, 4))
+        z_i = np.mean(grid.z_sorted[:, :, i:i+1], axis=(3, 4))
         z_i = z_i[:, :, :, None, None]
 
-        u_i = flow_field.u[:, :, i:i+1]
-        v_i = flow_field.v[:, :, i:i+1]
+        u_i = flow_field.u_sorted[:, :, i:i+1]
+        v_i = flow_field.v_sorted[:, :, i:i+1]
 
         ct_i = Ct(
-            velocities=flow_field.u,
-            yaw_angle=farm.yaw_angles,
+            velocities=flow_field.u_sorted,
+            yaw_angle=farm.yaw_angles_sorted,
             fCt=farm.turbine_fCts,
-            turbine_type_map=farm.turbine_type_map,
+            turbine_type_map=farm.turbine_type_map_sorted,
             ix_filter=[i],
         )
         ct_i = ct_i[:, :, 0:1, None, None]  # Since we are filtering for the i'th turbine in the Ct function, get the first index here (0:1)
         axial_induction_i = axial_induction(
-            velocities=flow_field.u,
-            yaw_angle=farm.yaw_angles,
+            velocities=flow_field.u_sorted,
+            yaw_angle=farm.yaw_angles_sorted,
             fCt=farm.turbine_fCts,
-            turbine_type_map=farm.turbine_type_map,
+            turbine_type_map=farm.turbine_type_map_sorted,
             ix_filter=[i],
         )
         axial_induction_i = axial_induction_i[:, :, 0:1, None, None]    # Since we are filtering for the i'th turbine in the axial induction function, get the first index here (0:1)
         turbulence_intensity_i = turbine_turbulence_intensity[:, :, i:i+1]
-        yaw_angle_i = farm.yaw_angles[:, :, i:i+1, None, None]
-        hub_height_i = farm.hub_heights[: ,:, i:i+1, None, None]
-        rotor_diameter_i = farm.rotor_diameters[: ,:, i:i+1, None, None]
-        TSR_i = farm.TSRs[: ,:, i:i+1, None, None]
+        yaw_angle_i = farm.yaw_angles_sorted[:, :, i:i+1, None, None]
+        hub_height_i = farm.hub_heights_sorted[: ,:, i:i+1, None, None]
+        rotor_diameter_i = farm.rotor_diameters_sorted[: ,:, i:i+1, None, None]
+        TSR_i = farm.TSRs_sorted[: ,:, i:i+1, None, None]
 
         effective_yaw_i = np.zeros_like(yaw_angle_i)
         effective_yaw_i += yaw_angle_i
@@ -107,9 +107,9 @@ def sequential_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, mode
             added_yaw = wake_added_yaw(
                 u_i,
                 v_i,
-                flow_field.u_initial,
-                grid.y[:, :, i:i+1] - y_i,
-                grid.z[:, :, i:i+1],
+                flow_field.u_initial_sorted,
+                grid.y_sorted[:, :, i:i+1] - y_i,
+                grid.z_sorted[:, :, i:i+1],
                 rotor_diameter_i,
                 hub_height_i,
                 ct_i,
@@ -133,10 +133,10 @@ def sequential_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, mode
         if model_manager.enable_transverse_velocities:
             v_wake, w_wake = calculate_transverse_velocity(
                 u_i,
-                flow_field.u_initial,
-                grid.x - x_i,
-                grid.y - y_i,
-                grid.z,
+                flow_field.u_initial_sorted,
+                grid.x_sorted - x_i,
+                grid.y_sorted - y_i,
+                grid.z_sorted,
                 rotor_diameter_i,
                 hub_height_i,
                 yaw_angle_i,
@@ -150,7 +150,7 @@ def sequential_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, mode
                 u_i,
                 turbulence_intensity_i,
                 v_i,
-                flow_field.w[:, :, i:i+1],
+                flow_field.w_sorted[:, :, i:i+1],
                 v_wake[:, :, i:i+1],
                 w_wake[:, :, i:i+1],
             )
@@ -174,19 +174,19 @@ def sequential_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, mode
 
         wake_field = model_manager.combination_model.function(
             wake_field,
-            velocity_deficit * flow_field.u_initial
+            velocity_deficit * flow_field.u_initial_sorted
         )
 
         wake_added_turbulence_intensity = model_manager.turbulence_model.function(
             ambient_turbulence_intensity,
-            grid.x,
+            grid.x_sorted,
             x_i,
             rotor_diameter_i,
             axial_induction_i
         )
 
         # Calculate wake overlap for wake-added turbulence (WAT)
-        area_overlap = np.sum(velocity_deficit * flow_field.u_initial > 0.05, axis=(3, 4)) / (grid.grid_resolution * grid.grid_resolution)
+        area_overlap = np.sum(velocity_deficit * flow_field.u_initial_sorted > 0.05, axis=(3, 4)) / (grid.grid_resolution * grid.grid_resolution)
         area_overlap = area_overlap[:, :, :, None, None]
 
         # Modify wake added turbulence by wake area overlap
@@ -194,17 +194,17 @@ def sequential_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, mode
         ti_added = (
             area_overlap
             * np.nan_to_num(wake_added_turbulence_intensity, posinf=0.0)
-            * np.array(grid.x > x_i)
-            * np.array(np.abs(y_i - grid.y) < 2 * rotor_diameter_i)
-            * np.array(grid.x <= downstream_influence_length + x_i)
+            * np.array(grid.x_sorted > x_i)
+            * np.array(np.abs(y_i - grid.y_sorted) < 2 * rotor_diameter_i)
+            * np.array(grid.x_sorted <= downstream_influence_length + x_i)
         )
 
         # Combine turbine TIs with WAT
         turbine_turbulence_intensity = np.maximum( np.sqrt( ti_added ** 2 + ambient_turbulence_intensity ** 2 ) , turbine_turbulence_intensity )
 
-        flow_field.u = flow_field.u_initial - wake_field
-        flow_field.v += v_wake
-        flow_field.w += w_wake
+        flow_field.u_sorted = flow_field.u_initial_sorted - wake_field
+        flow_field.v_sorted += v_wake
+        flow_field.w_sorted += w_wake
 
     flow_field.turbulence_intensity_field = np.mean(turbine_turbulence_intensity, axis=(3,4))
     flow_field.turbulence_intensity_field = flow_field.turbulence_intensity_field[:,:,:,None,None]
@@ -247,45 +247,45 @@ def full_flow_sequential_solver(farm: Farm, flow_field: FlowField, flow_field_gr
     deflection_model_args = model_manager.deflection_model.prepare_function(flow_field_grid, flow_field)
     deficit_model_args = model_manager.velocity_model.prepare_function(flow_field_grid, flow_field)
 
-    wake_field = np.zeros_like(flow_field.u_initial)
-    v_wake = np.zeros_like(flow_field.v_initial)
-    w_wake = np.zeros_like(flow_field.w_initial)
+    wake_field = np.zeros_like(flow_field.u_initial_sorted)
+    v_wake = np.zeros_like(flow_field.v_initial_sorted)
+    w_wake = np.zeros_like(flow_field.w_initial_sorted)
 
     # Calculate the velocity deficit sequentially from upstream to downstream turbines
     for i in range(flow_field_grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(turbine_grid.x[:, :, i:i+1], axis=(3, 4))
+        x_i = np.mean(turbine_grid.x_sorted[:, :, i:i+1], axis=(3, 4))
         x_i = x_i[:, :, :, None, None]
-        y_i = np.mean(turbine_grid.y[:, :, i:i+1], axis=(3, 4))        
+        y_i = np.mean(turbine_grid.y_sorted[:, :, i:i+1], axis=(3, 4))        
         y_i = y_i[:, :, :, None, None]
-        z_i = np.mean(turbine_grid.z[:, :, i:i+1], axis=(3, 4))
+        z_i = np.mean(turbine_grid.z_sorted[:, :, i:i+1], axis=(3, 4))
         z_i = z_i[:, :, :, None, None]
 
-        u_i = turbine_grid_flow_field.u[:, :, i:i+1]
-        v_i = turbine_grid_flow_field.v[:, :, i:i+1]
+        u_i = turbine_grid_flow_field.u_sorted[:, :, i:i+1]
+        v_i = turbine_grid_flow_field.v_sorted[:, :, i:i+1]
 
         ct_i = Ct(
-            velocities=turbine_grid_flow_field.u,
-            yaw_angle=turbine_grid_farm.yaw_angles,
+            velocities=turbine_grid_flow_field.u_sorted,
+            yaw_angle=turbine_grid_farm.yaw_angles_sorted,
             fCt=turbine_grid_farm.turbine_fCts,
-            turbine_type_map=turbine_grid_farm.turbine_type_map,
+            turbine_type_map=turbine_grid_farm.turbine_type_map_sorted,
             ix_filter=[i],
         )
         ct_i = ct_i[:, :, 0:1, None, None]  # Since we are filtering for the i'th turbine in the Ct function, get the first index here (0:1)
         axial_induction_i = axial_induction(
-            velocities=turbine_grid_flow_field.u,
-            yaw_angle=turbine_grid_farm.yaw_angles,
+            velocities=turbine_grid_flow_field.u_sorted,
+            yaw_angle=turbine_grid_farm.yaw_angles_sorted,
             fCt=turbine_grid_farm.turbine_fCts,
-            turbine_type_map=turbine_grid_farm.turbine_type_map,
+            turbine_type_map=turbine_grid_farm.turbine_type_map_sorted,
             ix_filter=[i],
         )
         axial_induction_i = axial_induction_i[:, :, 0:1, None, None]    # Since we are filtering for the i'th turbine in the axial induction function, get the first index here (0:1)
         turbulence_intensity_i = turbine_grid_flow_field.turbulence_intensity_field[:, :, i:i+1]
-        yaw_angle_i = turbine_grid_farm.yaw_angles[:, :, i:i+1, None, None]
-        hub_height_i = turbine_grid_farm.hub_heights[: ,:, i:i+1, None, None]
-        rotor_diameter_i = turbine_grid_farm.rotor_diameters[: ,:, i:i+1, None, None]
-        TSR_i = turbine_grid_farm.TSRs[: ,:, i:i+1, None, None]
+        yaw_angle_i = turbine_grid_farm.yaw_angles_sorted[:, :, i:i+1, None, None]
+        hub_height_i = turbine_grid_farm.hub_heights_sorted[: ,:, i:i+1, None, None]
+        rotor_diameter_i = turbine_grid_farm.rotor_diameters_sorted[: ,:, i:i+1, None, None]
+        TSR_i = turbine_grid_farm.TSRs_sorted[: ,:, i:i+1, None, None]
 
         effective_yaw_i = np.zeros_like(yaw_angle_i)
         effective_yaw_i += yaw_angle_i
@@ -294,9 +294,9 @@ def full_flow_sequential_solver(farm: Farm, flow_field: FlowField, flow_field_gr
             added_yaw = wake_added_yaw(
                 u_i,
                 v_i,
-                turbine_grid_flow_field.u_initial,
-                turbine_grid.y[:, :, i:i+1] - y_i,
-                turbine_grid.z[:, :, i:i+1],
+                turbine_grid_flow_field.u_initial_sorted,
+                turbine_grid.y_sorted[:, :, i:i+1] - y_i,
+                turbine_grid.z_sorted[:, :, i:i+1],
                 rotor_diameter_i,
                 hub_height_i,
                 ct_i,
@@ -320,10 +320,10 @@ def full_flow_sequential_solver(farm: Farm, flow_field: FlowField, flow_field_gr
         if model_manager.enable_transverse_velocities:
             v_wake, w_wake = calculate_transverse_velocity(
                 u_i,
-                flow_field.u_initial,
-                flow_field_grid.x - x_i,
-                flow_field_grid.y - y_i,
-                flow_field_grid.z,
+                flow_field.u_initial_sorted,
+                flow_field_grid.x_sorted - x_i,
+                flow_field_grid.y_sorted - y_i,
+                flow_field_grid.z_sorted,
                 rotor_diameter_i,
                 hub_height_i,
                 yaw_angle_i,
@@ -349,12 +349,12 @@ def full_flow_sequential_solver(farm: Farm, flow_field: FlowField, flow_field_gr
 
         wake_field = model_manager.combination_model.function(
             wake_field,
-            velocity_deficit * flow_field.u_initial
+            velocity_deficit * flow_field.u_initial_sorted
         )
 
-        flow_field.u = flow_field.u_initial - wake_field
-        flow_field.v += v_wake
-        flow_field.w += w_wake
+        flow_field.u_sorted = flow_field.u_initial_sorted - wake_field
+        flow_field.v_sorted += v_wake
+        flow_field.w_sorted += w_wake
 
 
 def cc_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, model_manager: WakeModelManager) -> None:
@@ -364,15 +364,15 @@ def cc_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, model_manage
     deficit_model_args = model_manager.velocity_model.prepare_function(grid, flow_field)
 
     # This is u_wake
-    v_wake = np.zeros_like(flow_field.v_initial)
-    w_wake = np.zeros_like(flow_field.w_initial)
-    turb_u_wake = np.zeros_like(flow_field.u_initial)
-    turb_inflow_field = copy.deepcopy(flow_field.u_initial)
+    v_wake = np.zeros_like(flow_field.v_initial_sorted)
+    w_wake = np.zeros_like(flow_field.w_initial_sorted)
+    turb_u_wake = np.zeros_like(flow_field.u_initial_sorted)
+    turb_inflow_field = copy.deepcopy(flow_field.u_initial_sorted)
 
     turbine_turbulence_intensity = flow_field.turbulence_intensity * np.ones((flow_field.n_wind_directions, flow_field.n_wind_speeds, farm.n_turbines, 1, 1))
     ambient_turbulence_intensity = flow_field.turbulence_intensity
 
-    shape = (farm.n_turbines,) + np.shape(flow_field.u_initial)
+    shape = (farm.n_turbines,) + np.shape(flow_field.u_initial_sorted)
     Ctmp = np.zeros((shape))
     # Ctmp = np.zeros((len(x_coord), len(wd), len(ws), len(x_coord), y_ngrid, z_ngrid))
     
@@ -383,52 +383,52 @@ def cc_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, model_manage
     for i in range(grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(grid.x[:, :, i:i+1], axis=(3, 4))
+        x_i = np.mean(grid.x_sorted[:, :, i:i+1], axis=(3, 4))
         x_i = x_i[:, :, :, None, None]
-        y_i = np.mean(grid.y[:, :, i:i+1], axis=(3, 4))        
+        y_i = np.mean(grid.y_sorted[:, :, i:i+1], axis=(3, 4))        
         y_i = y_i[:, :, :, None, None]
-        z_i = np.mean(grid.z[:, :, i:i+1], axis=(3, 4))
+        z_i = np.mean(grid.z_sorted[:, :, i:i+1], axis=(3, 4))
         z_i = z_i[:, :, :, None, None]
 
-        mask2 = np.array(grid.x < x_i + 0.01) * np.array(grid.x > x_i - 0.01) * np.array(grid.y < y_i + 0.51*126.0) * np.array(grid.y > y_i - 0.51*126.0)
-        # mask2 = np.logical_and(np.logical_and(np.logical_and(grid.x < x_i + 0.01, grid.x > x_i - 0.01), grid.y < y_i + 0.51*126.0), grid.y > y_i - 0.51*126.0)
-        turb_inflow_field = turb_inflow_field * ~mask2 + (flow_field.u_initial - turb_u_wake) * mask2
+        mask2 = np.array(grid.x_sorted < x_i + 0.01) * np.array(grid.x_sorted > x_i - 0.01) * np.array(grid.y_sorted < y_i + 0.51*126.0) * np.array(grid.y_sorted > y_i - 0.51*126.0)
+        # mask2 = np.logical_and(np.logical_and(np.logical_and(grid.x_sorted < x_i + 0.01, grid.x_sorted > x_i - 0.01), grid.y_sorted < y_i + 0.51*126.0), grid.y_sorted > y_i - 0.51*126.0)
+        turb_inflow_field = turb_inflow_field * ~mask2 + (flow_field.u_initial_sorted - turb_u_wake) * mask2
 
         turb_avg_vels = average_velocity(turb_inflow_field)
         turb_Cts = Ct(
             turb_avg_vels,
-            farm.yaw_angles,
+            farm.yaw_angles_sorted,
             farm.turbine_fCts,
-            turbine_type_map=farm.turbine_type_map,
+            turbine_type_map=farm.turbine_type_map_sorted,
         )
         turb_Cts = turb_Cts[:, :, :, None, None]     
         turb_aIs = axial_induction(
             turb_avg_vels,
-            farm.yaw_angles,
+            farm.yaw_angles_sorted,
             farm.turbine_fCts,
-            turbine_type_map=farm.turbine_type_map,
+            turbine_type_map=farm.turbine_type_map_sorted,
             ix_filter=[i],
         )
         turb_aIs = turb_aIs[:, :, :, None, None]
 
         u_i = turb_inflow_field[:, :, i:i+1]
-        v_i = flow_field.v[:, :, i:i+1]
+        v_i = flow_field.v_sorted[:, :, i:i+1]
 
         axial_induction_i = axial_induction(
-            velocities=flow_field.u,
-            yaw_angle=farm.yaw_angles,
+            velocities=flow_field.u_sorted,
+            yaw_angle=farm.yaw_angles_sorted,
             fCt=farm.turbine_fCts,
-            turbine_type_map=farm.turbine_type_map,
+            turbine_type_map=farm.turbine_type_map_sorted,
             ix_filter=[i],
         )
 
         axial_induction_i = axial_induction_i[:, :, :, None, None]
 
         turbulence_intensity_i = turbine_turbulence_intensity[:, :, i:i+1]
-        yaw_angle_i = farm.yaw_angles[:, :, i:i+1, None, None]
-        hub_height_i = farm.hub_heights[: ,:, i:i+1, None, None]
-        rotor_diameter_i = farm.rotor_diameters[: ,:, i:i+1, None, None]
-        TSR_i = farm.TSRs[: ,:, i:i+1, None, None]
+        yaw_angle_i = farm.yaw_angles_sorted[:, :, i:i+1, None, None]
+        hub_height_i = farm.hub_heights_sorted[: ,:, i:i+1, None, None]
+        rotor_diameter_i = farm.rotor_diameters_sorted[: ,:, i:i+1, None, None]
+        TSR_i = farm.TSRs_sorted[: ,:, i:i+1, None, None]
 
         effective_yaw_i = np.zeros_like(yaw_angle_i)
         effective_yaw_i += yaw_angle_i
@@ -437,9 +437,9 @@ def cc_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, model_manage
             added_yaw = wake_added_yaw(
                 u_i,
                 v_i,
-                flow_field.u_initial,
-                grid.y[:, :, i:i+1] - y_i,
-                grid.z[:, :, i:i+1],
+                flow_field.u_initial_sorted,
+                grid.y_sorted[:, :, i:i+1] - y_i,
+                grid.z_sorted[:, :, i:i+1],
                 rotor_diameter_i,
                 hub_height_i,
                 turb_Cts[:, :, i:i+1],
@@ -464,10 +464,10 @@ def cc_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, model_manage
         if model_manager.enable_transverse_velocities:
             v_wake, w_wake = calculate_transverse_velocity(
                 u_i,
-                flow_field.u_initial,
-                grid.x - x_i,
-                grid.y - y_i,
-                grid.z,
+                flow_field.u_initial_sorted,
+                grid.x_sorted - x_i,
+                grid.y_sorted - y_i,
+                grid.z_sorted,
                 rotor_diameter_i,
                 hub_height_i,
                 yaw_angle_i,
@@ -482,7 +482,7 @@ def cc_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, model_manage
                 u_i,
                 turbulence_intensity_i,
                 v_i,
-                flow_field.w[:, :, i:i+1],
+                flow_field.w_sorted[:, :, i:i+1],
                 v_wake[:, :, i:i+1],
                 w_wake[:, :, i:i+1],
             )
@@ -499,7 +499,7 @@ def cc_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, model_manage
             yaw_angle_i,
             turbine_turbulence_intensity,
             turb_Cts,
-            farm.rotor_diameters[:, :, :, None, None],
+            farm.rotor_diameters_sorted[:, :, :, None, None],
             turb_u_wake,
             Ctmp,
             **deficit_model_args
@@ -507,7 +507,7 @@ def cc_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, model_manage
 
         wake_added_turbulence_intensity = model_manager.turbulence_model.function(
             ambient_turbulence_intensity,
-            grid.x,
+            grid.x_sorted,
             x_i,
             rotor_diameter_i,
             turb_aIs
@@ -522,17 +522,17 @@ def cc_solver(farm: Farm, flow_field: FlowField, grid: TurbineGrid, model_manage
         ti_added = (
             area_overlap
             * np.nan_to_num(wake_added_turbulence_intensity, posinf=0.0)
-            * np.array(grid.x > x_i)
-            * np.array(np.abs(y_i - grid.y) < 2 * rotor_diameter_i)
-            * np.array(grid.x <= downstream_influence_length + x_i)
+            * np.array(grid.x_sorted > x_i)
+            * np.array(np.abs(y_i - grid.y_sorted) < 2 * rotor_diameter_i)
+            * np.array(grid.x_sorted <= downstream_influence_length + x_i)
         )
 
         # Combine turbine TIs with WAT
         turbine_turbulence_intensity = np.maximum( np.sqrt( ti_added ** 2 + ambient_turbulence_intensity ** 2 ) , turbine_turbulence_intensity )
 
-        flow_field.v += v_wake
-        flow_field.w += w_wake
-    flow_field.u = turb_inflow_field
+        flow_field.v_sorted += v_wake
+        flow_field.w_sorted += w_wake
+    flow_field.u_sorted = turb_inflow_field
 
     flow_field.turbulence_intensity_field = np.mean(turbine_turbulence_intensity, axis=(3,4))
     flow_field.turbulence_intensity_field = flow_field.turbulence_intensity_field[:,:,:,None,None]
@@ -555,7 +555,7 @@ def full_flow_cc_solver(farm: Farm, flow_field: FlowField, flow_field_grid: Flow
 
     turbine_grid = TurbineGrid(
         turbine_coordinates=turbine_grid_farm.coordinates,
-        reference_turbine_diameter=turbine_grid_farm.rotor_diameters,
+        reference_turbine_diameter=turbine_grid_farm.rotor_diameters_sorted,
         wind_directions=turbine_grid_flow_field.wind_directions,
         wind_speeds=turbine_grid_flow_field.wind_speeds,
         grid_resolution=3,
@@ -573,50 +573,50 @@ def full_flow_cc_solver(farm: Farm, flow_field: FlowField, flow_field_grid: Flow
     deflection_model_args = model_manager.deflection_model.prepare_function(flow_field_grid, flow_field)
     deficit_model_args = model_manager.velocity_model.prepare_function(flow_field_grid, flow_field)
 
-    v_wake = np.zeros_like(flow_field.v_initial)
-    w_wake = np.zeros_like(flow_field.w_initial)
-    turb_u_wake = np.zeros_like(flow_field.u_initial)
+    v_wake = np.zeros_like(flow_field.v_initial_sorted)
+    w_wake = np.zeros_like(flow_field.w_initial_sorted)
+    turb_u_wake = np.zeros_like(flow_field.u_initial_sorted)
 
-    shape = (farm.n_turbines,) + np.shape(flow_field.u_initial)
+    shape = (farm.n_turbines,) + np.shape(flow_field.u_initial_sorted)
     Ctmp = np.zeros((shape))
 
     # Calculate the velocity deficit sequentially from upstream to downstream turbines
     for i in range(flow_field_grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(turbine_grid.x[:, :, i:i+1], axis=(3, 4))
+        x_i = np.mean(turbine_grid.x_sorted[:, :, i:i+1], axis=(3, 4))
         x_i = x_i[:, :, :, None, None]
-        y_i = np.mean(turbine_grid.y[:, :, i:i+1], axis=(3, 4))        
+        y_i = np.mean(turbine_grid.y_sorted[:, :, i:i+1], axis=(3, 4))        
         y_i = y_i[:, :, :, None, None]
-        z_i = np.mean(turbine_grid.z[:, :, i:i+1], axis=(3, 4))
+        z_i = np.mean(turbine_grid.z_sorted[:, :, i:i+1], axis=(3, 4))
         z_i = z_i[:, :, :, None, None]
 
-        u_i = turbine_grid_flow_field.u[:, :, i:i+1]
-        v_i = turbine_grid_flow_field.v[:, :, i:i+1]
+        u_i = turbine_grid_flow_field.u_sorted[:, :, i:i+1]
+        v_i = turbine_grid_flow_field.v_sorted[:, :, i:i+1]
 
-        turb_avg_vels = average_velocity(turbine_grid_flow_field.u)
+        turb_avg_vels = average_velocity(turbine_grid_flow_field.u_sorted)
         turb_Cts = Ct(
             velocities=turb_avg_vels,
-            yaw_angle=turbine_grid_farm.yaw_angles,
+            yaw_angle=turbine_grid_farm.yaw_angles_sorted,
             fCt=turbine_grid_farm.turbine_fCts,
-            turbine_type_map=turbine_grid_farm.turbine_type_map,
+            turbine_type_map=turbine_grid_farm.turbine_type_map_sorted,
         )
         turb_Cts = turb_Cts[:, :, :, None, None]
 
         axial_induction_i = axial_induction(
-            velocities=turbine_grid_flow_field.u,
-            yaw_angle=turbine_grid_farm.yaw_angles,
+            velocities=turbine_grid_flow_field.u_sorted,
+            yaw_angle=turbine_grid_farm.yaw_angles_sorted,
             fCt=turbine_grid_farm.turbine_fCts,
-            turbine_type_map=turbine_grid_farm.turbine_type_map,
+            turbine_type_map=turbine_grid_farm.turbine_type_map_sorted,
             ix_filter=[i],
         )
         axial_induction_i = axial_induction_i[:, :, :, None, None]
 
         turbulence_intensity_i = turbine_grid_flow_field.turbulence_intensity_field[:, :, i:i+1]
-        yaw_angle_i = turbine_grid_farm.yaw_angles[:, :, i:i+1, None, None]
-        hub_height_i = turbine_grid_farm.hub_heights[: ,:, i:i+1, None, None]
-        rotor_diameter_i = turbine_grid_farm.rotor_diameters[: ,:, i:i+1, None, None]
-        TSR_i = turbine_grid_farm.TSRs[: ,:, i:i+1, None, None]
+        yaw_angle_i = turbine_grid_farm.yaw_angles_sorted[:, :, i:i+1, None, None]
+        hub_height_i = turbine_grid_farm.hub_heights_sorted[: ,:, i:i+1, None, None]
+        rotor_diameter_i = turbine_grid_farm.rotor_diameters_sorted[: ,:, i:i+1, None, None]
+        TSR_i = turbine_grid_farm.TSRs_sorted[: ,:, i:i+1, None, None]
 
         effective_yaw_i = np.zeros_like(yaw_angle_i)
         effective_yaw_i += yaw_angle_i
@@ -625,9 +625,9 @@ def full_flow_cc_solver(farm: Farm, flow_field: FlowField, flow_field_grid: Flow
             added_yaw = wake_added_yaw(
                 u_i,
                 v_i,
-                turbine_grid_flow_field.u_initial,
-                turbine_grid.y[:, :, i:i+1] - y_i,
-                turbine_grid.z[:, :, i:i+1],
+                turbine_grid_flow_field.u_initial_sorted,
+                turbine_grid.y_sorted[:, :, i:i+1] - y_i,
+                turbine_grid.z_sorted[:, :, i:i+1],
                 rotor_diameter_i,
                 hub_height_i,
                 turb_Cts[:, :, i:i+1],
@@ -652,10 +652,10 @@ def full_flow_cc_solver(farm: Farm, flow_field: FlowField, flow_field_grid: Flow
         if model_manager.enable_transverse_velocities:
             v_wake, w_wake = calculate_transverse_velocity(
                 u_i,
-                flow_field.u_initial,
-                flow_field_grid.x - x_i,
-                flow_field_grid.y - y_i,
-                flow_field_grid.z,
+                flow_field.u_initial_sorted,
+                flow_field_grid.x_sorted - x_i,
+                flow_field_grid.y_sorted - y_i,
+                flow_field_grid.z_sorted,
                 rotor_diameter_i,
                 hub_height_i,
                 yaw_angle_i,
@@ -676,12 +676,12 @@ def full_flow_cc_solver(farm: Farm, flow_field: FlowField, flow_field_grid: Flow
             yaw_angle_i,
             turbine_grid_flow_field.turbulence_intensity_field,
             turb_Cts,
-            turbine_grid_farm.rotor_diameters[:, :, :, None, None],
+            turbine_grid_farm.rotor_diameters_sorted[:, :, :, None, None],
             turb_u_wake,
             Ctmp,
             **deficit_model_args
         )
 
-        flow_field.v += v_wake
-        flow_field.w += w_wake
-    flow_field.u = flow_field.u_initial - turb_u_wake
+        flow_field.v_sorted += v_wake
+        flow_field.w_sorted += w_wake
+    flow_field.u_sorted = flow_field.u_initial_sorted - turb_u_wake

--- a/floris/simulation/wake_deflection/gauss.py
+++ b/floris/simulation/wake_deflection/gauss.py
@@ -88,10 +88,10 @@ class GaussVelocityDeflection(BaseModel):
     ) -> Dict[str, Any]:
 
         kwargs = dict(
-            x=grid.x,
-            y=grid.y,
-            z=grid.z,
-            freestream_velocity=flow_field.u_initial,
+            x=grid.x_sorted,
+            y=grid.y_sorted,
+            z=grid.z_sorted,
+            freestream_velocity=flow_field.u_initial_sorted,
             wind_veer=flow_field.wind_veer,
         )
         return kwargs

--- a/floris/simulation/wake_deflection/jimenez.py
+++ b/floris/simulation/wake_deflection/jimenez.py
@@ -49,7 +49,7 @@ class JimenezVelocityDeflection(BaseModel):
     ) -> Dict[str, Any]:
 
         kwargs = dict(
-            x=grid.x,
+            x=grid.x_sorted,
         )
         return kwargs
 

--- a/floris/simulation/wake_velocity/cumulative_gauss_curl.py
+++ b/floris/simulation/wake_velocity/cumulative_gauss_curl.py
@@ -47,10 +47,10 @@ class CumulativeGaussCurlVelocityDeficit(BaseModel):
     ) -> Dict[str, Any]:
 
         kwargs = dict(
-            x=grid.x,
-            y=grid.y,
-            z=grid.z,
-            u_initial=flow_field.u_initial,
+            x=grid.x_sorted,
+            y=grid.y_sorted,
+            z=grid.z_sorted,
+            u_initial=flow_field.u_initial_sorted,
         )
         return kwargs
 

--- a/floris/simulation/wake_velocity/gauss.py
+++ b/floris/simulation/wake_velocity/gauss.py
@@ -40,10 +40,10 @@ class GaussVelocityDeficit(BaseModel):
     ) -> Dict[str, Any]:
 
         kwargs = dict(
-            x=grid.x,
-            y=grid.y,
-            z=grid.z,
-            u_initial=flow_field.u_initial,
+            x=grid.x_sorted,
+            y=grid.y_sorted,
+            z=grid.z_sorted,
+            u_initial=flow_field.u_initial_sorted,
             wind_veer=flow_field.wind_veer
         )
         return kwargs

--- a/floris/simulation/wake_velocity/jensen.py
+++ b/floris/simulation/wake_velocity/jensen.py
@@ -57,9 +57,9 @@ class JensenVelocityDeficit(BaseModel):
         the model function.
         """
         kwargs = dict(
-            x=grid.x,
-            y=grid.y,
-            z=grid.z,
+            x=grid.x_sorted,
+            y=grid.y_sorted,
+            z=grid.z_sorted,
         )
         return kwargs
 
@@ -90,7 +90,7 @@ class JensenVelocityDeficit(BaseModel):
         # grid.rotate_fields(flow_field.wind_directions)  # TODO: check the rotations with multiple directions or non-0/270
 
         # Calculate and apply wake mask
-        # x = grid.x # mesh_x_rotated - x_coord_rotated
+        # x = grid.x_sorted # mesh_x_rotated - x_coord_rotated
 
         # This is the velocity deficit seen by the i'th turbine due to wake effects from upstream turbines.
         # Indeces of velocity_deficit corresponding to unwaked turbines will have 0's

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -200,12 +200,12 @@ class FlorisInterface(LoggerBase):
             :py:class:`pandas.DataFrame`: containing values of x1, x2, u, v, w
         """
         # Get results vectors
-        x_flat = self.floris.grid.x[0, 0].flatten()
-        y_flat = self.floris.grid.y[0, 0].flatten()
-        z_flat = self.floris.grid.z[0, 0].flatten()
-        u_flat = self.floris.flow_field.u[0, 0].flatten()
-        v_flat = self.floris.flow_field.v[0, 0].flatten()
-        w_flat = self.floris.flow_field.w[0, 0].flatten()
+        x_flat = self.floris.grid.x_sorted[0, 0].flatten()
+        y_flat = self.floris.grid.y_sorted[0, 0].flatten()
+        z_flat = self.floris.grid.z_sorted[0, 0].flatten()
+        u_flat = self.floris.flow_field.u_sorted[0, 0].flatten()
+        v_flat = self.floris.flow_field.v_sorted[0, 0].flatten()
+        w_flat = self.floris.flow_field.w_sorted[0, 0].flatten()
 
         # Create a df of these
         if normal_vector == "z":

--- a/floris/tools/optimization/yaw_optimization/yaw_optimization_tools.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimization_tools.py
@@ -53,7 +53,7 @@ def derive_downstream_turbines(fi, wind_direction, wake_slope=0.30, plot_lines=F
     # Get farm layout
     x = fi.layout_x
     y = fi.layout_y
-    D = np.ones_like(x) * fi.floris.farm.rotor_diameters[0][0][0]
+    D = np.ones_like(x) * fi.floris.farm.rotor_diameters_sorted[0][0][0]
     n_turbs = len(x)
 
     # Rotate farm and determine freestream/waked turbines

--- a/tests/flow_field_unit_test.py
+++ b/tests/flow_field_unit_test.py
@@ -33,20 +33,20 @@ def test_initialize_velocity_field(flow_field_fixture, turbine_grid_fixture: Tur
 
     # Check the shape of the velocity arrays: u_initial, v_initial, w_initial  and u, v, w
     # Dimensions are (# wind speeds, # turbines, N grid points, M grid points)
-    assert np.shape(flow_field_fixture.u)[0] == flow_field_fixture.n_wind_directions
-    assert np.shape(flow_field_fixture.u)[1] == flow_field_fixture.n_wind_speeds
-    assert np.shape(flow_field_fixture.u)[2] == N_TURBINES
-    assert np.shape(flow_field_fixture.u)[3] == turbine_grid_fixture.grid_resolution
-    assert np.shape(flow_field_fixture.u)[4] == turbine_grid_fixture.grid_resolution
+    assert np.shape(flow_field_fixture.u_sorted)[0] == flow_field_fixture.n_wind_directions
+    assert np.shape(flow_field_fixture.u_sorted)[1] == flow_field_fixture.n_wind_speeds
+    assert np.shape(flow_field_fixture.u_sorted)[2] == N_TURBINES
+    assert np.shape(flow_field_fixture.u_sorted)[3] == turbine_grid_fixture.grid_resolution
+    assert np.shape(flow_field_fixture.u_sorted)[4] == turbine_grid_fixture.grid_resolution
 
     # Check that the wind speed profile was created correctly. By setting the shear
     # exponent to 1.0 above, the shear profile is a linear function of height and
     # the points on the turbine rotor are equally spaced about the rotor.
     # This means that their average should equal the wind speed at the center
     # which is the input wind speed.
-    shape = np.shape(flow_field_fixture.u[0, 0, 0, :, :])
+    shape = np.shape(flow_field_fixture.u_sorted[0, 0, 0, :, :])
     n_elements = shape[0] * shape[1]
-    average = np.sum(flow_field_fixture.u[:, :, 0, :, :], axis=(-2, -1)) / np.array([n_elements])
+    average = np.sum(flow_field_fixture.u_sorted[:, :, 0, :, :], axis=(-2, -1)) / np.array([n_elements])
     baseline = np.reshape(flow_field_fixture.wind_speeds, (1, -1)) * np.ones(
         (flow_field_fixture.n_wind_directions, flow_field_fixture.n_wind_speeds)
     )

--- a/tests/grid_unit_test.py
+++ b/tests/grid_unit_test.py
@@ -36,27 +36,27 @@ def test_turbinegrid_set_grid(turbine_grid_fixture):
     # then, search for any elements that are true and negate the results
     # if an element is zero, the not will return true
     # if an element is non-zero, the not will return false
-    assert not np.any(turbine_grid_fixture.x[0, 0] - expected_x_grid)
-    assert not np.any(turbine_grid_fixture.y[0, 0] - expected_y_grid)
-    assert not np.any(turbine_grid_fixture.z[0, 0] - expected_z_grid)
+    assert not np.any(turbine_grid_fixture.x_sorted[0, 0] - expected_x_grid)
+    assert not np.any(turbine_grid_fixture.y_sorted[0, 0] - expected_y_grid)
+    assert not np.any(turbine_grid_fixture.z_sorted[0, 0] - expected_z_grid)
 
 
 def test_turbinegrid_dimensions(turbine_grid_fixture):
-    assert np.shape(turbine_grid_fixture.x) == (
+    assert np.shape(turbine_grid_fixture.x_sorted) == (
         N_WIND_DIRECTIONS,
         N_WIND_SPEEDS,
         N_TURBINES,
         TURBINE_GRID_RESOLUTION,
         TURBINE_GRID_RESOLUTION
     )
-    assert np.shape(turbine_grid_fixture.y) == (
+    assert np.shape(turbine_grid_fixture.y_sorted) == (
         N_WIND_DIRECTIONS,
         N_WIND_SPEEDS,
         N_TURBINES,
         TURBINE_GRID_RESOLUTION,
         TURBINE_GRID_RESOLUTION
     )
-    assert np.shape(turbine_grid_fixture.z) == (
+    assert np.shape(turbine_grid_fixture.z_sorted) == (
         N_WIND_DIRECTIONS,
         N_WIND_SPEEDS,
         N_TURBINES,


### PR DESCRIPTION
**Not ready to be merged**

**Feature or improvement description**
This bugfix adds `_sorted` versions of the respective variables that get sorted based on wind direction during the initialization step for use within the solver. In the finalize step after the solve completes, the sorted variables are unsorted and stored in a new variable, therefore allowing repeated calls to `calculate_wake` and maintaining the sorting of the required variables.

**Related issue, if one exists**
Closes #378 

**Impacted areas of the software**
Most of the simulation software, though I am not 100% that I have properly covered all the initialization of the variables (@rafmudaf could use your eyes here).

**Additional supporting information**
The code in issue #378 now produces the expected result of:

![image](https://user-images.githubusercontent.com/12664940/157348073-edbe03b7-67df-4ffb-a7a7-10b808e212f3.png)
