### PR TITLE
Bug fix: revise verify_convergence to support multiple wind speeds

### DIFF
--- a/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
@@ -14,6 +14,7 @@
 
 
 import copy
+from time import perf_counter as timerpc
 
 import numpy as np
 import pandas as pd
@@ -522,7 +523,7 @@ class YawOptimization:
         self,
         farm_power_opt_subset,
         yaw_angles_opt_subset,
-        min_yaw_offset=0.10,
+        min_yaw_offset=0.01,
         min_power_gain_for_yaw=0.02,
         verbose=True,
     ):
@@ -560,12 +561,16 @@ class YawOptimization:
 
         print("Verifying convergence of the found optimal yaw angles.")
 
+        # Start timer
+        start_time = timerpc()
+
         # Define variables locally
         yaw_angles_opt_subset = np.array(yaw_angles_opt_subset, copy=True)
         yaw_angles_baseline_subset = self._yaw_angles_baseline_subset
         farm_power_baseline_subset = self._farm_power_baseline_subset
+        turbs_to_opt_subset = self._turbs_to_opt_subset
 
-        # Round small nonzero yaw angles
+        # Round small nonzero yaw angles to zero
         ydiff = np.abs(yaw_angles_opt_subset - yaw_angles_baseline_subset)
         ids = np.where((ydiff < min_yaw_offset) & (ydiff > 0.0))
         if len(ids[0]) > 0:
@@ -576,8 +581,8 @@ class YawOptimization:
             ydiff[ids] = 0.0
 
         # Turbines to test whether their angles sufficiently improve farm power
-        ids = np.where((self._turbs_to_opt_subset) & (ydiff > min_yaw_offset))
-        
+        ids = np.where((turbs_to_opt_subset) & (ydiff > min_yaw_offset))
+
         # Define situations that need to be calculated and find farm power.
         # Each situation basically contains the exact same conditions as the
         # baseline conditions and optimal yaw angles, besides for a single
@@ -585,70 +590,101 @@ class YawOptimization:
         # typically 0.0 deg). This way, we investigate whether the yaw offset
         # of that turbine really adds significant uplift to the farm power
         # production.
-        wd_array = self.fi_subset.floris.flow_field.wind_directions[ids[0]]
-        # ws_array = self.fi_subset.floris.flow_field.wind_speeds[ids[1]]
-        turbine_weights = self._turbine_weights_subset[ids[0]]
-        yaw_angles = yaw_angles_opt_subset[ids[0], :]
-        for wdii, ti in enumerate(ids[2]):
-            yaw_angles[wdii, 0, ti] = \
-                yaw_angles_baseline_subset[ids[0][wdii], 0, ti]
+
+        # For each turbine in the farm, reset its values to baseline. Thus,
+        # we copy the atmospheric conditions n_turbs times and for each
+        # copy of atmospheric conditions, we reset that turbine's yaw angle
+        # to its baseline value for all conditions.
+        n_turbs = len(self.fi.layout_x)
+        sp = (n_turbs, 1, 1)  # Tile shape for matrix expansion
+        wd_array_nominal = self.fi_subset.floris.flow_field.wind_directions
+        n_wind_directions = len(wd_array_nominal)
+        yaw_angles_verify = np.tile(yaw_angles_opt_subset, sp)
+        yaw_angles_bl_verify = np.tile(yaw_angles_baseline_subset, sp)
+        turbine_id_array = np.zeros(np.shape(yaw_angles_verify)[0], dtype=int)
+        for ti in range(n_turbs):
+            ids = ti * n_wind_directions + np.arange(n_wind_directions)
+            yaw_angles_verify[ids, :, ti] = yaw_angles_bl_verify[ids, :, ti]
+            turbine_id_array[ids] = ti
 
         # Now evaluate all situations
+        farm_power_baseline_verify = np.tile(farm_power_baseline_subset, (n_turbs, 1))
         farm_power = self._calculate_farm_power(
-            yaw_angles=yaw_angles,
-            wd_array=wd_array,
-            turbine_weights=turbine_weights
+            yaw_angles=yaw_angles_verify,
+            wd_array=np.tile(wd_array_nominal, n_turbs),
+            turbine_weights=np.tile(self._turbs_to_opt_subset, sp)
         )
 
         # Calculate power uplift for optimal solutions
-        uplift_o = 100.0 * (
-            farm_power_opt_subset[ids[0]].flatten() /
-            farm_power_baseline_subset[ids[0]].flatten()
-        ) - 100.0
-        
+        uplift_o = 100 * (
+            np.tile(farm_power_opt_subset, (n_turbs, 1)) /
+            farm_power_baseline_verify - 1.0
+        )
+
         # Calculate power uplift for all cases we evaluated
-        uplift_n = 100.0 * (
-            farm_power.flatten() /
-            farm_power_baseline_subset[ids[0]].flatten()
-        ) - 100.0
+        uplift_n = 100.0 * (farm_power / farm_power_baseline_verify - 1.0)
 
         # Check difference in uplift, where each row represents a different
         # situation (i.e., where one turbine was set to its baseline yaw angle
         # instead of its optimal yaw angle).
         dp = uplift_o - uplift_n
