### PR TITLE
Bring the Ishihara Qian model into v3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,4 +40,4 @@ repos:
     rev: '4.0.1'
     hooks:
     -   id: flake8
-        args: [--max-line-length=120]
+        args: [--max-line-length=120, --exclude=*/__init__.py]

--- a/floris/simulation/wake.py
+++ b/floris/simulation/wake.py
@@ -13,46 +13,47 @@
 # See https://floris.readthedocs.io for documentation
 
 import attrs
-from attrs import define, field
+from attrs import field, define
 
 from floris.simulation import BaseClass, BaseModel
-from floris.simulation.wake_deflection import (
-    GaussVelocityDeflection,
-    JimenezVelocityDeflection,
-    NoneVelocityDeflection,
-)
-from floris.simulation.wake_combination import FLS, MAX, SOSFS
-from floris.simulation.wake_turbulence import CrespoHernandez, NoneWakeTurbulence
 from floris.simulation.wake_velocity import (
     NoneVelocityDeficit,
-    CumulativeGaussCurlVelocityDeficit,
     GaussVelocityDeficit,
     JensenVelocityDeficit,
     TurbOParkVelocityDeficit,
+    CumulativeGaussCurlVelocityDeficit,
 )
+from floris.simulation.wake_deflection import (
+    NoneVelocityDeflection,
+    GaussVelocityDeflection,
+    JimenezVelocityDeflection,
+)
+from floris.simulation.wake_turbulence import (
+    IshiharaQian,
+    CrespoHernandez,
+    NoneWakeTurbulence,
+)
+from floris.simulation.wake_combination import FLS, MAX, SOSFS
 
 
 MODEL_MAP = {
-    "combination_model": {
-        "fls": FLS,
-        "max": MAX,
-        "sosfs": SOSFS
-    },
+    "combination_model": {"fls": FLS, "max": MAX, "sosfs": SOSFS},
     "deflection_model": {
         "jimenez": JimenezVelocityDeflection,
         "gauss": GaussVelocityDeflection,
-        "none": NoneVelocityDeflection
+        "none": NoneVelocityDeflection,
     },
     "turbulence_model": {
         "none": NoneWakeTurbulence,
-        "crespo_hernandez": CrespoHernandez
+        "crespo_hernandez": CrespoHernandez,
+        "ishihara_qian": IshiharaQian,
     },
     "velocity_model": {
         "none": NoneVelocityDeficit,
         "cc": CumulativeGaussCurlVelocityDeficit,
         "gauss": GaussVelocityDeficit,
         "jensen": JensenVelocityDeficit,
-        "turbopark": TurbOParkVelocityDeficit
+        "turbopark": TurbOParkVelocityDeficit,
     },
 }
 
