### PR TITLE
Add 'none' submodel option for wake deflection, deficit and turbulence

### DIFF
--- a/examples/17_compare_models_nodeflection.py
+++ b/examples/17_compare_models_nodeflection.py
@@ -1,0 +1,78 @@
+# Copyright 2022 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# See https://floris.readthedocs.io for documentation
+
+
+from time import perf_counter as timerpc
+import matplotlib.pyplot as plt
+import numpy as np
+
+from floris.tools import FlorisInterface
+
+
+"""
+04_sweep_wind_directions
+
+This example demonstrates vectorization of wind direction.  
+A vector of wind directions is passed to the intialize function 
+and the powers of the two simulated turbines is computed for all
+wind directions in one call
+
+The power of both turbines for each wind direction is then plotted
+
+"""
+
+# Instantiate FLORIS using either the GCH or CC model
+fi = FlorisInterface("inputs/gch.yaml") # GCH model matched to the default "legacy_gauss" of V2
+fi_nodeflection = FlorisInterface("inputs/gch_nodeflection.yaml")
+
+# Define a two turbine farm
+wd_array = np.arange(0.0, 360.0, 1.0)
+layout_x = 5 * 126.0 * np.arange(30)  # 30 turbines
+layout_y = np.zeros_like(layout_x)
+
+fi.reinitialize(
+    layout = [layout_x, layout_y],
+    wind_directions=wd_array
+)
+fi_nodeflection.reinitialize(
+    layout=[layout_x, layout_y],
+    wind_directions=wd_array,
+)
+
+# Define yaw angles
+yaw_angles = np.zeros((len(wd_array), 1, len(layout_x))) 
+# yaw_angles[:, :, 0] = 20.0  # First turbine misaligned
+
+# Collect the turbine powers
+start_time = timerpc()
+fi.calculate_wake(yaw_angles=yaw_angles)
+farm_powers = fi.get_farm_power().flatten() / 1E3 # In kW
+t = timerpc() - start_time
+print("Time spent (with defl. model): {:.3f} s.".format(t))
+
+start_time = timerpc()
+fi_nodeflection.calculate_wake(yaw_angles=yaw_angles)
+farm_powers_nodeflection = fi_nodeflection.get_farm_power().flatten() / 1E3 # In kW
+t = timerpc() - start_time
+print("Time spent (without defl. model): {:.3f} s.".format(t))
+
+# Plot
+fig, ax = plt.subplots()
+ax.plot(wd_array, farm_powers, label='With deflection model')
+ax.plot(wd_array, farm_powers_nodeflection, label='Without deflection model')
+ax.grid(True)
+ax.legend()
+ax.set_xlabel('Wind Direction (deg)')
+ax.set_ylabel('Power (kW)')
+plt.show()

--- a/examples/inputs/gch_nodeflection.yaml
+++ b/examples/inputs/gch_nodeflection.yaml
@@ -1,0 +1,89 @@
+
+name: GCH
+description: Three turbines using Gauss Curl Hybrid model
+floris_version: v3.0.0
+
+logging:
+  console:
+    enable: true
+    level: WARNING
+  file:
+    enable: false
+    level: WARNING
+
+solver:
+  type: turbine_grid
+  turbine_grid_points: 3
+
+farm:
+  layout_x:
+  - 0.0
+  - 630.0
+  - 1260.0
+  layout_y:
+  - 0.0
+  - 0.0
+  - 0.0
+  turbine_type:
+  - nrel_5MW
+
+flow_field:
+  air_density: 1.225
+  reference_wind_height: -1 # -1 is code for use the hub height
+  turbulence_intensity: 0.06
+  wind_directions:
+  - 270.0
+  wind_shear: 0.12
+  wind_speeds:
+  - 8.0
+  wind_veer: 0.0
+
+wake:
+  model_strings:
+    combination_model: sosfs
+    deflection_model: none
+    turbulence_model: crespo_hernandez
+    velocity_model: gauss
+
+  enable_secondary_steering: true
+  enable_yaw_added_recovery: true
+  enable_transverse_velocities: true
+
+  wake_deflection_parameters:
+    gauss:
+      ad: 0.0
+      alpha: 0.58
+      bd: 0.0
+      beta: 0.077
+      dm: 1.0
+      ka: 0.38
+      kb: 0.004
+    jimenez:
+      ad: 0.0
+      bd: 0.0
+      kd: 0.05
+
+  wake_velocity_parameters:
+    cc:
+      a_s: 0.179367259
+      b_s: 0.0118889215
+      c_s1: 0.0563691592
+      c_s2: 0.13290157
+      a_f: 3.11
+      b_f: -0.68
+      c_f: 2.41
+      alpha_mod: 1.0
+    gauss:
+      alpha: 0.58
+      beta: 0.077
+      ka: 0.38
+      kb: 0.004
+    jensen:
+      we: 0.05
+
+  wake_turbulence_parameters:
+    crespo_hernandez:
+      initial: 0.1
+      constant: 0.5
+      ai: 0.8
+      downstream: -0.32

