### PR TITLE
adding missing time_series flag to cc flow field solver call

### DIFF
--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -562,6 +562,7 @@ def full_flow_cc_solver(farm: Farm, flow_field: FlowField, flow_field_grid: Flow
         wind_directions=turbine_grid_flow_field.wind_directions,
         wind_speeds=turbine_grid_flow_field.wind_speeds,
         grid_resolution=3,
+        time_series=turbine_grid_flow_field.time_series,
     )
     turbine_grid_farm.expand_farm_properties(
         turbine_grid_flow_field.n_wind_directions, turbine_grid_flow_field.n_wind_speeds, turbine_grid.sorted_coord_indices


### PR DESCRIPTION
**Feature or improvement description**
This is a small bugfix to add a missing `time_series` flag to the CC model full flow field solver. It is pointed at the develop branch as the time series functionality is not yet in the main branch.

**Related issue, if one exists**
None.

**Impacted areas of the software**
`solver.py`

**Additional supporting information**
None.

**Test results, if applicable**
Can now run example 02 and visualize the CC model, when previously it would error out.