@@ -70,6 +71,7 @@ class WakeModelManager(BaseClass):
             - deflection_model (str): The name of the deflection model to be instantiated.
             - combination_model (str): The name of the combination model to be instantiated.
     """
+
     model_strings: dict = field(converter=dict)
     enable_secondary_steering: bool = field(converter=bool)
     enable_yaw_added_recovery: bool = field(converter=bool)
@@ -121,12 +123,7 @@ class WakeModelManager(BaseClass):
 
     @model_strings.validator
     def validate_model_strings(self, instance: attrs.Attribute, value: dict) -> None:
-        required_strings = [
-            "velocity_model",
-            "deflection_model",
-            "combination_model",
-            "turbulence_model"
-        ]
+        required_strings = ["velocity_model", "deflection_model", "combination_model", "turbulence_model"]
         # Check that all required strings are given
         for s in required_strings:
             if s not in value.keys():
@@ -135,7 +132,9 @@ class WakeModelManager(BaseClass):
         # Check that no other strings are given
         for k in value.keys():
             if k not in required_strings:
-                raise KeyError(f"Wake: '{k}' was given as input but it is not a valid option. Required inputs are: {', '.join(required_strings)}")
+                raise KeyError(
+                    f"Wake: '{k}' was given as input but it is not a valid option. Required inputs are: {', '.join(required_strings)}"  # noqa: 501
+                )
 
     @property
     def deflection_function(self):

--- a/floris/simulation/wake_turbulence/__init__.py
+++ b/floris/simulation/wake_turbulence/__init__.py
@@ -13,5 +13,6 @@
 # See https://floris.readthedocs.io for documentation
 
 
-from floris.simulation.wake_turbulence.crespo_hernandez import CrespoHernandez
 from floris.simulation.wake_turbulence.none import NoneWakeTurbulence
+from floris.simulation.wake_turbulence.ishihara_qian import IshiharaQian
+from floris.simulation.wake_turbulence.crespo_hernandez import CrespoHernandez

--- a/floris/simulation/wake_turbulence/ishihara_qian.py
+++ b/floris/simulation/wake_turbulence/ishihara_qian.py
@@ -1,0 +1,167 @@
+# Copyright 2021 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+import attrs
+import numpy as np
+from attrs import field, define
+
+from floris.type_dec import FromDictMixin
+from floris.simulation.grid import Grid
+from floris.simulation.flow_field import FlowField
+
+
+@define(auto_attribs=True)
+class IQParam(FromDictMixin):
+    """A parameter mapping for all parameters of the Ishihara Qian model.
+
+    Args:
+        const (float): The constant coefficient.
+        Ct (float): The thrust coefficient exponent.
+        TI (float): The turbulence intensity exponent.
+    """
+
+    const: float = field(converter=float, validator=attrs.validators.instance_of(float))
+    Ct: float = field(converter=float, validator=attrs.validators.instance_of(float))
+    TI: float = field(converter=float, validator=attrs.validators.instance_of(float))
+
+    def parameter_value(self, Ct: float, ti_initial: float) -> float:
+        """
+        Calculates model parameters using current conditions and parameter settings.
+
+        Args:
+            Ct (float): Thrust coefficient of the current turbine.
+            ti_initial (float): Turbulence intensity.
+
+        Returns:
+            float: Current value of model parameter.
+        """
+        return self.const * Ct**self.Ct * ti_initial**self.TI
+
+
+@define(auto_attribs=True)
+class IshiharaQian:
+    """
+    IshiharaQian is a wake velocity subclass that is used to compute the wake
+    velocity deficit based on the Gaussian wake model with self-similarity and
+    a near wake correction. The IshiharaQian wake model includes a Gaussian
+    wake velocity deficit profile in the spanwise and vertical directions and
+    includes the effects of ambient turbulence, added turbulence from upstream
+    wakes, as well as wind shear and wind veer. For more info, see
+    :cite:`iqt-qian2018new`.
+
+    Args:
+        kstar (dict): A dictionary of the `const`, `Ct`, and `TI` parameters related to
+            the linear relationship between the turbulence intensity and the width of
+            the Gaussian wake shape.
+        epsilon (dict): A dictionary of the `const`, `Ct`, and `TI` parameters of the
+            second parameter used to determine the linear relationship between the
+            turbulence intensity and the width of the Gaussian wake shape.
+        d (dict): A dictionary of the `const`, `Ct`, and `TI` parameters of the constant
+            coefficient used in calculation of wake-added turbulence.
+        e (dict): A dictionary of the `const`, `Ct`, and `TI` parameters of the linear
+            coefficient used in calculation of wake-added turbulence.
+        f (dict): A dictionary of the `const`, `Ct`, and `TI` parameters of the near-wake
+            coefficient used in calculation of wake-added turbulence.
+
+    References:
+        .. bibliography:: /source/zrefs.bib
+            :style: unsrt
+            :filter: docname in docnames
+            :keyprefix: iqt-
+    """
+
+    # wake model parameter
+    kstar: IQParam = field(converter=IQParam.from_dict)
+    epsilon: IQParam = field(converter=IQParam.from_dict)
+    d: IQParam = field(converter=IQParam.from_dict)
+    e: IQParam = field(converter=IQParam.from_dict)
+    f: IQParam = field(converter=IQParam.from_dict)
+
+    def prepare_function(self, grid: Grid, flow_field: FlowField) -> dict[str, Any]:
+        kwargs = dict()
+        return kwargs
+
+    def function(self, ambient_TI, coord_ti, turbine_coord, turbine):
+        # function(self, x_locations, y_locations, z_locations, turbine,
+        #  turbine_coord, flow_field, turb_u_wake, sorted_map):
+        """
+        Calculates wake-added turbulence as a function of
+        external conditions and wind turbine operation. This function is
+        accessible through the :py:class:`~.wake.Wake` class as the
+        :py:meth:`~.Wake.turbulence_function` method.
+        Args:
+            ambient_TI (float): TI of the background flow field.
+            coord_ti (:py:class:`~.utilities.Vec3`): Coordinate where TI
+                is to be calculated (e.g. downstream wind turbines).
+            turbine_coord (:py:class:`~.utilities.Vec3`): Coordinate of
+                the wind turbine adding turbulence to the flow.
+            turbine (:py:class:`~.turbine.Turbine`): Wind turbine
+                adding turbulence to the flow.
+        Returns:
+            float: Wake-added turbulence from the current wind turbine
+            (**turbine**) at location specified by (**coord_ti**).
+        """
+        # added turbulence model
+        ti_initial = ambient_TI
+
+        # turbine parameters
+        D = turbine.rotor_diameter
+        HH = turbine.hub_height
+        Ct = turbine.Ct
+
+        local_x = coord_ti.x1 - turbine_coord.x1
+        local_y = coord_ti.x2 - turbine_coord.x2
+        local_z = coord_ti.x3 - turbine_coord.x3
+        # coordinate info
+        r = np.sqrt(local_y**2 + (local_z) ** 2)
+
+        kstar = self.parameter_value_from_dict(self.kstar, Ct, ti_initial)
+        epsilon = self.parameter_value_from_dict(self.epsilon, Ct, ti_initial)
+
+        d = self.parameter_value_from_dict(self.d, Ct, ti_initial)
+        e = self.parameter_value_from_dict(self.e, Ct, ti_initial)
+        f = self.parameter_value_from_dict(self.f, Ct, ti_initial)
+
+        k1 = np.cos(np.pi / 2 * (r / D - 0.5)) ** 2
+        # TODO: make work for array of turbulences/grid points
+        # k1[r / D > 0.5] = 1.0
+
+        k2 = np.cos(np.pi / 2 * (r / D + 0.5)) ** 2
+        # TODO: make work for array of turbulences/grid points
+        # k2[r / D > 0.5] = 0.0
+
+        if r / D > 0.5:
+            k1 = 1.0
+            k2 = 0.0
+
+        # Representative wake width = \sigma / D
+        wake_width = kstar * (local_x / D) + epsilon
+
+        # Added turbulence intensity = \Delta I_1 (x,y,z)
+        delta = ti_initial * np.sin(np.pi * (HH - local_z) / HH) ** 2
+        # TODO: make work for array of turbulences/grid points
+        # delta[local_z >= HH] = 0.0
+        ti_calculation = (
+            1
+            / (d + e * (local_x / D) + f * (1 + (local_x / D)) ** (-2))
+            * (
+                (k1 * np.exp(-((r - D / 2) ** 2) / (2 * (wake_width * D) ** 2)))
+                + (k2 * np.exp(-((r + D / 2) ** 2) / (2 * (wake_width * D) ** 2)))
+            )
+            - delta
+        )
+
+        return ti_calculation

--- a/floris/simulation/wake_turbulence/ishihara_qian.py
+++ b/floris/simulation/wake_turbulence/ishihara_qian.py
@@ -88,7 +88,7 @@ class IshiharaQian:
     default_parameters = {
         "kstar": {"const": 0.11, "Ct": 1.07, "TI": 0.2},
         "epsilon": {"const": 0.23, "Ct": -0.25, "TI": 0.17},
-        "d": {"const": 2.3, "Ct": 1.2, "TI": 0.0},
+        "d": {"const": 2.3, "Ct": -1.2, "TI": 0.0},
         "e": {"const": 1.0, "Ct": 0.0, "TI": 0.1},
         "f": {"const": 0.7, "Ct": -3.2, "TI": -0.45},
     }

--- a/floris/simulation/wake_turbulence/ishihara_qian.py
+++ b/floris/simulation/wake_turbulence/ishihara_qian.py
@@ -84,14 +84,6 @@ class IshiharaQian:
             :keyprefix: iqt-
     """
 
