### PR TITLE
pass in het map when copying fi

### DIFF
--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -84,7 +84,7 @@ class FlorisInterface(LoggerBase):
 
     def copy(self):
         """Create an independent copy of the current FlorisInterface object"""
-        return FlorisInterface(self.floris.as_dict())
+        return FlorisInterface(self.floris.as_dict(), het_map=self.het_map)
 
     def calculate_wake(
         self,


### PR DESCRIPTION
Ready to be merged

**Feature or improvement description**
The function in FlorisInterface copy() does not currently pass in the het map, thus it returns a homogenous version of itself, instead of a complete copy.  This pull request fixes that.

Code to demonstrate fix (run in examples):

```



import matplotlib.pyplot as plt
import numpy as np

from floris.tools import FlorisInterface
from floris.tools.floris_interface import generate_heterogeneous_wind_map


speed_ups = [[2.0, 2.0, 1.0, 1.0]]
x_locs = [-300.0, -300.0, 2600.0, 2600.0]
y_locs = [ -300.0, 300.0, -300.0, 300.0]

het_map_2d = generate_heterogeneous_wind_map(speed_ups, x_locs, y_locs)

# Initialize FLORIS with the given input file via FlorisInterface.
# Also, pass the heterogeneous map into the FlorisInterface.
fi = FlorisInterface("inputs/gch.yaml", het_map=het_map_2d)

fi_copy = fi.copy()

print(fi.het_map)

print('===')

print(fi_copy.het_map)
```

Before the change, second print is "None"