### PR TITLE
Enabling vectorized time series calculation of wind conditions

### DIFF
--- a/examples/02_visualizations.py
+++ b/examples/02_visualizations.py
@@ -45,7 +45,7 @@ fi = FlorisInterface("inputs/gch.yaml")
 
 # Using the FlorisInterface functions, get 2D slices.
 horizontal_plane = fi.calculate_horizontal_plane(x_resolution=200, y_resolution=100, height=90.0)
-y_plane = fi.calculate_y_plane(x_resolution=200, z_resolution=100, crossstream_dist=630.0)
+y_plane = fi.calculate_y_plane(x_resolution=200, z_resolution=100, crossstream_dist=0.0)
 cross_plane = fi.calculate_cross_plane(y_resolution=100, z_resolution=100, downstream_dist=630.0)
 
 

--- a/examples/18_demo_time_series.py
+++ b/examples/18_demo_time_series.py
@@ -1,0 +1,92 @@
+# Copyright 2021 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# See https://floris.readthedocs.io for documentation
+
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from floris.tools import FlorisInterface
+
+"""
+This example demonstrates running FLORIS in time series mode.
+
+Typically when an array of wind directions and wind speeds are passed in FLORIS,
+it is assumed these are defining a grid of wd/ws points to consider, as in a wind rose.  
+All combinations of wind direction and wind speed are therefore computed, and resulting
+matrices, for example of turbine power are returned with martrices whose dimensions are
+wind direction, wind speed and turbine number.
+
+In time series mode, specified by setting the time_series flag of the FLORIS interface to True
+each wd/ws pair is assumed to constitute a single point in time and each pair is computed.
+Results are returned still as a 3 dimensional matrix, however the index of the (wd/ws) pair 
+is provided in the first dimension, the second dimension is fixed at 1, and the thrid is 
+turbine number again for consistency.
+
+Note by not specifying yaw, the assumption is that all turbines are always pointing into the
+current wind direction with no offset
+
+
+"""
+
+# Initialize FLORIS to simple 4 turbine farm
+fi = FlorisInterface("inputs/gch.yaml")
+
+# Convert to a simple two turbine layout
+fi.reinitialize( layout=( [0, 500.], [0., 0.] ) )
+
+
+# Create a fake time history where wind speed steps in the middle while wind direction
+# Walks randomly
+time = np.arange(0,120,10.) # Each time step represents a 10-minute average
+ws = np.ones_like(time) * 8.
+ws[int(len(ws)/2):] = 9.
+wd = np.ones_like(time) * 270.
+
+for idx in range(1,len(time)):
+    wd[idx] = wd[idx-1] + np.random.randn() * 2.
+
+
+# Now intiialize FLORIS object to this history using time_series flag
+fi.reinitialize(wind_directions=wd, wind_speeds=ws,time_series=True)
+
+# Collect the powers
+fi.calculate_wake()
+turbine_powers = fi.get_turbine_powers()/1000.
+
+# Show the dimensions
+num_turbines = len(fi.layout_x)
+print('There are %d time samples, and %d turbines and so the resulting turbine power matrix has the shape:' % (len(time), num_turbines), turbine_powers.shape)
+
+
+fig, axarr = plt.subplots(3,1,sharex=True,figsize=(7,8))
+
+ax = axarr[0]
+ax.plot(time,ws,'o-')
+ax.set_ylabel('Wind Speed (m/s)')
+ax.grid(True)
+
+ax = axarr[1]
+ax.plot(time,wd,'o-')
+ax.set_ylabel('Wind Direction (Deg)')
+ax.grid(True)
+
+ax = axarr[2]
+for t in range(num_turbines):
+    ax.plot(time,turbine_powers[:,0,t],'o-',label='Turbine %d' % t)
+ax.legend()
+ax.set_ylabel('Turbine Power (kW)')
+ax.set_xlabel('Time (minutes)')
+ax.grid(True)
+
+plt.show()

--- a/examples/18_demo_time_series.py
+++ b/examples/18_demo_time_series.py
@@ -34,56 +34,53 @@ is provided in the first dimension, the second dimension is fixed at 1, and the 
 turbine number again for consistency.
 
 Note by not specifying yaw, the assumption is that all turbines are always pointing into the