--- a/floris/simulation/wake.py
+++ b/floris/simulation/wake.py
@@ -19,10 +19,12 @@ from floris.simulation import BaseClass, BaseModel
 from floris.simulation.wake_deflection import (
     GaussVelocityDeflection,
     JimenezVelocityDeflection,
+    NoneVelocityDeflection,
 )
 from floris.simulation.wake_combination import FLS, MAX, SOSFS
-from floris.simulation.wake_turbulence.crespo_hernandez import CrespoHernandez
+from floris.simulation.wake_turbulence import CrespoHernandez, NoneWakeTurbulence
 from floris.simulation.wake_velocity import (
+    NoneVelocityDeficit,
     CumulativeGaussCurlVelocityDeficit,
     GaussVelocityDeficit,
     JensenVelocityDeficit
@@ -37,12 +39,15 @@ MODEL_MAP = {
     },
     "deflection_model": {
         "jimenez": JimenezVelocityDeflection,
-        "gauss": GaussVelocityDeflection
+        "gauss": GaussVelocityDeflection,
+        "none": NoneVelocityDeflection
     },
     "turbulence_model": {
+        "none": NoneWakeTurbulence,
         "crespo_hernandez": CrespoHernandez
     },
     "velocity_model": {
+        "none": NoneVelocityDeficit,
         "cc": CumulativeGaussCurlVelocityDeficit,
         "gauss": GaussVelocityDeficit,
         "jensen": JensenVelocityDeficit
@@ -79,7 +84,10 @@ class WakeModelManager(BaseClass):
 
     def __attrs_post_init__(self) -> None:
         model: BaseModel = MODEL_MAP["velocity_model"][self.model_strings["velocity_model"]]
-        model_parameters = self.wake_velocity_parameters[self.model_strings["velocity_model"]]
+        if self.model_strings["velocity_model"].lower() == "none":
+            model_parameters = None
+        else:
+            model_parameters = self.wake_velocity_parameters[self.model_strings["velocity_model"]]
         if model_parameters is None:
             # Use model defaults
             self.velocity_model = model()
@@ -87,14 +95,20 @@ class WakeModelManager(BaseClass):
             self.velocity_model = model.from_dict(model_parameters)
 
         model: BaseModel = MODEL_MAP["deflection_model"][self.model_strings["deflection_model"]]
-        model_parameters = self.wake_deflection_parameters[self.model_strings["deflection_model"]]
+        if self.model_strings["deflection_model"].lower() == "none":
+            model_parameters = None
+        else:
+            model_parameters = self.wake_deflection_parameters[self.model_strings["deflection_model"]]
         if model_parameters is None:
             self.deflection_model = model()
         else:
             self.deflection_model = model.from_dict(model_parameters)
 
         model: BaseModel = MODEL_MAP["turbulence_model"][self.model_strings["turbulence_model"]]
-        model_parameters = self.wake_turbulence_parameters[self.model_strings["turbulence_model"]]
+        if self.model_strings["turbulence_model"].lower() == "none":
+            model_parameters = None
+        else:
+            model_parameters = self.wake_turbulence_parameters[self.model_strings["turbulence_model"]]
         if model_parameters is None:
             self.turbulence_model = model()
         else:

--- a/floris/simulation/wake_deflection/__init__.py
+++ b/floris/simulation/wake_deflection/__init__.py
@@ -15,3 +15,4 @@
 
 from floris.simulation.wake_deflection.gauss import GaussVelocityDeflection
 from floris.simulation.wake_deflection.jimenez import JimenezVelocityDeflection
+from floris.simulation.wake_deflection.none import NoneVelocityDeflection

--- a/floris/simulation/wake_deflection/none.py
+++ b/floris/simulation/wake_deflection/none.py
@@ -1,0 +1,63 @@
+# Copyright 2021 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+from typing import Any, Dict
+
+from attrs import define
+import numpy as np
+
+from floris.simulation import BaseModel
+from floris.simulation import FlowField
+from floris.simulation import Grid
+
+
+@define
+class NoneVelocityDeflection(BaseModel):
+    """
+    The None deflection model is a placeholder code that simple ignores any
+    deflection and just returns an empty array of zeroes.
+    """
+    model_string = "none"
+
+    def prepare_function(
+        self,
+        grid: Grid,
+        flow_field: FlowField,
+    ) -> Dict[str, Any]:
+
+        kwargs = dict(
+            x=grid.x,
+            y=grid.y,
+            z=grid.z,
+            freestream_velocity=flow_field.u_initial,
+            wind_veer=flow_field.wind_veer,
+        )
+        return kwargs
+
+    # @profile
+    def function(
+        self,
+        x_i: np.ndarray,
+        y_i: np.ndarray,
+        yaw_i: np.ndarray,
+        turbulence_intensity_i: np.ndarray,
+        ct_i: np.ndarray,
+        rotor_diameter_i: float,
+        *,
+        x: np.ndarray,
+        y: np.ndarray,
+        z: np.ndarray,
+        freestream_velocity: np.ndarray,
+        wind_veer: float,
+    ):
+        """Skip all deflection calculations and returns empty array."""
+        return np.zeros_like(freestream_velocity)

--- a/floris/simulation/wake_turbulence/__init__.py
+++ b/floris/simulation/wake_turbulence/__init__.py
@@ -14,3 +14,4 @@
 
 
 from floris.simulation.wake_turbulence.crespo_hernandez import CrespoHernandez
+from floris.simulation.wake_turbulence.none import NoneWakeTurbulence

--- a/floris/simulation/wake_turbulence/none.py
+++ b/floris/simulation/wake_turbulence/none.py
@@ -1,0 +1,40 @@
+# Copyright 2021 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+from typing import Any, Dict
+
+from attrs import define, field
+import numpy as np
+
+from floris.simulation import BaseModel
+
+
+@define
+class NoneWakeTurbulence(BaseModel):
+    """
+    The None wake turbulence model is a placeholder code that simple ignores
+    any wake turbulence and just returns an array of the ambient TIs.
+    """
+
+    def prepare_function(self) -> dict:
+        pass
+
+    def function(
+        self,
+        ambient_TI: float,
+        x: np.ndarray,
+        x_i: np.ndarray,
+        rotor_diameter: float,
+        axial_induction: np.ndarray,
+    ) -> None:
+        """Return unchanged field of turbulence intensities"""
+        return np.ones_like(x) * ambient_TI

--- a/floris/simulation/wake_velocity/__init__.py
+++ b/floris/simulation/wake_velocity/__init__.py
@@ -13,6 +13,7 @@
 # See https://floris.readthedocs.io for documentation
 
 
+from floris.simulation.wake_velocity.none import NoneVelocityDeficit
 from floris.simulation.wake_velocity.cumulative_gauss_curl import CumulativeGaussCurlVelocityDeficit
 from floris.simulation.wake_velocity.gauss import GaussVelocityDeficit
 from floris.simulation.wake_velocity.jensen import JensenVelocityDeficit

--- a/floris/simulation/wake_velocity/none.py
+++ b/floris/simulation/wake_velocity/none.py
@@ -1,0 +1,67 @@
+# Copyright 2021 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+from typing import Any, Dict
+
+from attrs import define, field
+import numpy as np
+
+from floris.simulation import BaseModel
+from floris.simulation import FlowField
+from floris.simulation import Grid
+
+
+@define
+class NoneVelocityDeficit(BaseModel):
+    """
+    The None deficit model is a placeholder code that simple ignores any
+    wake wind speed deficits and just returns an empty array of zeroes.
+    """
+    def prepare_function(
+        self,
+        grid: Grid,
+        flow_field: FlowField,
+    ) -> Dict[str, Any]:
+
+        kwargs = dict(
+            x=grid.x,
+            y=grid.y,
+            z=grid.z,
+            u_initial=flow_field.u_initial,
+            wind_veer=flow_field.wind_veer
+        )
+        return kwargs
+
+    # @profile
+    def function(
+        self,
+        x_i: np.ndarray,
+        y_i: np.ndarray,
+        z_i: np.ndarray,
+        axial_induction_i: np.ndarray,
+        deflection_field_i: np.ndarray,
+        yaw_angle_i: np.ndarray,
+        turbulence_intensity_i: np.ndarray,
+        ct_i: np.ndarray,
+        hub_height_i: float,
+        rotor_diameter_i: np.ndarray,
+        # enforces the use of the below as keyword arguments and adherence to the
+        # unpacking of the results from prepare_function()
+        *,
+        x: np.ndarray,
+        y: np.ndarray,
+        z: np.ndarray,
+        u_initial: np.ndarray,
+        wind_veer: float
+    ) -> None:
+
+        return np.zeros_like(u_initial)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Adds the option to use `none` or `None` for the wake deficit, wake deflection and added-turbulence submodels.

**Related issue, if one exists**
#394 

**Impacted areas of the software**
FLORIS simulation.

**Additional supporting information**
N/A

**Test results, if applicable**
Example 17 has been added that compares the farm power with and without a deflection model. It shows that the non-deflection model is notably faster (20%+) while yielding pretty much identical results.

```
Time spent (with defl. model): 1.576 s.
Time spent (without defl. model): 1.321 s.
```
![image](https://user-images.githubusercontent.com/22119448/158896986-fcc6e24c-39eb-45c5-a69e-07dd434a902a.png)

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->