### PR TITLE
Fix bug in `plot_turbines_with_fi`

### DIFF
--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -67,8 +67,8 @@ def plot_turbines_with_fi(ax, fi, color=None):
         ax,
         fi.layout_x,
         fi.layout_y,
-        fi.get_yaw_angles()[0, 0],
-        fi.floris.farm.rotor_diameter[0, 0],
+        fi.floris.farm.yaw_angles[0, 0],
+        fi.floris.farm.rotor_diameters[0, 0],
         color=color,
         wind_direction=fi.floris.flow_field.wind_directions[0],
     )


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
The parameters passed to `plot_turbines` in `plot_turbines_with_fi` are corrected to account for the fact that the `fi.get_yaw_angles()` method no longer exists and that `fi.floris.farm.rotor_diameter` has been renamed to `fi.floris.farm.rotor_diameters`.

**Related issue, if one exists**
#443

**Impacted areas of the software**
`floris.tools.visualization.plot_turbines_with_fi`

**Additional supporting information**
Refer to #443 for details about the bug.

**Test results, if applicable**
![image](https://user-images.githubusercontent.com/16693035/174901983-6e08d722-9911-4d4e-ac29-3a9d494b6750.png)
```
$ pytest
================================================================================================ test session starts =================================================================================================
platform win32 -- Python 3.9.12, pytest-7.1.2, pluggy-1.0.0
rootdir: C:\Users\pireland\floris, configfile: pyproject.toml, testpaths: tests
plugins: anyio-3.6.1, dash-2.4.1, cov-3.0.0, env-0.6.2, forked-1.4.0, timeout-2.1.0, xdist-2.5.0, xprocess-0.18.1
collected 99 items

tests\base_test.py ..                                                                                                                                                                                           [  2%] 
tests\farm_unit_test.py ..                                                                                                                                                                                      [  4%] 
tests\floris_interface_test.py ................................                                                                                                                                                 [ 36%]
tests\floris_unit_test.py ....                                                                                                                                                                                  [ 40%]
tests\flow_field_unit_test.py ....                                                                                                                                                                              [ 44%] 
tests\grid_unit_test.py ...                                                                                                                                                                                     [ 47%]
tests\turbine_unit_test.py ..........                                                                                                                                                                           [ 57%]
tests\type_dec_unit_test.py ....                                                                                                                                                                                [ 61%] 
tests\utilities_unit_test.py .......                                                                                                                                                                            [ 68%]
tests\vec3_unit_test.py .......                                                                                                                                                                                 [ 75%]
tests\reg_tests\cumulative_curl_regression_test.py ......                                                                                                                                                       [ 81%]
tests\reg_tests\gauss_regression_test.py .......                                                                                                                                                                [ 88%]
tests\reg_tests\jensen_jimenez_regression_test.py ....                                                                                                                                                          [ 92%]
tests\reg_tests\none_regression_test.py ....                                                                                                                                                                    [ 96%]
tests\reg_tests\turbopark_regression_test.py ...                                                                                                                                                                [100%]

================================================================================================= 99 passed in 8.11s ================================================================================================= 
```

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