-    # wake model parameter
-    default_parameters = {
-        "kstar": {"const": 0.11, "Ct": 1.07, "TI": 0.2},
-        "epsilon": {"const": 0.23, "Ct": -0.25, "TI": 0.17},
-        "d": {"const": 2.3, "Ct": -1.2, "TI": 0.0},
-        "e": {"const": 1.0, "Ct": 0.0, "TI": 0.1},
-        "f": {"const": 0.7, "Ct": -3.2, "TI": -0.45},
-    }
     kstar: IQParam = field(converter=IQParam.from_dict, default={"const": 0.11, "Ct": 1.07, "TI": 0.2})
     epsilon: IQParam = field(converter=IQParam.from_dict, default={"const": 0.23, "Ct": -0.25, "TI": 0.17})
     d: IQParam = field(converter=IQParam.from_dict, default={"const": 2.3, "Ct": 1.2, "TI": 0.0})

--- a/floris/simulation/wake_turbulence/ishihara_qian.py
+++ b/floris/simulation/wake_turbulence/ishihara_qian.py
@@ -37,7 +37,7 @@ class IQParam(FromDictMixin):
     Ct: float = field(converter=float, validator=attrs.validators.instance_of(float))
     TI: float = field(converter=float, validator=attrs.validators.instance_of(float))
 
