### PR TITLE
Save yaw angles for reset in plane visualizations

### DIFF
--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -335,10 +335,9 @@ class FlorisInterface(LoggerBase):
         # Reset the fi object back to the turbine grid configuration
         self.floris = Floris.from_dict(floris_dict)
         self.floris.flow_field.het_map = self.het_map
-        self.floris.farm.yaw_angles = current_yaw_angles
 
         # Run the simulation again for futher postprocessing (i.e. now we can get farm power)
-        self.calculate_wake()
+        self.calculate_wake(yaw_angles=current_yaw_angles)
 
         return horizontal_plane
 
@@ -416,10 +415,9 @@ class FlorisInterface(LoggerBase):
         # Reset the fi object back to the turbine grid configuration
         self.floris = Floris.from_dict(floris_dict)
         self.floris.flow_field.het_map = self.het_map
-        self.floris.farm.yaw_angles = current_yaw_angles
 
         # Run the simulation again for futher postprocessing (i.e. now we can get farm power)
-        self.calculate_wake()
+        self.calculate_wake(yaw_angles=current_yaw_angles)
 
         return cross_plane
 
@@ -497,10 +495,9 @@ class FlorisInterface(LoggerBase):
         # Reset the fi object back to the turbine grid configuration
         self.floris = Floris.from_dict(floris_dict)
         self.floris.flow_field.het_map = self.het_map
-        self.floris.farm.yaw_angles = current_yaw_angles
 
         # Run the simulation again for futher postprocessing (i.e. now we can get farm power)
-        self.calculate_wake()
+        self.calculate_wake(yaw_angles=current_yaw_angles)
 
         return y_plane
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -301,6 +301,7 @@ class FlorisInterface(LoggerBase):
 
         # Store the current state for reinitialization
         floris_dict = self.floris.as_dict()
+        current_yaw_angles = self.floris.farm.yaw_angles
 
         # Set the solver to a flow field planar grid
         solver_settings = {
@@ -334,6 +335,7 @@ class FlorisInterface(LoggerBase):
         # Reset the fi object back to the turbine grid configuration
         self.floris = Floris.from_dict(floris_dict)
         self.floris.flow_field.het_map = self.het_map
+        self.floris.farm.yaw_angles = current_yaw_angles
 
         # Run the simulation again for futher postprocessing (i.e. now we can get farm power)
         self.calculate_wake()
@@ -376,11 +378,11 @@ class FlorisInterface(LoggerBase):
             wd = self.floris.flow_field.wind_directions
         if ws is None:
             ws = self.floris.flow_field.wind_speeds
-
         self.check_wind_condition_for_viz(wd=wd, ws=ws)
 
         # Store the current state for reinitialization
         floris_dict = self.floris.as_dict()
+        current_yaw_angles = self.floris.farm.yaw_angles
 
         # Set the solver to a flow field planar grid
         solver_settings = {
@@ -414,6 +416,7 @@ class FlorisInterface(LoggerBase):
         # Reset the fi object back to the turbine grid configuration
         self.floris = Floris.from_dict(floris_dict)
         self.floris.flow_field.het_map = self.het_map
+        self.floris.farm.yaw_angles = current_yaw_angles
 
         # Run the simulation again for futher postprocessing (i.e. now we can get farm power)
         self.calculate_wake()
@@ -460,6 +463,7 @@ class FlorisInterface(LoggerBase):
 
         # Store the current state for reinitialization
         floris_dict = self.floris.as_dict()
+        current_yaw_angles = self.floris.farm.yaw_angles
 
         # Set the solver to a flow field planar grid
         solver_settings = {
@@ -493,6 +497,7 @@ class FlorisInterface(LoggerBase):
         # Reset the fi object back to the turbine grid configuration
         self.floris = Floris.from_dict(floris_dict)
         self.floris.flow_field.het_map = self.het_map
+        self.floris.farm.yaw_angles = current_yaw_angles
 
         # Run the simulation again for futher postprocessing (i.e. now we can get farm power)
         self.calculate_wake()


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Currently, the state of `floris.farm.yaw_angles` is not saved during the `floris`-object export in `FlorisInterface.calculate_XX_plane()` functions. While we generally expect that yaw angles will have to be reset for additional calculations, the intention for resetting the `floris`-object to its previous state after the visualization calculation was to allow for additional post processing in the script. Not saving the yaw angles means that any additional analysis will be different before and after `FlorisInterface.calculate_XX_plane()`.

**Related issue, if one exists**
None

**Impacted areas of the software**
`FlorisInterface.calculate_horizontal_plane()`
`FlorisInterface.calculate_y_plane()`
`FlorisInterface.calculate_cross_plane()`

**Additional supporting information**
Generally, these API's will will be improved in the future along with the rest of the `floris.tools` package.