### PR TITLE
add ref density to legacy reader

### DIFF
--- a/floris/tools/floris_interface_legacy_reader.py
+++ b/floris/tools/floris_interface_legacy_reader.py
@@ -188,6 +188,7 @@ def _convert_v24_dictionary_to_v3(dict_legacy):
         "rotor_diameter": tp["rotor_diameter"],
         "TSR": tp["TSR"],
         "power_thrust_table": tp["power_thrust_table"],
+        "ref_density_cp_ct": 1.225 # This was implicit in the former input file
     }
 
     return dict_floris, dict_turbine


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
The legacy reader returns an error currently because it doesn't create an entry for "ref_density_cp_ct" in the Turbine module.  In the legacy JSON format this value is implicitly 1.225 so maxing explicit and resolves the issue.
