### PR TITLE
Feature: parallelization in the floris interface

### DIFF
--- a/examples/04_sweep_wind_directions.py
+++ b/examples/04_sweep_wind_directions.py
@@ -13,6 +13,7 @@
 # See https://floris.readthedocs.io for documentation
 
 
+from time import perf_counter as timerpc
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -32,44 +33,23 @@ The power of both turbines for each wind direction is then plotted
 
 """
 
-# Instantiate FLORIS using either the GCH or CC model
-fi = FlorisInterface("inputs/gch.yaml") # GCH model matched to the default "legacy_gauss" of V2
-# fi = FlorisInterface("inputs/cc.yaml") # New CumulativeCurl model
+# Initialize FLORIS object
+X, Y = np.meshgrid(np.arange(50) * 5 * 126.4, np.arange(2) * 3 * 126.4)
+fi = FlorisInterface("inputs/gch.yaml")
+fi.reinitialize(
+    wind_directions=np.arange(0.0, 360.0, 3.0),
+    wind_speeds=np.arange(4.0, 8.0, 1.0),
+    layout=[X.flatten(), Y.flatten()]
+)
 
-# Define a two turbine farm
-D = 126.
-layout_x = np.array([0, D*6])
-layout_y = [0, 0]
-fi.reinitialize(layout = [layout_x, layout_y])
-
-# Sweep wind speeds but keep wind direction fixed
-wd_array = np.arange(250,291,1.)
-fi.reinitialize(wind_directions=wd_array)
-
-# Define a matrix of yaw angles to be all 0
-# Note that yaw angles is now specified as a matrix whose dimesions are
-# wd/ws/turbine
-num_wd = len(wd_array) # Number of wind directions
-num_ws = 1 # Number of wind speeds
-num_turbine = len(layout_x) #  Number of turbines
-yaw_angles = np.zeros((num_wd, num_ws, num_turbine)) 
-
-# Calculate
-fi.calculate_wake(yaw_angles=yaw_angles)
-
-# Collect the turbine powers
+# Calculate without parallelization
+t0 = timerpc()
+fi.calculate_wake()
+print("Time spent (non-parallelized): {:.3f} s".format(timerpc() - t0))
 turbine_powers = fi.get_turbine_powers() / 1E3 # In kW
 
-# Pull out the power values per turbine
-pow_t0 = turbine_powers[:,:,0].flatten()
-pow_t1 = turbine_powers[:,:,1].flatten()
-
-# Plot
-fig, ax = plt.subplots()
-ax.plot(wd_array,pow_t0,color='k',label='Upstream Turbine')
-ax.plot(wd_array,pow_t1,color='r',label='Downstream Turbine')
-ax.grid(True)
-ax.legend()
-ax.set_xlabel('Wind Direction (deg)')
-ax.set_ylabel('Power (kW)')
-plt.show()
+# Calculate with parallelization
+t0 = timerpc()
+fi.calculate_wake(num_tasks=4)
+print("Time spent (parallelized): {:.3f} s".format(timerpc() - t0))
+turbine_powers = fi.get_turbine_powers() / 1E3 # In kW

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -857,7 +857,7 @@ def split_num_tasks_to_wd_and_ws(n_wind_speeds, n_wind_directions, num_tasks):
         n_ws_splits = 1
         n_wd_splits = np.min([n_wind_directions, num_tasks])
     else:
-        n_wd_splits = int(np.floor(num_tasks / n_wind_directions))
+        n_wd_splits = int(np.floor(n_wind_directions / num_tasks))
         n_wd_splits = np.clip(n_wd_splits, 1, num_tasks)
         n_ws_splits = int(np.floor(num_tasks / n_wd_splits))
         


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
This PR is **not** ready to be merged.

<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This feature adds a parallelization option to `calculate_wake` in `FlorisInterface`.

**Related issue, if one exists**
Issue #401.

**Impacted areas of the software**
Simulation core of FLORIS.

**Additional supporting information**
This PR adds two options to `calculate_wake`, being `num_tasks=1` and `use_mpi=False`. If `num_tasks > 1`, the code is simulated using parallel processing. If `use_mpi=False` (default), it'll use Python's `multiprocessing` library for that. If `use_mpi=True`, it uses the `mpi4py.futures` module for parallelization.

This PR is one way I envision is useful to speed up computations, particularly for large farms. The `calculate_wake` parallelization function can easily reflect in other functions such as `get_farm_AEP` by passing the `num_tasks` and `use_mpi` arguments. Additionally, it'll also speed up computations for `UncertaintyInterface`, since that directly uses `calculate_wake`. For yaw optimizations, this PR may yield some speedup, but it is probably better to parallelize the code at a higher level for better performance.

Some open questions:
1. Do we want to have parallelization on the `floris_interface` level, like I propose it to be now? Or should it reside as a separate class on top of `floris_interface`, perhaps?
2. Are all relevant variables gathered after processing the tasks? I am currently mainly collecting the flow information.

**Test results, if applicable**
I ran the following code on Europa, NREL Eagle's Jupyter Notebook interface. I believe Jupyter has 32 cores readily available for parallelization. Here, I am benchmarking the parallelization performance using `multiprocessing` for various farm sizes.

```
from time import perf_counter as timerpc
import matplotlib.pyplot as plt
import numpy as np

from floris.tools import FlorisInterface
from floris.tools.visualization import visualize_cut_plane


def load_floris(nx=10):
    # Initialize FLORIS object
    X, Y = np.meshgrid(np.arange(nx) * 5 * 126.4, np.arange(10) * 3 * 126.4)
    fi = FlorisInterface("inputs/gch.yaml")
    fi.reinitialize(
        wind_directions=np.arange(0.0, 360.0, 3.0),
        wind_speeds=np.arange(4.0, 25.0, 1.0),
        layout=[X.flatten(), Y.flatten()]
    )
    return fi


for nx in range(1, 10):
    # Calculate with parallelization
    num_task_list = [1, 2, 3, 4, 8, 12, 18, 24, 30]
    timings = np.zeros(len(num_task_list))
    for ii, num_tasks in enumerate(num_task_list):
        fi = load_floris(nx=nx)
        t0 = timerpc()
        fi.calculate_wake(num_tasks=num_tasks)
        timings[ii] = timerpc() - t0
    
    fig, ax = plt.subplots()
    ax.plot(num_task_list, timings, "-o")
    ax.set_title("Farm with {:d} turbines".format(nx * 10))
    ax.set_xlabel("Num of tasks in parallelization")
    ax.set_ylabel("Time to completion (seconds)")
    ax.grid(True)  
```
![download](https://user-images.githubusercontent.com/22119448/160933506-13204430-0c9e-4aff-96b1-32be94f8cd35.png)
![download](https://user-images.githubusercontent.com/22119448/160933512-c817b025-7314-4a52-bc3c-ccf406d6aa98.png)
![download](https://user-images.githubusercontent.com/22119448/160933517-5338ae96-67e9-4a5a-afbc-fc2bca5e21fb.png)
![download](https://user-images.githubusercontent.com/22119448/160933526-82e2c989-b053-4e5b-8105-14c3158fb866.png)
![download](https://user-images.githubusercontent.com/22119448/160933537-c8f344c4-5b5d-4f3a-a821-d94c8f1894de.png)
![download](https://user-images.githubusercontent.com/22119448/160933621-b7b09ab4-bf54-4335-a993-ea0b16cdfa5e.png)
![download](https://user-images.githubusercontent.com/22119448/160933626-105e497c-5311-4460-b0c4-abfa31306a04.png)
![download](https://user-images.githubusercontent.com/22119448/160933634-615a3e6b-d601-4bb4-b111-8e323aa21b6e.png)
![download](https://user-images.githubusercontent.com/22119448/160933637-8c306e9f-e537-4a85-bd89-46a54bbb9fd5.png)

Parallelizing the code adds notable overhead and often leads to slow-downs in small farms. Also, FLORIS is particularly fast because the code is vectorized, and splitting it up into multiple problems will reduce the benefit of that. Parallelization is mostly useful for large wind farms and many atmospheric conditions, and with the right computational resources (e.g., a high performance computing facility).

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->