### PR TITLE
Improve CLI in LegacyInterface

### DIFF
--- a/floris/tools/floris_interface_legacy_reader.py
+++ b/floris/tools/floris_interface_legacy_reader.py
@@ -200,17 +200,37 @@ if __name__ == "__main__":
     Please specify your input and output paths accordingly, and it will
     produce the necessary file.
     """
+    import argparse
+    from pathlib import Path
+
+    # Parse the input arguments
+    description = "Converts a FLORIS v2.4 input file to a FLORIS v3 compatible input file.\
+        The file format is changed from JSON to YAML and all inputs are mapped, as needed."
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("-i",
+                        "--input-file",
+                        nargs=1,
+                        required=True,
+                        help="Path to the legacy input file")
+    parser.add_argument("-o",
+                        "--output-file",
+                        nargs="?",
+                        default=None,
+                        help="Path to write the output file")
+    args = parser.parse_args()
 
     # Specify paths
-    legacy_json_path = "inputs/legacy_example_input.json"
-    floris_yaml_output_path = "converted_out/floris_input_file.yaml"
+    legacy_json_path = Path(args.input_file[0])
+    if args.output_file:
+        floris_yaml_output_path = args.output_file
+    else:
+        floris_yaml_output_path = legacy_json_path.stem + ".yaml"
 
     # Load legacy input .json file into V3 object
     fi = FlorisInterfaceLegacyV2(legacy_json_path)
 
     # Create output directory and save converted input file
-    fout = os.path.abspath(floris_yaml_output_path)
-    os.makedirs(os.path.dirname(fout), exist_ok=True)
-    fi.floris.to_file(fout)
+    fi.floris.to_file(floris_yaml_output_path)
 
-    print("Converted file saved to: {:s}".format(fout))
+    print(f"Converted file saved to: {floris_yaml_output_path}")


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
This PR **is** ready to be merged

**Feature or improvement description**
This is the work of  @rafmudaf in [this PR](https://github.com/Bartdoekemeijer/floris/pull/2), which I forgot to merge. This PR improves the command line interface for the legacy input reader. Users can now convert files by
```
python floris/tools/floris_interface_legacy_reader.py -i /path/to/input.json -o /path/to/output.yaml
```


**Related issue, if one exists**
N/A

**Impacted areas of the software**
Legacy input file reader.

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
I have tested the functionality and it successfully converted my floris v2.4 input file for Anholt into a `.yaml` file.

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->