-    def parameter_value(self, Ct: float, ti_initial: float) -> float:
+    def current_value(self, Ct: float, ti_initial: float) -> float:
         """
         Calculates model parameters using current conditions and parameter settings.
 
@@ -94,7 +94,8 @@ class IshiharaQian:
         kwargs = dict()
         return kwargs
 
-    def function(self, ambient_TI, coord_ti, turbine_coord, turbine):
+    # TODO: Translate this function to v3 inputs format
+    def function(self, ambient_TI, coord_ti, turbine_coord, turbine) -> np.ndarray:
         # function(self, x_locations, y_locations, z_locations, turbine,
         #  turbine_coord, flow_field, turb_u_wake, sorted_map):
         """
@@ -128,12 +129,12 @@ class IshiharaQian:
         # coordinate info
         r = np.sqrt(local_y**2 + (local_z) ** 2)
 
-        kstar = self.parameter_value_from_dict(self.kstar, Ct, ti_initial)
-        epsilon = self.parameter_value_from_dict(self.epsilon, Ct, ti_initial)
+        kstar = self.kstar.current_value(Ct, ti_initial)
+        epsilon = self.epsilon.current_value(Ct, ti_initial)
 
-        d = self.parameter_value_from_dict(self.d, Ct, ti_initial)
-        e = self.parameter_value_from_dict(self.e, Ct, ti_initial)
-        f = self.parameter_value_from_dict(self.f, Ct, ti_initial)
+        d = self.d.current_value(Ct, ti_initial)
+        e = self.e.current_value(Ct, ti_initial)
+        f = self.f.current_value(Ct, ti_initial)
 
         k1 = np.cos(np.pi / 2 * (r / D - 0.5)) ** 2
         # TODO: make work for array of turbulences/grid points

--- a/floris/simulation/wake_turbulence/ishihara_qian.py
+++ b/floris/simulation/wake_turbulence/ishihara_qian.py
@@ -85,11 +85,18 @@ class IshiharaQian:
     """
 
     # wake model parameter
-    kstar: IQParam = field(converter=IQParam.from_dict)
-    epsilon: IQParam = field(converter=IQParam.from_dict)
-    d: IQParam = field(converter=IQParam.from_dict)
-    e: IQParam = field(converter=IQParam.from_dict)
-    f: IQParam = field(converter=IQParam.from_dict)
+    default_parameters = {
+        "kstar": {"const": 0.11, "Ct": 1.07, "TI": 0.2},
+        "epsilon": {"const": 0.23, "Ct": -0.25, "TI": 0.17},
+        "d": {"const": 2.3, "Ct": 1.2, "TI": 0.0},
+        "e": {"const": 1.0, "Ct": 0.0, "TI": 0.1},
+        "f": {"const": 0.7, "Ct": -3.2, "TI": -0.45},
+    }
+    kstar: IQParam = field(converter=IQParam.from_dict, default={"const": 0.11, "Ct": 1.07, "TI": 0.2})
+    epsilon: IQParam = field(converter=IQParam.from_dict, default={"const": 0.23, "Ct": -0.25, "TI": 0.17})
+    d: IQParam = field(converter=IQParam.from_dict, default={"const": 2.3, "Ct": 1.2, "TI": 0.0})
+    e: IQParam = field(converter=IQParam.from_dict, default={"const": 1.0, "Ct": 0.0, "TI": 0.1})
+    f: IQParam = field(converter=IQParam.from_dict, default={"const": 0.7, "Ct": -3.2, "TI": -0.45})
 
     def prepare_function(self) -> dict[str, Any]:
         kwargs = dict()


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This adds the Ishihara Qian wake turbulence model in v3 format, per #356.

**Related issue, if one exists**
Closes #356 
Closes #274 (see commit [63693ee](https://github.com/NREL/floris/commit/63693eefcf094249bc4462fc2a3d0e4c9f574e0d))
TODO: address #264 

**Impacted areas of the software**
- Updates the `WakeModelManager` to have `IshiharaQian` as a valid wake turbulence model
- Adds the `floris/simulation/wake_turbulence/ishihara_qian.py` module to include the new model
- Small updates to the pre-commit configuration to have flake8 ignore `__init__.py` files

**Additional supporting information**
N/A

**Test results, if applicable**
There didn't appear to be any regression tests in v2, so I have yet to include any, though I'm in support of adding some, if there are any known settings/results to use for this aspect.

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->

@rafmudaf, @bayc, and @paulf81 I've started this PR to open the discussion about any other needs for bringing Ishihara Qian into v3, and to get general feedback at this stage until tests are incorporated, and I can confirm any past issues are addressed.