### PR TITLE
Selectively invert plot axis via normal vector in CutPlane

### DIFF
--- a/floris/tools/cut_plane.py
+++ b/floris/tools/cut_plane.py
@@ -105,7 +105,7 @@ class CutPlane:
     FLORIS simulation, or other such as SOWFA result.
     """
 
-    def __init__(self, df, x1_resolution, x2_resolution):
+    def __init__(self, df, x1_resolution, x2_resolution, normal_vector):
         """
         Initialize CutPlane object, storing the DataFrame and resolution.
 
@@ -114,6 +114,7 @@ class CutPlane:
                 columns x1, x2, u, v, w.
         """
         self.df = df
+        self.normal_vector = normal_vector
         self.resolution = (x1_resolution, x2_resolution)
 
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -329,7 +329,7 @@ class FlorisInterface(LoggerBase):
         )
 
         # Compute the cutplane
-        horizontal_plane = CutPlane(df, self.floris.grid.grid_resolution[0], self.floris.grid.grid_resolution[1])
+        horizontal_plane = CutPlane(df, self.floris.grid.grid_resolution[0], self.floris.grid.grid_resolution[1], "z")
 
         # Reset the fi object back to the turbine grid configuration
         self.floris = Floris.from_dict(floris_dict)
@@ -409,7 +409,7 @@ class FlorisInterface(LoggerBase):
         )
 
         # Compute the cutplane
-        cross_plane = CutPlane(df, y_resolution, z_resolution)
+        cross_plane = CutPlane(df, y_resolution, z_resolution, "x")
 
         # Reset the fi object back to the turbine grid configuration
         self.floris = Floris.from_dict(floris_dict)
@@ -488,7 +488,7 @@ class FlorisInterface(LoggerBase):
         )
 
         # Compute the cutplane
-        y_plane = CutPlane(df, x_resolution, z_resolution)
+        y_plane = CutPlane(df, x_resolution, z_resolution, "y")
 
         # Reset the fi object back to the turbine grid configuration
         self.floris = Floris.from_dict(floris_dict)

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -169,6 +169,9 @@ def visualize_cut_plane(
     # Add line contour
     line_contour_cut_plane(cut_plane, ax=ax, levels=levels, colors="w", linewidths=0.8, alpha=0.3)
 
+    if cut_plane.normal_vector == "x":
+        ax.invert_xaxis()
+
     if color_bar:
         cbar = plt.colorbar(im, ax=ax)
         cbar.set_label('m/s')
@@ -249,7 +252,7 @@ def plot_rotor_values(
     return_fig_objects: bool = False,
     save_path: Union[str, None] = None,
     show: bool = False
-) -> Union[None, tuple[plt.figure, plt.axes]]:
+) -> Union[None, tuple[plt.figure, plt.axes, plt.axis, plt.colorbar]]:
     """Plots the gridded turbine rotor values. This is intended to be used for
     understanding the differences between two sets of values, so each subplot can be
     used for inspection of what values are differing, and under what conditions.
@@ -294,6 +297,7 @@ def plot_rotor_values(
         norm = mplcolors.Normalize(vmin, vmax)
 
         ax.imshow(values[wd_index, ws_index, i].T, cmap=cmap, norm=norm, origin="lower")
+        ax.invert_xaxis()
 
         ax.set_xticks([])
         ax.set_yticks([])


### PR DESCRIPTION
**Feature or improvement description**
This pull request adds an option to invert the flow field and rotor plane plots. Specifically, floris currently plots y-planes from the perspective of downstream of the turbine and looking upstream. This pull request inverts the axes when we are plotting a `CutPlane` with x normal vector.

Below are plots of three turbines in a row with the leading turbine yawed with the latest `develop` and this pull request. The spanwise plots and the rotor plane plots are inverted.

**Related issue, if one exists**
None

**Impacted areas of the software**
Visualization tools and `CutPlane` class

## Current `develop` branch
![up1](https://user-images.githubusercontent.com/13797903/157509346-86db4675-34ff-47bc-8fe7-8448d0f95736.png)
![up2](https://user-images.githubusercontent.com/13797903/157509357-71a2f288-a143-407b-88b0-3a65bc262aeb.png)

## This pull request
![down](https://user-images.githubusercontent.com/13797903/157509359-8989c618-5123-4239-9747-180731ef8ed3.png)
![down2](https://user-images.githubusercontent.com/13797903/157509361-ff27470b-39e7-4214-a868-fbf7db6217e9.png)