-current wind direction with no offset
-
-
+current wind direction with no offset.
 """
 
 # Initialize FLORIS to simple 4 turbine farm
 fi = FlorisInterface("inputs/gch.yaml")
 
 # Convert to a simple two turbine layout
-fi.reinitialize( layout=( [0, 500.], [0., 0.] ) )
-
+fi.reinitialize(layout=([0, 500.], [0., 0.]))
 
 # Create a fake time history where wind speed steps in the middle while wind direction
 # Walks randomly
-time = np.arange(0,120,10.) # Each time step represents a 10-minute average
+time = np.arange(0, 120, 10.) # Each time step represents a 10-minute average
 ws = np.ones_like(time) * 8.
-ws[int(len(ws)/2):] = 9.
+ws[int(len(ws) / 2):] = 9.
 wd = np.ones_like(time) * 270.
 
-for idx in range(1,len(time)):
-    wd[idx] = wd[idx-1] + np.random.randn() * 2.
+for idx in range(1, len(time)):
+    wd[idx] = wd[idx - 1] + np.random.randn() * 2.
 
 
 # Now intiialize FLORIS object to this history using time_series flag
-fi.reinitialize(wind_directions=wd, wind_speeds=ws,time_series=True)
+fi.reinitialize(wind_directions=wd, wind_speeds=ws, time_series=True)
 
 # Collect the powers
 fi.calculate_wake()
-turbine_powers = fi.get_turbine_powers()/1000.
+turbine_powers = fi.get_turbine_powers() / 1000.
 
 # Show the dimensions
 num_turbines = len(fi.layout_x)
 print('There are %d time samples, and %d turbines and so the resulting turbine power matrix has the shape:' % (len(time), num_turbines), turbine_powers.shape)
 
 
-fig, axarr = plt.subplots(3,1,sharex=True,figsize=(7,8))
+fig, axarr = plt.subplots(3, 1, sharex=True, figsize=(7,8))
 
 ax = axarr[0]
-ax.plot(time,ws,'o-')
+ax.plot(time, ws, 'o-')
 ax.set_ylabel('Wind Speed (m/s)')
 ax.grid(True)
 
 ax = axarr[1]
-ax.plot(time,wd,'o-')
+ax.plot(time, wd, 'o-')
 ax.set_ylabel('Wind Direction (Deg)')
 ax.grid(True)
 
 ax = axarr[2]
 for t in range(num_turbines):
-    ax.plot(time,turbine_powers[:,0,t],'o-',label='Turbine %d' % t)
+    ax.plot(time,turbine_powers[:, 0, t], 'o-', label='Turbine %d' % t)
 ax.legend()
 ax.set_ylabel('Turbine Power (kW)')
 ax.set_xlabel('Time (minutes)')

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -83,6 +83,7 @@ class Floris(logging_manager.LoggerBase, FromDictMixin):
                 wind_directions=self.flow_field.wind_directions,
                 wind_speeds=self.flow_field.wind_speeds,
                 grid_resolution=self.solver["turbine_grid_points"],
+                time_series=self.flow_field.time_series,
             )
         elif self.solver["type"] == "flow_field_grid":
             self.grid = FlowFieldGrid(
@@ -91,6 +92,7 @@ class Floris(logging_manager.LoggerBase, FromDictMixin):
                 wind_directions=self.flow_field.wind_directions,
                 wind_speeds=self.flow_field.wind_speeds,
                 grid_resolution=self.solver["flow_field_grid_points"],
+                time_series=self.flow_field.time_series,
             )
         elif self.solver["type"] == "flow_field_planar_grid":
             self.grid = FlowFieldPlanarGrid(
@@ -103,6 +105,7 @@ class Floris(logging_manager.LoggerBase, FromDictMixin):
                 grid_resolution=self.solver["flow_field_grid_points"],
                 x1_bounds=self.solver["flow_field_bounds"][0],
                 x2_bounds=self.solver["flow_field_bounds"][1],
+                time_series=self.flow_field.time_series,
             )
         else:
             raise ValueError(

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -102,7 +102,7 @@ class FlowField(FromDictMixin):
         else:
             self.u_initial_sorted = (self.wind_speeds[None, :].T * wind_profile_plane.T).T * speed_ups
         self.v_initial_sorted = np.zeros(np.shape(self.u_initial_sorted), dtype=self.u_initial_sorted.dtype)
-        self.v_initial_sorted = np.zeros(np.shape(self.u_initial_sorted), dtype=self.u_initial_sorted.dtype)
+        self.w_initial_sorted = np.zeros(np.shape(self.u_initial_sorted), dtype=self.u_initial_sorted.dtype)
 
         self.u_sorted = self.u_initial_sorted.copy()
         self.v_sorted = self.v_initial_sorted.copy()

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -34,7 +34,8 @@ class FlowField(FromDictMixin):
     wind_shear: float = field(converter=float)
     air_density: float = field(converter=float)
     turbulence_intensity: float = field(converter=float)
-    reference_wind_height: float = field(converter=float)
+    reference_wind_height: int = field(converter=int)
+    time_series : bool = field(default=False)
 
     n_wind_speeds: int = field(init=False)
     n_wind_directions: int = field(init=False)
@@ -55,7 +56,10 @@ class FlowField(FromDictMixin):
     @wind_speeds.validator
     def wind_speeds_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:
         """Using the validator method to keep the `n_wind_speeds` attribute up to date."""
-        self.n_wind_speeds = value.size
+        if self.time_series:
+            self.n_wind_speeds = 1
+        else:
+            self.n_wind_speeds = value.size
 
     @wind_directions.validator
     def wind_directions_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:
@@ -93,9 +97,12 @@ class FlowField(FromDictMixin):
         # here to do broadcasting from left to right (transposed), and then transpose back.
         # The result is an array the wind speed and wind direction dimensions on the left side
         # of the shape and the grid.template array on the right
-        self.u_initial_sorted = (self.wind_speeds[None, :].T * wind_profile_plane.T).T * speed_ups
+        if self.time_series:
+            self.u_initial_sorted = (self.wind_speeds[:].T * wind_profile_plane.T).T * speed_ups
+        else:
+            self.u_initial_sorted = (self.wind_speeds[None, :].T * wind_profile_plane.T).T * speed_ups
         self.v_initial_sorted = np.zeros(np.shape(self.u_initial_sorted), dtype=self.u_initial_sorted.dtype)
-        self.w_initial_sorted = np.zeros(np.shape(self.u_initial_sorted), dtype=self.u_initial_sorted.dtype)
+        self.v_initial_sorted = np.zeros(np.shape(self.u_initial_sorted), dtype=self.u_initial_sorted.dtype)
 
         self.u_sorted = self.u_initial_sorted.copy()
         self.v_sorted = self.v_initial_sorted.copy()

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -61,6 +61,7 @@ class Grid(ABC):
     grid_resolution: int | Iterable = field()
     wind_directions: NDArrayFloat = field(converter=floris_array_converter)
     wind_speeds: NDArrayFloat = field(converter=floris_array_converter)
+    time_series: bool = field()
 
     n_turbines: int = field(init=False)
     n_wind_speeds: int = field(init=False)
@@ -88,7 +89,10 @@ class Grid(ABC):
     @wind_speeds.validator
     def wind_speeds_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:
         """Using the validator method to keep the `n_wind_speeds` attribute up to date."""
-        self.n_wind_speeds = value.size
+        if self.time_series:
+            self.n_wind_speeds = 1
+        else:
+            self.n_wind_speeds = value.size
 
     @wind_directions.validator
     def wind_directions_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:

--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -555,7 +555,7 @@ def full_flow_cc_solver(farm: Farm, flow_field: FlowField, flow_field_grid: Flow
 
     turbine_grid = TurbineGrid(
         turbine_coordinates=turbine_grid_farm.coordinates,
-        reference_turbine_diameter=turbine_grid_farm.rotor_diameters_sorted,
+        reference_turbine_diameter=turbine_grid_farm.rotor_diameters,
         wind_directions=turbine_grid_flow_field.wind_directions,
         wind_speeds=turbine_grid_flow_field.wind_speeds,
         grid_resolution=3,

--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -233,6 +233,7 @@ def full_flow_sequential_solver(farm: Farm, flow_field: FlowField, flow_field_gr
         wind_directions=turbine_grid_flow_field.wind_directions,
         wind_speeds=turbine_grid_flow_field.wind_speeds,
         grid_resolution=3,
+        time_series=turbine_grid_flow_field.time_series,
     )
     turbine_grid_farm.expand_farm_properties(
         turbine_grid_flow_field.n_wind_directions, turbine_grid_flow_field.n_wind_speeds, turbine_grid.sorted_coord_indices

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -185,7 +185,8 @@ class FlorisInterface(LoggerBase):
         # turbine_id: list[str] | None = None,
         # wtg_id: list[str] | None = None,
         # with_resolution: float | None = None,
-        solver_settings: dict | None = None
+        solver_settings: dict | None = None,
+        time_series: bool | None = False
     ):
         # Export the floris object recursively as a dictionary
         floris_dict = self.floris.as_dict()
@@ -216,6 +217,11 @@ class FlorisInterface(LoggerBase):
             farm_dict["layout_y"] = layout[1]
         if turbine_type is not None:
             farm_dict["turbine_type"] = turbine_type
+
+        if time_series:
+            flow_field_dict["time_series"] = True
+        else:
+            flow_field_dict["time_series"] = False
 
         ## Wake
         # if wake is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,7 @@ Z_COORDS = [
 N_TURBINES = len(X_COORDS)
 ROTOR_DIAMETER = 126.0
 TURBINE_GRID_RESOLUTION = 2
+TIME_SERIES = False
 
 
 ## Unit test fixtures
@@ -116,7 +117,8 @@ def turbine_grid_fixture(sample_inputs_fixture) -> TurbineGrid:
         reference_turbine_diameter=rotor_diameters,
         wind_directions=np.array(WIND_DIRECTIONS),
         wind_speeds=np.array(WIND_SPEEDS),
-        grid_resolution=TURBINE_GRID_RESOLUTION
+        grid_resolution=TURBINE_GRID_RESOLUTION,
+        time_series=TIME_SERIES
     )
 
 @pytest.fixture


### PR DESCRIPTION
**Feature or improvement description**
This PR enables the vectorized calculation of time series data. Instead of having the wind direction and wind speed input arrays expanded on one another, the arrays are assumed to be equal length where each index is a wind condition to be evaluated.

**Related issue, if one exists**
Closes #299 

**Impacted areas of the software**
Parts of the simulation code and aflag to pass to `floris_interface`.

**Additional supporting information**
This is a first implementation. I am unsure if this should be enable this way, or if a separate time series solver should be created. Because only the modification of the initial matrix sizes is needed, I went with this implementation first. Could use this underlying code with a separate `floris_interface` wrapper function dedicated to time series calls, hopefully moving the `time_series` flag from reinitialize, but still would need to be established before the grids are setup..

**Test results, if applicable**
The below code results in:

```
Time to compute vectorized: 0.64427
Time to compute serial: 125.70354
```

```
import numpy as np
import time

from floris.tools import FlorisInterface

fi = FlorisInterface("inputs/gch.yaml")

time_steps = 1440
nx_turbs = 10
ny_turbs = 1
x_spc = 5 * 126.0
y_spc = 5 * 126.0

wd = np.array([270.0] * time_steps)
ws = np.array([8.0] * time_steps)

layout_x = [i * x_spc for j in  range(ny_turbs) for i in range(nx_turbs)]
layout_y = [j * y_spc for j in  range(ny_turbs) for i in range(nx_turbs)]

start = time.perf_counter()
fi.reinitialize(wind_directions=wd, wind_speeds=ws, layout=[layout_x, layout_y], time_series=True)
fi.calculate_wake()
end = time.perf_counter()
print('Time to compute vectorized: {0:.5f}'.format(end - start))

start = time.perf_counter()
for i in range(len(wd)):
    fi.reinitialize(wind_directions=[wd[i]], wind_speeds=[ws[i]], layout=[layout_x, layout_y], time_series=False)
    fi.calculate_wake()
end = time.perf_counter()
print('Time to compute serial: {0:.5f}'.format(end - start))
```

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->