-        ids_to_simplify = np.where(dp < min_power_gain_for_yaw)[0]
-        ids = (ids[0][ids_to_simplify], 0, ids[2][ids_to_simplify])
-        yaw_angles_opt_subset[ids] = yaw_angles_baseline_subset[ids]
-        n = len(ids_to_simplify)
+        ids_to_simplify = np.where(dp < min_power_gain_for_yaw)
+        ids_to_simplify = (
+            np.remainder(ids_to_simplify[0], n_wind_directions),  # Wind direction identifier
+            ids_to_simplify[1],  # Wind speed identifier
+            turbine_id_array[ids_to_simplify[0]],  # Turbine identifier
+        )
+
+        # Overwrite yaw angles that insufficiently increased farm power with baseline values
+        yaw_angles_opt_subset[ids_to_simplify] = (
+            yaw_angles_baseline_subset[ids_to_simplify]
+        )
+
+        n = len(ids_to_simplify[0])
         if n > 0:
             # Yaw angles notably changed: recalculate farm powers
-            farm_power_opt_subset_new = self._calculate_farm_power(
-                yaw_angles_opt_subset)
+            farm_power_opt_subset_new = (
+                self._calculate_farm_power(yaw_angles_opt_subset)
+            )
 
             if verbose:
                 # Calculate old uplift for all conditions
-                uplift_o = 100.0 * (
-                    farm_power_opt_subset.flatten() /
-                    farm_power_baseline_subset.flatten()
+                dP_old = 100.0 * (
+                    farm_power_opt_subset /
+                    farm_power_baseline_subset
                 ) - 100.0
 
                 # Calculate new uplift for all conditions
-                uplift_n = 100.0 * (
-                    farm_power_opt_subset_new.flatten() /
-                    farm_power_baseline_subset.flatten()
+                dP_new = 100.0 * (
+                    farm_power_opt_subset_new /
+                    farm_power_baseline_subset
                 ) - 100.0
 
                 # Calculate differences in power uplift
-                dp = uplift_o - uplift_n
-                id_max_loss = np.argmax(dp)
+                diff_uplift = dP_old - dP_new
+                ids_max_loss = np.where(np.nanmax(diff_uplift) == diff_uplift)
+                jj = (ids_max_loss[0][0], ids_max_loss[1][0])
+                ws_array_nominal = self.fi_subset.floris.flow_field.wind_speeds
                 print(
                     "Nullified the optimal yaw offset for {:d}".format(n) +
-                    " turbines over all wind directions. The maximum change " +
-                    "in power uplift: from {:.3f}% to {:.3f}%.".format(
-                        uplift_o[id_max_loss], uplift_n[id_max_loss]
+                    " conditions and turbines."
+                 )
+                print(
+                     "Simplifying the yaw angles for these conditions lead " +
+                     "to a maximum change in wake-steering power uplift from "
+                     + "{:.5f}% to {:.5f}% at ".format(dP_old[jj], dP_new[jj])
+                     + " WD = {:.1f} deg and WS = {:.1f} m/s.".format(
+                        wd_array_nominal[jj[0]], ws_array_nominal[jj[1]],
                     )
                 )
 
+                t = timerpc() - start_time
+                print(
+                    "Time spent to verify the convergence of the optimal " +
+                    "yaw angles: {:.3f} s.".format(t)
+                )
+
+            # Return optimal solutions to the user
             farm_power_opt_subset = farm_power_opt_subset_new
 
         return yaw_angles_opt_subset, farm_power_opt_subset


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
This feature fixes bug #383 where `verify_convergence` does not work if more than one wind speed is defined in FLORIS. 

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
Issue #383 

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
Yaw optimization.

**Additional supporting information**
<!-- Add any other context about the problem here. -->
In the past, we would first locate which turbines have a nonzero yaw angle and at what wind directions and wind speeds. We would only check the wind farm's power production for those turbines and conditions with and without yaw misalignment. With the grid-style way FLORIS is calculated, it's not possible to isolate exactly which wind direction/speed combinations we need to evaluate without doing a one-by-one loop, which is slow. Hence, the current method is simplified and just evaluates all atmospheric conditions num_turbs times, and for each atmospheric condition set we reset one of the turbine's yaw angle to its baseline value and calculate the power production. This means we may do many more calculations than necessary, but it does keep things in gridded format.

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
Running example `09_opt_yaw_multiple_ws.py` with `verify_convergence=False` yields:
![image](https://user-images.githubusercontent.com/22119448/157525688-0db9fe45-294b-4f90-b627-cded13f196f7.png)


In which we see nonzero yaw angles at high wind speeds of 15-17 m/s, due to numerical precision. These yaw angles just shift the `cp` value ever so slightly that the wind farm power is slightly higher. With `verify_convergence=True`, it yields:
![image](https://user-images.githubusercontent.com/22119448/157525474-ce87f4dc-0dce-466b-aff5-b74f11649e56.png)

Though, I have seen that the computation time can increase by 10-20% using `verify_convergence=True`. Hence, it still defaults to `False` and it's up to the user to decide whether one would like to include this functionality. Perhaps once the timeseries calculation functionality for FLORIS is implemented (#299) I can restructure this code to more efficiently evaluate a minimal set of conditions.

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->