### PR TITLE
Fix type hinting and other type issues

### DIFF
--- a/floris/logging_manager.py
+++ b/floris/logging_manager.py
@@ -14,7 +14,6 @@
 
 import logging
 from datetime import datetime
-from typing import Type
 
 import coloredlogs
 
@@ -157,7 +156,7 @@ class LoggerBase:
             "{}.{}".format(type(self).__module__, type(self).__name__)
         )
 
-    def error(self, error_type: Type[Exception], message: str):
+    def error(self, error_type: Exception, message: str):
         self.logger.error(message)
         raise error_type(message)
 

--- a/floris/logging_manager.py
+++ b/floris/logging_manager.py
@@ -14,6 +14,7 @@
 
 import logging
 from datetime import datetime
+from typing import Type
 
 import coloredlogs
 
@@ -155,3 +156,13 @@ class LoggerBase:
         return logging.getLogger(
             "{}.{}".format(type(self).__module__, type(self).__name__)
         )
+
+    def error(self, error_type: Type[Exception], message: str):
+        self.logger.error(message)
+        raise error_type(message)
+
+    def warn(self, message: str):
+        self.logger.warn(message)
+
+    def info(self, message: str):
+        self.logger.info(message)

--- a/floris/simulation/base.py
+++ b/floris/simulation/base.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, Final
 
 import attrs
 
-from floris.type_dec import FromDictMixin
+from floris.type_dec import NDArrayFloat, FromDictMixin
 from floris.logging_manager import LoggerBase
 
 
@@ -73,9 +73,9 @@ class BaseModel(BaseClass, ABC):
     NUM_EPS: Final[float] = 0.001  # This is a numerical epsilon to prevent divide by zeros
 
     @abstractmethod
-    def prepare_function() -> dict:
+    def prepare_function(self, *args) -> dict:
         raise NotImplementedError("BaseModel.prepare_function")
 
     @abstractmethod
-    def function() -> None:
+    def function(self, *args, **kwargs) -> NDArrayFloat:
         raise NotImplementedError("BaseModel.function")

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -26,6 +26,7 @@ from floris.utilities import load_yaml
 from floris.utilities import Vec3
 from floris.simulation import BaseClass
 from floris.simulation import Turbine
+from floris.simulation import State
 
 
 @define
@@ -191,7 +192,7 @@ class Farm(BaseClass):
         self.TSRs = np.take_along_axis(self.TSRs_sorted, unsorted_indices[:,:,:,0,0], axis=2)
         self.pPs = np.take_along_axis(self.pPs_sorted, unsorted_indices[:,:,:,0,0], axis=2)
         self.turbine_type_map = np.take_along_axis(self.turbine_type_map_sorted, unsorted_indices[:,:,:,0,0], axis=2)
-        self.state.USED
+        self.state = State.USED
 
     @property
     def n_turbines(self):

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -62,12 +62,12 @@ class Farm(BaseClass):
     @layout_x.validator
     def check_x(self, instance: attrs.Attribute, value: Any) -> None:
         if len(value) != len(self.layout_y):
-            raise ValueError("layout_x and layout_y must have the same number of entries.")
+            self.error(ValueError, "layout_x and layout_y must have the same number of entries.")
 
     @layout_y.validator
     def check_y(self, instance: attrs.Attribute, value: Any) -> None:
         if len(value) != len(self.layout_x):
-            raise ValueError("layout_x and layout_y must have the same number of entries.")
+            self.error(ValueError, "layout_x and layout_y must have the same number of entries.")
 
     @turbine_type.validator
     def check_turbine_type(self, instance: attrs.Attribute, value: Any) -> None:
@@ -75,7 +75,10 @@ class Farm(BaseClass):
             if len(value) == 1:
                 value = self.turbine_type * len(self.layout_x)
             else:
-                raise ValueError("turbine_type must have the same number of entries as layout_x/layout_y or have a single turbine_type value.")
+                self.error(
+                    ValueError,
+                    "turbine_type must have the same number of entries as layout_x/layout_y or have a single turbine_type value."
+                )
 
         self.turbine_definitions = copy.deepcopy(value)
         for i, val in enumerate(value):
@@ -83,7 +86,10 @@ class Farm(BaseClass):
                 _floris_dir = Path(__file__).parent.parent
                 fname = _floris_dir / "turbine_library" / f"{val}.yaml"
                 if not Path.is_file(fname):
-                    raise ValueError("User-selected turbine definition `{}` does not exist in pre-defined turbine library.".format(val))
+                    self.error(
+                        ValueError,
+                        "User-selected turbine definition `{}` does not exist in pre-defined turbine library.".format(val)
+                    )
                 self.turbine_definitions[i] = load_yaml(fname)
 
                 # This is a temporary block of code that catches that ref_density_cp_ct is not defined
@@ -91,11 +97,11 @@ class Farm(BaseClass):
                 # A warning is issued letting the user know in future versions defining this value explicitly
                 # will be required 
                 if not 'ref_density_cp_ct' in self.turbine_definitions[i]:
-                    self.logger.warn("The value ref_density_cp_ct is not defined in the file: %s " % fname)
-                    self.logger.warn("This value is not the simulated air density but is the density at which the cp/ct curves are defined")
-                    self.logger.warn("In previous versions this was assumed to be 1.225")
-                    self.logger.warn("Future versions of FLORIS will give an error if this value is not explicitly defined")
-                    self.logger.warn("Currently this value is being set to the prior default value of 1.225")
+                    self.warn("The value ref_density_cp_ct is not defined in the file: %s " % fname)
+                    self.warn("This value is not the simulated air density but is the density at which the cp/ct curves are defined")
+                    self.warn("In previous versions this was assumed to be 1.225")
+                    self.warn("Future versions of FLORIS will give an error if this value is not explicitly defined")
+                    self.warn("Currently this value is being set to the prior default value of 1.225")
                     self.turbine_definitions[i]['ref_density_cp_ct'] = 1.225
 
     def initialize(self, sorted_indices):

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -55,7 +55,7 @@ class Farm(BaseClass):
     TSRs: NDArrayFloat = field(init=False)
     pPs: NDArrayFloat = field(init=False)
     turbine_map: NDArrayFloat = field(init=False)
-    turbine_fCts: NDArrayObject = field(init=False)
+    turbine_fCts: dict = field(init=False)
     turbine_fCps: NDArrayFloat = field(init=False)
     turbine_power_interps: dict = field(init=False)
     coordinates: NDArrayFloat = field(init=False)
@@ -153,13 +153,13 @@ class Farm(BaseClass):
         self.turbine_map = [Turbine.from_dict(turb) for turb in self.turbine_definitions]
 
     def construct_turbine_fCts(self):
-        self.turbine_fCts = [(turb.turbine_type, turb.fCt_interp) for turb in self.turbine_map]
+        self.turbine_fCts = {turb.turbine_type: turb.fCt_interp for turb in self.turbine_map}
 
     def construct_turbine_fCps(self):
         self.turbine_fCps = [(turb.turbine_type, turb.fCp_interp) for turb in self.turbine_map]
 
     def construct_turbine_power_interps(self):
