### PR TITLE
Use existing simulation yaw angles in planar calculations instead of switching to zero yaw angles

### DIFF
--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -385,6 +385,8 @@ class FlorisInterface(LoggerBase):
         # TODO this has to be done here as it seems to be lost with reinitialize
         if yaw_angles is not None:
             self.floris.farm.yaw_angles = yaw_angles
+        else:
+            self.floris.farm.yaw_angles = current_yaw_angles
 
         # Calculate wake
         self.floris.solve_for_viz()
@@ -468,6 +470,8 @@ class FlorisInterface(LoggerBase):
         # TODO this has to be done here as it seems to be lost with reinitialize
         if yaw_angles is not None:
             self.floris.farm.yaw_angles = yaw_angles
+        else:
+            self.floris.farm.yaw_angles = current_yaw_angles
 
         # Calculate wake
         self.floris.solve_for_viz()
@@ -546,6 +550,8 @@ class FlorisInterface(LoggerBase):
         # TODO this has to be done here as it seems to be lost with reinitialize
         if yaw_angles is not None:
             self.floris.farm.yaw_angles = yaw_angles
+        else:
+            self.floris.farm.yaw_angles = current_yaw_angles
 
         # Calculate wake
         self.floris.solve_for_viz()


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
`calculate_horizontal_plane`, `calculate_cross_plane`, and `calculate_y_plane` previously used zero yaw angles if called with `yaw_angles=None`. This PR changes the behavior to use the existing yaw angles from `self.floris.farm.yaw_angles` instead.

**Related issue, if one exists**
#448 

**Impacted areas of the software**
`floris.tools.floris_interface.py`

**Test results, if applicable**

Example visualization before change:
![image](https://user-images.githubusercontent.com/16693035/175130489-ab7a41a1-4d68-4fb4-8bab-304349681d61.png)

Example visualization after change:
![image](https://user-images.githubusercontent.com/16693035/175130345-d57f3a89-2bb0-481a-b086-f4b58a985c93.png)

Unit test results:
```
$ pytest
================================================================================================ test session starts =================================================================================================
platform win32 -- Python 3.9.12, pytest-7.1.2, pluggy-1.0.0
rootdir: C:\Users\pireland\floris, configfile: pyproject.toml, testpaths: tests
plugins: anyio-3.6.1, dash-2.3.1, cov-3.0.0, env-0.6.2, forked-1.4.0, timeout-2.1.0, xdist-2.5.0, xprocess-0.18.1
collected 99 items

tests\base_test.py ..                                                                                                                                                                                           [  2%] 
tests\farm_unit_test.py ..                                                                                                                                                                                      [  4%] 
tests\floris_interface_test.py ................................                                                                                                                                                 [ 36%]
tests\floris_unit_test.py ....                                                                                                                                                                                  [ 40%]
tests\flow_field_unit_test.py ....                                                                                                                                                                              [ 44%] 
tests\grid_unit_test.py ...                                                                                                                                                                                     [ 47%]
tests\turbine_unit_test.py ..........                                                                                                                                                                           [ 57%]
tests\type_dec_unit_test.py ....                                                                                                                                                                                [ 61%]
tests\utilities_unit_test.py .......                                                                                                                                                                            [ 68%]
tests\vec3_unit_test.py .......                                                                                                                                                                                 [ 75%]
tests\reg_tests\cumulative_curl_regression_test.py ......                                                                                                                                                       [ 81%]
tests\reg_tests\gauss_regression_test.py .......                                                                                                                                                                [ 88%]
tests\reg_tests\jensen_jimenez_regression_test.py ....                                                                                                                                                          [ 92%]
tests\reg_tests\none_regression_test.py ....                                                                                                                                                                    [ 96%]
tests\reg_tests\turbopark_regression_test.py ...                                                                                                                                                                [100%]

================================================================================================== warnings summary ================================================================================================== 
..\Anaconda3\envs\wedev-new-floris\lib\site-packages\numexpr\expressions.py:21
..\Anaconda3\envs\wedev-new-floris\lib\site-packages\numexpr\expressions.py:21
  C:\Users\pireland\Anaconda3\envs\wedev-new-floris\lib\site-packages\numexpr\expressions.py:21: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_forbids_neg_powint = LooseVersion(numpy.__version__) >= LooseVersion('1.12.0b1')

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================== 99 passed, 2 warnings in 3.87s ===========================================================================================
```


<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->