### PR TITLE
Bugfix: using the wrong rotor diameters when plotting with the CC model

### DIFF
--- a/examples/02_visualizations.py
+++ b/examples/02_visualizations.py
@@ -45,7 +45,7 @@ fi = FlorisInterface("inputs/gch.yaml")
 
 # Using the FlorisInterface functions, get 2D slices.
 horizontal_plane = fi.calculate_horizontal_plane(x_resolution=200, y_resolution=100, height=90.0)
-y_plane = fi.calculate_y_plane(x_resolution=200, z_resolution=100, crossstream_dist=630.0)
+y_plane = fi.calculate_y_plane(x_resolution=200, z_resolution=100, crossstream_dist=0.0)
 cross_plane = fi.calculate_cross_plane(y_resolution=100, z_resolution=100, downstream_dist=630.0)
 
 

--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -555,7 +555,7 @@ def full_flow_cc_solver(farm: Farm, flow_field: FlowField, flow_field_grid: Flow
 
     turbine_grid = TurbineGrid(
         turbine_coordinates=turbine_grid_farm.coordinates,
-        reference_turbine_diameter=turbine_grid_farm.rotor_diameters_sorted,
+        reference_turbine_diameter=turbine_grid_farm.rotor_diameters,
         wind_directions=turbine_grid_flow_field.wind_directions,
         wind_speeds=turbine_grid_flow_field.wind_speeds,
         grid_resolution=3,


### PR DESCRIPTION
**Feature or improvement description**
This bugfix corrects the rotor diameters that are being used when plotting the CC model. Currently, plotting with the CC model results in a code error. It also corrects the `crossstream_dist` value in the `02_visualizations.py` example.

**Related issue, if one exists**
None.

**Impacted areas of the software**
`solver.py`

**Additional supporting information**
This bug was introduced in pull #381, on line 558 of `simulation/solver.py`.

**Test results, if applicable**
Running example `02_visualizations.py` with the `cc.yaml` input file produces:

![image](https://user-images.githubusercontent.com/12664940/163852876-be56c9c8-918c-41c3-8c8e-005665b83c0f.png)

![image](https://user-images.githubusercontent.com/12664940/163853084-0e249e0a-ac0f-45f1-84f1-ee71a3b20672.png)

![image](https://user-images.githubusercontent.com/12664940/163853103-481f037d-29b4-42b7-89f2-953d58f38411.png)