-        self.turbine_power_interps = [(turb.turbine_type, turb.power_interp) for turb in self.turbine_map]
+        self.turbine_power_interps = {turb.turbine_type: turb.power_interp for turb in self.turbine_map}
 
     def construct_coordinates(self):
         self.coordinates = np.array(

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -10,22 +10,21 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# from __future__ import annotations
-from typing import Any, List
-
-import attrs
-from attrs import define, field
-import numpy as np
-from pathlib import Path
+import os
 import copy
 
-from floris.type_dec import (
-    NDArrayObject,
-    floris_array_converter,
-    NDArrayFloat
-)
-from floris.utilities import Vec3, load_yaml
-from floris.simulation import BaseClass, State
+from typing import Any, List
+from pathlib import Path
+
+import attrs
+import numpy as np
+from attrs import field, define
+
+from floris.type_dec import floris_array_converter
+from floris.type_dec import NDArrayFloat, NDArrayObject
+from floris.utilities import load_yaml
+from floris.utilities import Vec3
+from floris.simulation import BaseClass
 from floris.simulation import Turbine
 
 
@@ -48,16 +47,26 @@ class Farm(BaseClass):
     turbine_type: List = field()
 
     turbine_definitions: dict = field(init=False)
-    yaw_angles: NDArrayFloat = field(init=False)
+    yaw_angles: NDArrayFloat = field(init=False, converter=floris_array_converter, on_setattr=attrs.setters.convert)
     yaw_angles_sorted: NDArrayFloat = field(init=False)
-    coordinates: List[Vec3] = field(init=False)
+
     hub_heights: NDArrayFloat = field(init=False)
+    rotor_diameters: NDArrayFloat = field(init=False)
+    TSRs: NDArrayFloat = field(init=False)
+    pPs: NDArrayFloat = field(init=False)
+    turbine_map: NDArrayFloat = field(init=False)
+    turbine_fCts: NDArrayObject = field(init=False)
+    turbine_fCps: NDArrayFloat = field(init=False)
+    turbine_power_interps: dict = field(init=False)
+    coordinates: NDArrayFloat = field(init=False)
+
+    # Sorted versions of the above variables
     hub_heights_sorted: NDArrayFloat = field(init=False, default=[])
-    turbine_fCts: tuple = field(init=False, default=[])
-    turbine_type_map_sorted: NDArrayObject = field(init=False, default=[])
     rotor_diameters_sorted: NDArrayFloat = field(init=False, default=[])
     TSRs_sorted: NDArrayFloat = field(init=False, default=[])
     pPs_sorted: NDArrayFloat = field(init=False, default=[])
+    turbine_type_map_sorted: NDArrayObject = field(init=False, default=[])
+
 
     @layout_x.validator
     def check_x(self, instance: attrs.Attribute, value: Any) -> None:

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -16,28 +16,31 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+
 import yaml
-from floris.utilities import load_yaml
+from attrs import field, define
 
 import floris.logging_manager as logging_manager
+from floris.type_dec import FromDictMixin
+from floris.utilities import load_yaml
 from floris.simulation import (
     BaseClass,
     Farm,
-    WakeModelManager,
-    FlowField,
     Grid,
+    State,
+    Turbine,
+    FlowField,
     TurbineGrid,
     FlowFieldGrid,
+    WakeModelManager,
     FlowFieldPlanarGrid,
-    State,
-    sequential_solver,
     cc_solver,
     turbopark_solver,
-    full_flow_sequential_solver,
+    sequential_solver,
     full_flow_cc_solver,
     full_flow_turbopark_solver,
+    full_flow_sequential_solver,
 )
-from attrs import define, field
 
 
 @define
@@ -50,9 +53,9 @@ class Floris(BaseClass):
 
     logging: dict = field(converter=dict)
     solver: dict = field(converter=dict)
-    wake: WakeModelManager = field(converter=WakeModelManager.from_dict)
-    farm: Farm = field(converter=Farm.from_dict)
-    flow_field: FlowField = field(converter=FlowField.from_dict)
+    wake: WakeModelManager = field(converter=WakeModelManager.from_dict)  # type: ignore
+    farm: Farm = field(converter=Farm.from_dict)  # type: ignore
+    flow_field: FlowField = field(converter=FlowField.from_dict)  # type: ignore
 
     # These fields are included to appease the requirement that all inputs must
     # be mapped to a field in the class. They are not used in FLORIS.

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -85,7 +85,7 @@ class Grid(ABC):
         """Ensures all elements are `Vec3` objects and keeps the `n_turbines` attribute up to date."""
         types = np.unique([isinstance(c, Vec3) for c in value])
         if not all(types):
-            raise TypeError("'turbine_coordinates' must be `Vec3` objects.")
+            self.error(TypeError, "'turbine_coordinates' must be `Vec3` objects.")
 
         self.n_turbines = len(value)
 
@@ -141,6 +141,11 @@ class TurbineGrid(Grid):
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
         self.set_grid()
+
+    @grid_resolution.validator
+    def grid_resolution_validator(self, instance: attrs.Attribute, value: int) -> None:
+        if not isinstance(value, int):
+            self.error(TypeError, "TurbineGrid.grid_resolution must be a single value of type `int`.")
 
     def set_grid(self) -> None:
         """
@@ -255,6 +260,13 @@ class FlowFieldGrid(Grid):
         super().__attrs_post_init__()
         self.set_grid()
 
+    @grid_resolution.validator
+    def grid_resolution_validator(self, instance: attrs.Attribute, value: Sequence) -> None:
+        if np.shape(value) != 3:
+            self.error(ValueError, "FlowFieldGrid.grid_resolution must contain 3 values.")
+        if not all(isinstance(v, int) for v in value):
+            self.error(TypeError, "FlowFieldGrid.grid_resolution must be all of type: `int`")
+
     def set_grid(self) -> None:
         """
         Create a structured grid for the entire flow field domain.
@@ -314,6 +326,13 @@ class FlowFieldPlanarGrid(Grid):
     def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
         self.set_grid()
+
+    @grid_resolution.validator
+    def grid_resolution_validator(self, instance: attrs.Attribute, value: Sequence) -> None:
+        if np.shape(value) != 2:
+            self.error(ValueError, "FlowFieldPlanarGrid.grid_resolution must contain 3 values.")
+        if not all(isinstance(v, int) for v in value):
+            self.error(TypeError, "FlowFieldPlanarGrid.grid_resolution must be all of type: `int`")
 
     def set_grid(self) -> None:
         """

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -28,11 +28,12 @@ from floris.type_dec import (
     floris_float_type,
     floris_array_converter,
 )
+from floris.simulation import BaseClass
 from floris.utilities import Vec3, rotate_coordinates_rel_west
 
 
 @define
-class Grid(ABC):
+class Grid(ABC, BaseClass):
     """
     Grid should establish domain bounds based on given criteria,
     and develop three arrays to contain components of the grid
@@ -317,9 +318,9 @@ class FlowFieldPlanarGrid(Grid):
     @grid_resolution.validator
     def grid_resolution_validator(self, instance: attrs.Attribute, value: Sequence) -> None:
         if np.shape(value) != 2:
-            self.error(ValueError, "FlowFieldPlanarGrid.grid_resolution must contain 3 values.")
+            self.error(ValueError, f"FlowFieldPlanarGrid.grid_resolution must contain 2 values; given value: {value}.")
         if not all(isinstance(v, int) for v in value):
-            self.error(TypeError, "FlowFieldPlanarGrid.grid_resolution must be all of type: `int`")
+            self.error(TypeError, f"FlowFieldPlanarGrid.grid_resolution must be of type `int`; given value: {value}.")
 
     def set_grid(self) -> None:
         """

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -84,7 +84,7 @@ def power(
     velocities: NDArrayFloat,
     yaw_angle: NDArrayFloat,
     pP: NDArrayFloat,
-    power_interp: NDArrayObject,
+    power_interp: dict,
     turbine_type_map: NDArrayObject,
     ix_filter: NDArrayInt | Iterable[int] | None = None,
 ) -> NDArrayFloat:
@@ -141,7 +141,6 @@ def power(
 
     # Loop over each turbine type given to get thrust coefficient for all turbines
     p = np.zeros(np.shape(yaw_effective_velocity))
-    power_interp = dict(power_interp)
     turb_types = np.unique(turbine_type_map)
     for turb_type in turb_types:
         # Using a masked array, apply the thrust coefficient for all turbines of the current
@@ -154,7 +153,7 @@ def power(
 def Ct(
     velocities: NDArrayFloat,
     yaw_angle: NDArrayFloat,
-    fCt: NDArrayObject,
+    fCt: dict,
     turbine_type_map: NDArrayObject,
     ix_filter: NDArrayFilter | Iterable[int] | None = None,
 ) -> NDArrayFloat:
@@ -189,7 +188,6 @@ def Ct(
 
     # Loop over each turbine type given to get thrust coefficient for all turbines
     thrust_coefficient = np.zeros(np.shape(average_velocities))
-    fCt = dict(fCt)
     turb_types = np.unique(turbine_type_map)
     for turb_type in turb_types:
         # Using a masked array, apply the thrust coefficient for all turbines of the current
@@ -203,7 +201,7 @@ def Ct(
 def axial_induction(
     velocities: NDArrayFloat,  # (wind directions, wind speeds, turbines, grid, grid)
     yaw_angle: NDArrayFloat,  # (wind directions, wind speeds, turbines)
-    fCt: NDArrayObject,  # (turbines)
+    fCt: dict,  # (turbines)
     turbine_type_map: NDArrayObject, # (wind directions, 1, turbines)
     ix_filter: NDArrayFilter | Iterable[int] | None = None,
 ) -> NDArrayFloat:

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -266,7 +266,7 @@ def average_velocity(velocities: NDArrayFloat, ix_filter: NDArrayFilter | Iterab
 
 
 @define
-class PowerThrustTable(FromDictMixin):
+class PowerThrustTable(BaseClass):
     """Helper class to convert the dictionary and list-based inputs to a object of arrays.
 
     Args:
@@ -288,11 +288,11 @@ class PowerThrustTable(FromDictMixin):
         inputs = (self.power, self.thrust, self.wind_speed)
 
         if any(el.ndim > 1 for el in inputs):
-            raise ValueError("power, thrust, and wind_speed inputs must be 1-D.")
+            self.error(ValueError, "power, thrust, and wind_speed inputs must be 1-D.")
 
-        if len( set( (self.power.size, self.thrust.size, self.wind_speed.size) ) ) > 1:        
-            raise ValueError("power, thrust, and wind_speed tables must be the same size.")
-        
+        if len( set( (self.power.size, self.thrust.size, self.wind_speed.size) ) ) > 1:
+            self.error(ValueError, "power, thrust, and wind_speed tables must be the same size.")
+
         # Remove any duplicate wind speed entries
         _, duplicate_filter = np.unique(self.wind_speed, return_index=True)
         object.__setattr__(self, "power", self.power[duplicate_filter])
@@ -403,7 +403,7 @@ class Turbine(BaseClass):
     @rotor_diameter.validator
     def reset_rotor_diameter_dependencies(self, instance: attrs.Attribute, value: float) -> None:
         """Resets the `rotor_radius` and `rotor_area` attributes."""
-        # Temporarily turn off validators to avoid infinite recursion
+        # Temporarily turn off validators to avoid infinite recursion with the `reset_rotor_radius` validator
         with attrs.validators.disabled():
             # Reset the values
             self.rotor_radius = value / 2.0

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -13,20 +13,21 @@
 # See https://floris.readthedocs.io for documentation
 
 from __future__ import annotations
+
 from collections.abc import Iterable
 
 import attrs
-from attrs import define, field
 import numpy as np
+from attrs import field, define
 from scipy.interpolate import interp1d
 
 from floris.type_dec import (
-    floris_array_converter,
-    NDArrayFloat,
-    NDArrayFilter,
     NDArrayInt,
-    NDArrayObject,
+    NDArrayFloat,
     FromDictMixin,
+    NDArrayFilter,
+    NDArrayObject,
+    floris_array_converter,
 )
 from floris.utilities import cosd
 from floris.simulation import BaseClass
@@ -82,7 +83,7 @@ def power(
     ref_density_cp_ct: float,
     velocities: NDArrayFloat,
     yaw_angle: NDArrayFloat,
-    pP: float,
+    pP: NDArrayFloat,
     power_interp: NDArrayObject,
     turbine_type_map: NDArrayObject,
     ix_filter: NDArrayInt | Iterable[int] | None = None,
@@ -237,7 +238,7 @@ def axial_induction(
     return 0.5 / cosd(yaw_angle) * (1 - np.sqrt(1 - thrust_coefficient * cosd(yaw_angle)))
 
 
-def average_velocity(velocities: NDArrayFloat, ix_filter: NDArrayFilter | Iterable[int] | None = None) -> NDArrayFloat:
+def average_velocity(velocities: NDArrayFloat, ix_filter: NDArrayFilter | list[int] | None = None) -> NDArrayFloat:
     """This property calculates and returns the cube root of the
     mean cubed velocity in the turbine's rotor swept area (m/s).
 
@@ -348,9 +349,7 @@ class Turbine(BaseClass):
     TSR: float
     generator_efficiency: float
     ref_density_cp_ct: float
-    power_thrust_table: PowerThrustTable = field(converter=PowerThrustTable.from_dict)
-
-
+    power_thrust_table: PowerThrustTable = field(converter=PowerThrustTable.from_dict)  # type: ignore
 
     # rloc: float = float_attrib()  # TODO: goes here or on the Grid?
     # use_points_on_perimeter: bool = bool_attrib()
@@ -390,7 +389,7 @@ class Turbine(BaseClass):
         Given an array of wind speeds, this function returns an array of the interpolated thrust coefficients
         from the power / thrust table used to define the Turbine. The values are bound by the range of the input values.
         Any requested wind speeds outside of the range of input wind speeds are assigned Ct of 0.0001 or 0.9999.
-        
+
         The fill_value arguments sets (upper, lower) bounds for any values outside of the input range
         """
         self.fCt_interp = interp1d(

--- a/floris/simulation/wake.py
+++ b/floris/simulation/wake.py
@@ -130,12 +130,12 @@ class WakeModelManager(BaseClass):
         # Check that all required strings are given
         for s in required_strings:
             if s not in value.keys():
-                raise KeyError(f"Wake: '{s}' not provided in the input but it is required.")
+                self.error(KeyError, f"Wake: '{s}' not provided in the input but it is required.")
 
         # Check that no other strings are given
         for k in value.keys():
             if k not in required_strings:
-                raise KeyError(f"Wake: '{k}' was given as input but it is not a valid option. Required inputs are: {', '.join(required_strings)}")
+                self.error(KeyError, f"Wake: '{k}' was given as input but it is not a valid option. Required inputs are: {', '.join(required_strings)}")
 
     @property
     def deflection_function(self):

--- a/floris/simulation/wake.py
+++ b/floris/simulation/wake.py
@@ -13,26 +13,26 @@
 # See https://floris.readthedocs.io for documentation
 
 import attrs
-from attrs import define, field
+from attrs import field, define
 
 from floris.simulation import BaseClass, BaseModel
-from floris.simulation.wake_deflection import (
-    GaussVelocityDeflection,
-    JimenezVelocityDeflection,
-    NoneVelocityDeflection,
-)
-from floris.simulation.wake_combination import FLS, MAX, SOSFS
-from floris.simulation.wake_turbulence import CrespoHernandez, NoneWakeTurbulence
 from floris.simulation.wake_velocity import (
     NoneVelocityDeficit,
-    CumulativeGaussCurlVelocityDeficit,
     GaussVelocityDeficit,
     JensenVelocityDeficit,
     TurbOParkVelocityDeficit,
+    CumulativeGaussCurlVelocityDeficit,
 )
+from floris.simulation.wake_deflection import (
+    NoneVelocityDeflection,
+    GaussVelocityDeflection,
+    JimenezVelocityDeflection,
+)
+from floris.simulation.wake_turbulence import CrespoHernandez, NoneWakeTurbulence
+from floris.simulation.wake_combination import FLS, MAX, SOSFS
 
 
-MODEL_MAP = {
+MODEL_MAP: dict = {
     "combination_model": {
         "fls": FLS,
         "max": MAX,
@@ -85,39 +85,41 @@ class WakeModelManager(BaseClass):
     velocity_model: BaseModel = field(init=False)
 
     def __attrs_post_init__(self) -> None:
-        model: BaseModel = MODEL_MAP["velocity_model"][self.model_strings["velocity_model"]]
+        model: BaseModel
+
+        model = MODEL_MAP["velocity_model"][self.model_strings["velocity_model"]]
         if self.model_strings["velocity_model"].lower() == "none":
             model_parameters = None
         else:
             model_parameters = self.wake_velocity_parameters[self.model_strings["velocity_model"]]
         if model_parameters is None:
             # Use model defaults
-            self.velocity_model = model()
+            self.velocity_model = model()  # type: ignore
         else:
             self.velocity_model = model.from_dict(model_parameters)
 
-        model: BaseModel = MODEL_MAP["deflection_model"][self.model_strings["deflection_model"]]
+        model = MODEL_MAP["deflection_model"][self.model_strings["deflection_model"]]
         if self.model_strings["deflection_model"].lower() == "none":
             model_parameters = None
         else:
             model_parameters = self.wake_deflection_parameters[self.model_strings["deflection_model"]]
         if model_parameters is None:
-            self.deflection_model = model()
+            self.deflection_model = model()  # type: ignore
         else:
             self.deflection_model = model.from_dict(model_parameters)
 
-        model: BaseModel = MODEL_MAP["turbulence_model"][self.model_strings["turbulence_model"]]
+        model = MODEL_MAP["turbulence_model"][self.model_strings["turbulence_model"]]
         if self.model_strings["turbulence_model"].lower() == "none":
             model_parameters = None
         else:
             model_parameters = self.wake_turbulence_parameters[self.model_strings["turbulence_model"]]
         if model_parameters is None:
-            self.turbulence_model = model()
+            self.turbulence_model = model()  # type: ignore
         else:
             self.turbulence_model = model.from_dict(model_parameters)
 
-        model: BaseModel = MODEL_MAP["combination_model"][self.model_strings["combination_model"]]
-        self.combination_model = model()
+        model = MODEL_MAP["combination_model"][self.model_strings["combination_model"]]
+        self.combination_model = model()  # type: ignore
 
     @model_strings.validator
     def validate_model_strings(self, instance: attrs.Attribute, value: dict) -> None:

--- a/floris/simulation/wake_combination/fls.py
+++ b/floris/simulation/wake_combination/fls.py
@@ -23,7 +23,7 @@ class FLS(BaseModel):
     deficits to the freestream flow field.
     """
 
-    def prepare_function(self) -> dict:
+    def prepare_function(self) -> dict:  # type: ignore
         pass
 
     def function(  # type: ignore

--- a/floris/simulation/wake_combination/fls.py
+++ b/floris/simulation/wake_combination/fls.py
@@ -10,8 +10,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from attrs import define
 import numpy as np
+from attrs import define
 
 from floris.simulation import BaseModel
 
@@ -26,7 +26,11 @@ class FLS(BaseModel):
     def prepare_function(self) -> dict:
         pass
 
-    def function(self, wake_field: np.ndarray, velocity_field: np.ndarray):
+    def function(  # type: ignore
+        self,
+        wake_field: np.ndarray,
+        velocity_field: np.ndarray
+    ) -> np.ndarray:
         """
         Combines the base flow field with the velocity deficits
         using freestream linear superpostion. In other words, the wake

--- a/floris/simulation/wake_combination/max.py
+++ b/floris/simulation/wake_combination/max.py
@@ -10,8 +10,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from attrs import define
 import numpy as np
+from attrs import define
 
 from floris.simulation import BaseModel
 
@@ -33,7 +33,11 @@ class MAX(BaseModel):
     def prepare_function(self) -> dict:
         pass
 
-    def function(self, wake_field: np.ndarray, velocity_field: np.ndarray):
+    def function(  # type: ignore
+        self,
+        wake_field: np.ndarray,
+        velocity_field: np.ndarray,
+    ) -> np.ndarray:
         """
         Incorporates the velicty deficits into the base flow field by
         selecting the maximum of the two for each point.

--- a/floris/simulation/wake_combination/max.py
+++ b/floris/simulation/wake_combination/max.py
@@ -30,7 +30,7 @@ class MAX(BaseModel):
             :keyprefix: max-
     """
 
-    def prepare_function(self) -> dict:
+    def prepare_function(self) -> dict:  # type: ignore
         pass
 
     def function(  # type: ignore

--- a/floris/simulation/wake_combination/sosfs.py
+++ b/floris/simulation/wake_combination/sosfs.py
@@ -24,7 +24,7 @@ class SOSFS(BaseModel):
     wake velocity deficits to the base flow field.
     """
 
-    def prepare_function(self) -> dict:
+    def prepare_function(self) -> dict:  # type: ignore
         pass
 
     def function(  # type: ignore

--- a/floris/simulation/wake_combination/sosfs.py
+++ b/floris/simulation/wake_combination/sosfs.py
@@ -10,9 +10,10 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from attrs import define
 import numpy as np
+from attrs import define
 
+from floris.type_dec import NDArrayFloat
 from floris.simulation import BaseModel
 
 
@@ -26,7 +27,11 @@ class SOSFS(BaseModel):
     def prepare_function(self) -> dict:
         pass
 
-    def function(self, wake_field: np.ndarray, velocity_field: np.ndarray):
+    def function(  # type: ignore
+        self,
+        wake_field: np.ndarray,
+        velocity_field: np.ndarray,
+    ) -> NDArrayFloat:
         """
         Combines the base flow field with the velocity defecits
         using sum of squares.

--- a/floris/simulation/wake_deflection/gauss.py
+++ b/floris/simulation/wake_deflection/gauss.py
@@ -12,15 +12,11 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+from attrs import field, define
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
-from floris.utilities import cosd, sind
+from floris.utilities import cosd, sind, tand
+from floris.simulation import Farm, Grid, Turbine, BaseModel, FlowField
 
 
 @define
@@ -80,7 +76,7 @@ class GaussVelocityDeflection(BaseModel):
     eps_gain: float = field(converter=float, default=0.2)
     use_secondary_steering: bool = field(converter=bool, default=True)
 
-    def prepare_function(
+    def prepare_function(  # type: ignore
         self,
         grid: Grid,
         flow_field: FlowField,
@@ -96,14 +92,14 @@ class GaussVelocityDeflection(BaseModel):
         return kwargs
 
     # @profile
-    def function(
+    def function(  # type: ignore
         self,
         x_i: np.ndarray,
         y_i: np.ndarray,
         yaw_i: np.ndarray,
         turbulence_intensity_i: np.ndarray,
         ct_i: np.ndarray,
-        rotor_diameter_i: float,
+        rotor_diameter_i: np.ndarray,
         *,
         x: np.ndarray,
         y: np.ndarray,

--- a/floris/simulation/wake_deflection/none.py
+++ b/floris/simulation/wake_deflection/none.py
@@ -12,12 +12,10 @@
 
 from typing import Any, Dict
 
-from attrs import define
 import numpy as np
+from attrs import define
 
-from floris.simulation import BaseModel
-from floris.simulation import FlowField
-from floris.simulation import Grid
+from floris.simulation import Grid, BaseModel, FlowField
 
 
 @define
@@ -27,7 +25,7 @@ class NoneVelocityDeflection(BaseModel):
     deflection and returns an array of zeroes.
     """
 
-    def prepare_function(
+    def prepare_function(  # type: ignore
         self,
         grid: Grid,
         flow_field: FlowField,
@@ -38,7 +36,7 @@ class NoneVelocityDeflection(BaseModel):
         )
         return kwargs
 
-    def function(
+    def function(  # type: ignore
         self,
         x_i: np.ndarray,
         y_i: np.ndarray,

--- a/floris/simulation/wake_turbulence/crespo_hernandez.py
+++ b/floris/simulation/wake_turbulence/crespo_hernandez.py
@@ -54,7 +54,7 @@ class CrespoHernandez(BaseModel):
     ai: float = field(converter=float, default=0.8)
     downstream: float = field(converter=float, default=-0.32)
 
-    def prepare_function(self) -> dict:
+    def prepare_function(self) -> dict:  # type: ignore
         pass
 
     def function(  # type: ignore

--- a/floris/simulation/wake_turbulence/crespo_hernandez.py
+++ b/floris/simulation/wake_turbulence/crespo_hernandez.py
@@ -12,15 +12,11 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+from attrs import field, define
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
-from floris.utilities import cosd, sind
+from floris.utilities import cosd, sind, tand
+from floris.simulation import Farm, Grid, Turbine, BaseModel, FlowField
 
 
 @define
@@ -61,12 +57,12 @@ class CrespoHernandez(BaseModel):
     def prepare_function(self) -> dict:
         pass
 
-    def function(
+    def function(  # type: ignore
         self,
         ambient_TI: float,
         x: np.ndarray,
         x_i: np.ndarray,
-        rotor_diameter: float,
+        rotor_diameter: np.ndarray,
         axial_induction: np.ndarray,
     ) -> None:
         # Replace zeros and negatives with 1 to prevent nans/infs

--- a/floris/simulation/wake_turbulence/none.py
+++ b/floris/simulation/wake_turbulence/none.py
@@ -26,7 +26,7 @@ class NoneWakeTurbulence(BaseModel):
     any wake turbulence and just returns an array of the ambient TIs.
     """
 
-    def prepare_function(self) -> dict:
+    def prepare_function(self) -> dict:  # type: ignore
         pass
 
     def function(  # type: ignore

--- a/floris/simulation/wake_turbulence/none.py
+++ b/floris/simulation/wake_turbulence/none.py
@@ -12,9 +12,10 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+from attrs import field, define
 
+from floris.type_dec import NDArrayFloat
 from floris.simulation import BaseModel
 
 
@@ -28,14 +29,14 @@ class NoneWakeTurbulence(BaseModel):
     def prepare_function(self) -> dict:
         pass
 
-    def function(
+    def function(  # type: ignore
         self,
         ambient_TI: float,
         x: np.ndarray,
         x_i: np.ndarray,
         rotor_diameter: float,
         axial_induction: np.ndarray,
-    ) -> None:
+    ) -> NDArrayFloat:
         """Return unchanged field of turbulence intensities"""
         self.logger.info(
             "The wake-turbulence model is set to 'none'. Turbulence model disabled."

--- a/floris/simulation/wake_velocity/cumulative_gauss_curl.py
+++ b/floris/simulation/wake_velocity/cumulative_gauss_curl.py
@@ -12,16 +12,15 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+import numexpr as ne
+from attrs import field, define
+from numpy import newaxis as na
 from scipy.special import gamma
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
-from floris.utilities import cosd, sind, tand
+from floris.type_dec import NDArrayFloat
+from floris.utilities import cosd, sind, tand, pshape
+from floris.simulation import Farm, Grid, Turbine, BaseModel, FlowField
 
 
 @define
@@ -36,7 +35,7 @@ class CumulativeGaussCurlVelocityDeficit(BaseModel):
     c_f: float = field(default=2.41)
     alpha_mod: float = field(default=1.0)
 
-    def prepare_function(
+    def prepare_function(  # type: ignore
         self,
         grid: Grid,
         flow_field: FlowField,
@@ -50,7 +49,7 @@ class CumulativeGaussCurlVelocityDeficit(BaseModel):
         )
         return kwargs
 
-    def function(
+    def function(  # type: ignore
         self,
         ii: int,
         x_i: np.ndarray,
@@ -71,7 +70,7 @@ class CumulativeGaussCurlVelocityDeficit(BaseModel):
         y: np.ndarray,
         z: np.ndarray,
         u_initial: np.ndarray,
-    ) -> None:
+    ) -> tuple[NDArrayFloat, NDArrayFloat]:
 
         turbine_Ct = ct
         turbine_ti = turbulence_intensity
@@ -154,7 +153,7 @@ class CumulativeGaussCurlVelocityDeficit(BaseModel):
         #     Z = (z_i_loc - z_coord) ** 2 / (2 * S)
 
         #     lbda = self.alpha_mod * sigma_i[0:ii-1, :, :, :, :, :] ** 2 / S * np.exp(-Y) * np.exp(-Z)
-        #     sum_lbda = np.sum(lbda * (Ctmp[0:ii-1, :, :, :, :, :] / u_initial), axis=0)       
+        #     sum_lbda = np.sum(lbda * (Ctmp[0:ii-1, :, :, :, :, :] / u_initial), axis=0)
         # else:
         #     sum_lbda = 0.0
 

--- a/floris/simulation/wake_velocity/jensen.py
+++ b/floris/simulation/wake_velocity/jensen.py
@@ -12,15 +12,11 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
-import numexpr as ne
 import numpy as np
+import numexpr as ne
+from attrs import field, define
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
+from floris.simulation import Farm, Grid, Turbine, BaseModel, FlowField
 
 
 @define
@@ -43,7 +39,7 @@ class JensenVelocityDeficit(BaseModel):
 
     we: float = field(converter=float, default=0.05)
 
-    def prepare_function(
+    def prepare_function(  # type: ignore
         self,
         grid: Grid,
         flow_field: FlowField,
@@ -63,7 +59,7 @@ class JensenVelocityDeficit(BaseModel):
         return kwargs
 
     # @profile
-    def function(
+    def function(  # type: ignore
         self,
         x_i: np.ndarray,
         y_i: np.ndarray,
@@ -142,10 +138,9 @@ class JensenVelocityDeficit(BaseModel):
 
         # C should be 0 everywhere outside of the lateral and vertical bounds defined by the wake expansion parameter
         boundary_mask = ne.evaluate("sqrt(dy ** 2 + dz ** 2) < boundary_line")
-        
+
         mask = np.logical_and(downstream_mask, boundary_mask)
-        c[~mask] = 0.0
-        # c = ne.evaluate("c * downstream_mask * boundary_mask")
+        c = ne.evaluate("c * downstream_mask * boundary_mask")
 
         velocity_deficit = ne.evaluate("2 * axial_induction_i * c")
 

--- a/floris/simulation/wake_velocity/none.py
+++ b/floris/simulation/wake_velocity/none.py
@@ -12,12 +12,10 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+from attrs import field, define
 
-from floris.simulation import BaseModel
-from floris.simulation import FlowField
-from floris.simulation import Grid
+from floris.simulation import Grid, BaseModel, FlowField
 
 
 @define
@@ -26,8 +24,8 @@ class NoneVelocityDeficit(BaseModel):
     The None deficit model is a placeholder code that simple ignores any
     wake wind speed deficits and returns an array of zeroes.
     """
-    
-    def prepare_function(
+
+    def prepare_function(  # type: ignore
         self,
         grid: Grid,
         flow_field: FlowField,
@@ -38,7 +36,7 @@ class NoneVelocityDeficit(BaseModel):
         )
         return kwargs
 
-    def function(
+    def function(  # type: ignore
         self,
         x_i: np.ndarray,
         y_i: np.ndarray,
@@ -54,6 +52,6 @@ class NoneVelocityDeficit(BaseModel):
         # unpacking of the results from prepare_function()
         *,
         u_initial: np.ndarray,
-    ) -> None:
+    ) -> np.ndarray:
         self.logger.warning("The wake deficit model is set to 'none'. Wake modeling disabled.")
         return np.zeros_like(u_initial)

--- a/floris/simulation/wake_velocity/turbopark.py
+++ b/floris/simulation/wake_velocity/turbopark.py
@@ -10,21 +10,18 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+import os
 from typing import Any, Dict
-
-from attrs import define, field
-import numpy as np
 from pathlib import Path
+
+import numpy as np
+import scipy.io
+from attrs import field, define
 from scipy import integrate
 from scipy.interpolate import RegularGridInterpolator
-import scipy.io
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
-from floris.utilities import cosd, sind, tand
+from floris.type_dec import NDArrayFloat
+from floris.simulation import Grid, BaseModel, FlowField
 
 
 @define
@@ -47,7 +44,7 @@ class TurbOParkVelocityDeficit(BaseModel):
         overlap_gauss = lookup_table_file['overlap_lookup_table'][0][0][2]
         self.overlap_gauss_interp = RegularGridInterpolator((dist, radius_down), overlap_gauss, method='linear', bounds_error=False)
 
-    def prepare_function(
+    def prepare_function(  # type: ignore
         self,
         grid: Grid,
         flow_field: FlowField,
@@ -62,7 +59,7 @@ class TurbOParkVelocityDeficit(BaseModel):
         return kwargs
 
     # @profile
-    def function(
+    def function(  # type: ignore
         self,
         x_i: np.ndarray,
         y_i: np.ndarray,
@@ -80,7 +77,7 @@ class TurbOParkVelocityDeficit(BaseModel):
         y: np.ndarray,
         z: np.ndarray,
         u_initial: np.ndarray,
-    ) -> None:
+    ) -> NDArrayFloat:
         delta_total = np.zeros_like(u_initial)
 
         # Normalized distances along x between the turbine i and all other turbines
@@ -120,7 +117,7 @@ class TurbOParkVelocityDeficit(BaseModel):
 
         delta_total[:, :, i, :, :] = np.sqrt(np.sum(np.nan_to_num(delta)**2, axis=2))
 
-        return delta_total          
+        return delta_total
 
 
 def precalculate_overlap():

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -57,7 +57,7 @@ class FlorisInterface(LoggerBase):
             self.floris = Floris.from_dict(self.configuration)
 
         else:
-            raise TypeError("The Floris `configuration` must be of type 'dict', 'str', or 'Path'.")
+            self.error(TypeError, "The Floris `configuration` must be of type 'dict', 'str', or 'Path'.")
 
         # Store the heterogeneous map for use after reinitailization
         self.het_map = het_map
@@ -71,15 +71,17 @@ class FlorisInterface(LoggerBase):
 
         # Make a check on reference height and provide a helpful warning
         unique_heights = np.unique(self.floris.farm.hub_heights)
-        if (len(unique_heights) == 1) and (self.floris.flow_field.reference_wind_height != unique_heights[0]):
+        if len(unique_heights) == 1 and self.floris.flow_field.reference_wind_height != unique_heights[0]:
             err_msg = "The only unique hub-height is not the equal to the specified reference wind height.  If this was unintended use -1 as the reference hub height to indicate use of hub-height as reference wind height."
             self.logger.warning(err_msg, stack_info=True)
 
         # Check the turbine_grid_points is reasonable
         if self.floris.solver["type"] == "turbine_grid":
             if self.floris.solver["turbine_grid_points"] > 3:
-                self.logger.error(f"turbine_grid_points value is {self.floris.solver['turbine_grid_points']} which is larger than the recommended value of less than or equal to 3. High amounts of turbine grid points reduce the computational performance but have a small change on accuracy.")
-                raise ValueError("turbine_grid_points must be less than or equal to 3.")
+                self.error(
+                    ValueError,
+                    f"turbine_grid_points value is {self.floris.solver['turbine_grid_points']} which is larger than the recommended value of less than or equal to 3. High amounts of turbine grid points reduce the computational performance but have a small change on accuracy."
+                )
 
     def assign_hub_height_to_ref_height(self):
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -152,8 +152,8 @@ class FlorisInterface(LoggerBase):
         """
 
         # TODO decide where to handle this sign issue
-        if (yaw_angles is not None) and not (np.all(yaw_angles==0.)):
-            self.floris.farm.yaw_angles = yaw_angles
+        if (yaw_angles is not None) and not (np.all(yaw_angles == 0.0)):
+            self.floris.farm.yaw_angles = yaw_angles  # type: ignore
 
         # Initialize solution space
         self.floris.initialize_domain()

--- a/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
@@ -19,10 +19,7 @@ from time import perf_counter as timerpc
 import numpy as np
 import pandas as pd
 
-from .yaw_optimization_tools import (
-    derive_downstream_turbines,
-    find_layout_symmetry,
-)
+from .yaw_optimization_tools import find_layout_symmetry, derive_downstream_turbines
 
 
 class YawOptimization:
@@ -439,9 +436,9 @@ class YawOptimization:
                 print("Exploitation of symmetry has been disabled.")
 
             self._sym_mapping_extrap = np.array(
-                [np.where(np.abs(x - wd_array_min) < 0.0001)[0][0] 
+                [np.where(np.abs(x - wd_array_min) < 0.0001)[0][0]
                 for x in wd_array_remn], dtype=int)
-            
+
             self._sym_mapping_reduce = copy.deepcopy(ids_minimal)
             self._sym_df = df
 
@@ -451,7 +448,7 @@ class YawOptimization:
         # Check if needed to un-reduce at all, if not, return directly
         if not self.exploit_layout_symmetry:
             return variable
-    
+
         if self._sym_df is None:
             return variable
 
@@ -572,8 +569,7 @@ class YawOptimization:
         ids = np.where((ydiff < min_yaw_offset) & (ydiff > 0.0))
         if len(ids[0]) > 0:
             if verbose:
-                print("Rounding {:d} insignificant yaw angles to their " +
-                "baseline value.".format(len(ids)))
+                print(f"Rounding {len(ids):d} insignificant yaw angles to their baseline value.")
             yaw_angles_opt_subset[ids] = yaw_angles_baseline_subset[ids]
             ydiff[ids] = 0.0
 

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -231,7 +231,7 @@ def visualize_quiver(cut_plane, ax=None, minSpeed=None, maxSpeed=None, downSamp=
     # ax.set_aspect('equal')
 
 
-def reverse_cut_plane_x_axis_in_plot(ax):
+def reverse_cut_plane_x_axis_in_plot(ax) -> None:
     """
     Shortcut method to reverse direction of x-axis.
 
@@ -239,6 +239,7 @@ def reverse_cut_plane_x_axis_in_plot(ax):
         ax (:py:class:`matplotlib.pyplot.axes`): Figure axes.
     """
     ax.invert_xaxis()
+    return
 
 
 def plot_rotor_values(
@@ -315,3 +316,5 @@ def plot_rotor_values(
 
     if show:
         plt.show()
+
+    return None

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -12,12 +12,12 @@
 
 # See https://floris.readthedocs.io for documentation
 
-from typing import Any, Iterable, Tuple, Union, Callable
+from typing import Any, Tuple, Union, Callable, Iterable
 
 import attrs
-from attrs import define, Attribute
 import numpy as np
 import numpy.typing as npt
+from attrs import Attribute, define
 
 
 ### Define general data types used throughout
@@ -98,15 +98,15 @@ class FromDictMixin:
                 The `attr`-defined class.
         """
         # Check for any inputs that aren't part of the class definition
-        class_attr_names = [a.name for a in cls.__attrs_attrs__]
+        class_attr_names = [a.name for a in cls.__attrs_attrs__]  # type: ignore
         extra_args = [d for d in data if d not in class_attr_names]
         if len(extra_args):
             raise AttributeError(f"The initialization for {cls.__name__} was given extraneous inputs: {extra_args}")
 
-        kwargs = {a.name: data[a.name] for a in cls.__attrs_attrs__ if a.name in data and a.init}
+        kwargs = {a.name: data[a.name] for a in cls.__attrs_attrs__ if a.name in data and a.init}  # type: ignore
 
         # Map the inputs must be provided: 1) must be initialized, 2) no default value defined
-        required_inputs = [a.name for a in cls.__attrs_attrs__ if a.init and a.default is attrs.NOTHING]
+        required_inputs = [a.name for a in cls.__attrs_attrs__ if a.init and a.default is attrs.NOTHING]  # type: ignore
         undefined = sorted(set(required_inputs) - set(kwargs))
 
         if undefined:
@@ -158,4 +158,3 @@ class FromDictMixin:
 #     kw_only=True,
 # )
 # update_wrapper(int_attrib, attr.ib)
-

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -12,14 +12,14 @@
 
 # See https://floris.readthedocs.io for documentation
 
+import os
 from typing import Tuple
 
-from attrs import define, field
-import numpy as np
 import yaml
-import os
+import numpy as np
+from attrs import field, define
 
-from floris.type_dec import floris_array_converter, NDArrayFloat
+from floris.type_dec import NDArrayFloat, floris_array_converter
 
 
 def pshape(array: np.ndarray, label: str = ""):
@@ -42,7 +42,7 @@ class Vec3:
     # NOTE: this does not convert elements to float if they are given as int. Is this ok?
 
     @components.validator
-    def _check_components(self, attribute, value) -> None:        
+    def _check_components(self, attribute, value) -> None:
         if np.ndim(value) > 1:
             raise ValueError(f"Vec3 must contain exactly 1 dimension, {np.ndim(value)} were given.")
         if np.size(value) != 3:
@@ -111,7 +111,7 @@ class Vec3:
         self.components[2] = float(value)
 
     @property
-    def elements(self) -> Tuple[float, float, float]:
+    def elements(self) -> NDArrayFloat:
         # TODO: replace references to elements with components
         # and remove this @property
         return self.components

--- a/tests/farm_unit_test.py
+++ b/tests/farm_unit_test.py
@@ -42,6 +42,13 @@ def test_farm_init_homogenous_turbines():
     # turbine_type=[turbine_data["turbine_type"]]
 
     farm.construct_hub_heights()
+    farm.construct_rotor_diameters()
+    farm.construct_turbine_TSRs()
+    farm.construc_turbine_pPs()
+    farm.construct_turbine_map()
+    farm.construct_turbine_fCts()
+    farm.construct_turbine_fCps()
+    farm.construct_turbine_power_interps()
     farm.construct_coordinates()
     farm.set_yaw_angles(N_WIND_DIRECTIONS, N_WIND_SPEEDS)
 
@@ -54,14 +61,29 @@ def test_farm_init_homogenous_turbines():
 def test_asdict(sample_inputs_fixture: SampleInputs):
     farm = Farm.from_dict(sample_inputs_fixture.farm)
     farm.construct_hub_heights()
+    farm.construct_rotor_diameters()
+    farm.construct_turbine_TSRs()
+    farm.construc_turbine_pPs()
+    farm.construct_turbine_map()
+    farm.construct_turbine_fCts()
+    farm.construct_turbine_fCps()
+    farm.construct_turbine_power_interps()
     farm.construct_coordinates()
     farm.set_yaw_angles(N_WIND_DIRECTIONS, N_WIND_SPEEDS)
     dict1 = farm.as_dict()
 
     new_farm = farm.from_dict(dict1)
     new_farm.construct_hub_heights()
+    new_farm.construct_rotor_diameters()
+    new_farm.construct_turbine_TSRs()
+    new_farm.construc_turbine_pPs()
+    new_farm.construct_turbine_map()
+    new_farm.construct_turbine_fCts()
+    new_farm.construct_turbine_fCps()
+    new_farm.construct_turbine_power_interps()
     new_farm.construct_coordinates()
     new_farm.set_yaw_angles(N_WIND_DIRECTIONS, N_WIND_SPEEDS)
     dict2 = new_farm.as_dict()
 
     assert dict1 == dict2
+

--- a/tests/logging_manager_unit_test.py
+++ b/tests/logging_manager_unit_test.py
@@ -1,0 +1,115 @@
+# Copyright 2022 NREL
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# See https://floris.readthedocs.io for documentation
+
+import copy
+import logging
+from pathlib import Path
+
+import yaml
+import floris.logging_manager
+from floris.simulation import Floris
+
+
+TEST_DATA = Path(__file__).resolve().parent / "data"
+YAML_INPUT = TEST_DATA / "input_full_v3.yaml"
+DICT_INPUT = yaml.load(open(YAML_INPUT, "r"), Loader=yaml.SafeLoader)
+
+
+def test_configure_console_log():
+
+    logger = logging.getLogger(name="floris")
+
+    # Enable console logging at INFO level
+    test_level  = "INFO"
+    floris.logging_manager.configure_console_log(enabled=True, level=test_level)
+
+    ## The number of handlers should always be 0, 1, or 2. In this case, either 1 or 2 since we've added one above.
+    assert 0 < len(logger.handlers) <= 2
+
+    ## Find the console logger - its a StreamHandler class
+    console_logger = None
+    for h in logger.handlers:
+        if isinstance(h, logging.StreamHandler):
+            console_logger = h
+    
+    ## The level should be set to the value above.
+    ## The nameToLevel dictionary converts the string to a numeric value used in the logging library
+    assert console_logger.level == logging._nameToLevel[test_level]
+
+
+    # Change the logging level to ERROR
+    test_level  = "ERROR"
+    floris.logging_manager.configure_console_log(enabled=True, level=test_level)
+    assert 0 < len(logger.handlers) <= 2
+    console_logger = None
+    for h in logger.handlers:
+        if isinstance(h, logging.StreamHandler):
+            console_logger = h
+    assert console_logger.level == logging._nameToLevel[test_level]
+
+
+    # Disbale console logging
+    floris.logging_manager.configure_console_log(enabled=False)
+
+    ## Here, there should be only 0 or 1 handlers
+    assert 0 <= len(logger.handlers) < 2
+
+    ## Search for a console logger - its an error if one is found
+    console_logger = None
+    for h in logger.handlers:
+        assert not isinstance(h, logging.StreamHandler)
+
+
+def test_configure_file_log():
+
+    logger = logging.getLogger(name="floris")
+
+    # Enable file logging at INFO level
+    test_level  = "INFO"
+    floris.logging_manager.configure_file_log(enabled=True, level=test_level)
+
+    ## The number of handlers should always be 0, 1, or 2. In this case, either 1 or 2 since we've added one above.
+    assert 0 < len(logger.handlers) <= 2
+
+    ## Find the file logger - its a FileHandler class
+    file_logger = None
+    for h in logger.handlers:
+        if isinstance(h, logging.FileHandler):
+            file_logger = h
+    
+    ## The level should be set to the value above.
+    ## The nameToLevel dictionary converts the string to a numeric value used in the logging library
+    assert file_logger.level == logging._nameToLevel[test_level]
+
+
+    # Change the logging level to ERROR
+    test_level  = "ERROR"
+    floris.logging_manager.configure_file_log(enabled=True, level=test_level)
+    assert 0 < len(logger.handlers) <= 2
+    file_logger = None
+    for h in logger.handlers:
+        if isinstance(h, logging.FileHandler):
+            file_logger = h
+    assert file_logger.level == logging._nameToLevel[test_level]
+
+
+    # Disbale file logging
+    floris.logging_manager.configure_file_log(enabled=False)
+
+    ## Here, there should be only 0 or 1 handlers
+    assert 0 <= len(logger.handlers) < 2
+
+    ## Search for a file logger - its an error if one is found
+    file_logger = None
+    for h in logger.handlers:
+        assert not isinstance(h, logging.FileHandler)

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -223,7 +223,7 @@ def test_ct():
     thrust = Ct(
         velocities=wind_speed * np.ones((1, 1, 1, 3, 3)),
         yaw_angle=np.zeros((1, 1, 1)),
-        fCt=np.array([(turbine.turbine_type, turbine.fCt_interp)]),
+        fCt={turbine.turbine_type: turbine.fCt_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
 
@@ -235,7 +235,7 @@ def test_ct():
     thrusts = Ct(
         velocities=np.ones((N_TURBINES, 3, 3)) * WIND_CONDITION_BROADCAST,  # 3 x 4 x 4 x 3 x 3
         yaw_angle=np.zeros((1, 1, N_TURBINES)),
-        fCt=np.array([(turbine.turbine_type, turbine.fCt_interp)]),
+        fCt={turbine.turbine_type: turbine.fCt_interp},
         turbine_type_map=turbine_type_map,
         ix_filter=INDEX_FILTER,
     )
@@ -263,7 +263,7 @@ def test_power():
         velocities=wind_speed * np.ones((1, 1, 1, 3, 3)),
         yaw_angle=np.zeros((1, 1, 1)),
         pP=turbine.pP * np.ones((1, 1, 1)),
-        power_interp=np.array([(turbine.turbine_type, turbine.fCp_interp)]),
+        power_interp={turbine.turbine_type: turbine.fCp_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
 
@@ -312,7 +312,7 @@ def test_axial_induction():
     ai = axial_induction(
         velocities=wind_speed * np.ones((1, 1, 1, 3, 3)),
         yaw_angle=np.zeros((1, 1, 1)),
-        fCt=np.array([(turbine.turbine_type, turbine.fCt_interp)]),
+        fCt={turbine.turbine_type: turbine.fCt_interp},
         turbine_type_map=turbine_type_map[0,0,0],
     )
     np.testing.assert_allclose(ai, baseline_ai)
@@ -321,7 +321,7 @@ def test_axial_induction():
     ai = axial_induction(
         velocities=np.ones((N_TURBINES, 3, 3)) * WIND_CONDITION_BROADCAST,  # 3 x 4 x 4 x 3 x 3
         yaw_angle=np.zeros((1, 1, N_TURBINES)),
-        fCt=np.array([(turbine.turbine_type, turbine.fCt_interp)]),
+        fCt={turbine.turbine_type: turbine.fCt_interp},
         turbine_type_map=turbine_type_map,
         ix_filter=INDEX_FILTER,
     )


### PR DESCRIPTION
**Feature or improvement description**
This pull request fixes the type hinting included in `floris.simulation` as well as some other issues around type checking primarily in the `Farm` class.

This started with a few cherry-picked commits in https://github.com/rhammond2/floris/tree/speedup/cython.

**Related issue, if one exists**
None

**Impacted areas of the software**
`floris.simulation` and the associated tests.

**Additional supporting information**
I've been using mypy to do the type checking. There are still some unresolved warnings and errors:

```bash
(floris) >>mbp@~/Development/floris/floris/simulation (fix_typing $)$ mypy *.py
turbine.py:22: error: Skipping analyzing "scipy.interpolate": module is installed, but missing library stubs or py.typed marker
turbine.py:22: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
turbine.py:260: error: Invalid index type "Tuple[slice, slice, Union[ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[bool_]], Iterable[int]]]" for "ndarray[Any, dtype[floating[_64Bit]]]"; expected type "Union[SupportsIndex, _SupportsArray[dtype[Union[bool_, integer[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any]]]]], _NestedSequence[Union[bool, int]], Tuple[Union[SupportsIndex, _SupportsArray[dtype[Union[bool_, integer[Any]]]], _NestedSequence[_SupportsArray[dtype[Union[bool_, integer[Any]]]]], _NestedSequence[Union[bool, int]]], ...]]"
Found 2 errors in 1 file (checked 9 source files)
```