### PR TITLE
Add a forced max of 3 to turbine grid points

### DIFF
--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -76,6 +76,13 @@ class Floris(logging_manager.LoggerBase, FromDictMixin):
         self.farm.set_yaw_angles(self.flow_field.n_wind_directions, self.flow_field.n_wind_speeds)
 
         if self.solver["type"] == "turbine_grid":
+
+            if self.solver["turbine_grid_points"] > 3:
+                print("turbine_grid_points was assigned a value greater than 3 (%d)" % self.solver["turbine_grid_points"])
+                print("high values of turbine_grid_points are associated with large reductions in performance without improved accurracy")
+                print("setting turbine_grid_points <- 3")
+                self.solver["turbine_grid_points"] = 3
+
             self.grid = TurbineGrid(
                 turbine_coordinates=self.farm.coordinates,
                 reference_turbine_diameter=self.farm.rotor_diameters,


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
Could be ready to merge after some discussions

**Feature or improvement description**
This branch adds a check to floris.py to look for values of turbine_grid_points larger than 3.  We believe this value is set too high typically erroneously and leads to very poor performance.  FLORIS dev team selected this as a current stop-gap solution

To check, recommend running example examples/01_opening_floris_computing_power.py before and after changing the value of turbine_grid_points in examples/inputs/gch.yaml to something above 3.

One note is that this change does change the solution of examples/02_visualizations.py since it used a value of 10 for one of the visualizations, but on balance seems a fair price to pay


