### PR TITLE
Speed up angle wrap functions and improve API

### DIFF
--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -164,7 +164,7 @@ def wrap_180(x):
         x (numeric or np.array): Scalar value or np.array of values to shift.
 
     Returns:
-        np.array: Shifted values.
+        np.ndarray | float | int: Shifted values.
     """
 
     return ((x + 180.0) % 360.0) - 180.0
@@ -178,7 +178,7 @@ def wrap_360(x):
         x (numeric or np.array): Scalar value or np.array of values to shift.
 
     Returns:
-        np.array: Shifted values.
+        np.ndarray | float | int: Shifted values.
     """
     
     return x % 360.0

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -166,9 +166,8 @@ def wrap_180(x):
     Returns:
         np.array: Shifted values.
     """
-    x = np.where(x <= -180.0, x + 360.0, x)
-    x = np.where(x > 180.0, x - 360.0, x)
-    return x
+
+    return ( (x + 180.) % 360.) - 180.
 
 
 def wrap_360(x):
@@ -181,9 +180,8 @@ def wrap_360(x):
     Returns:
         np.array: Shifted values.
     """
-    x = np.where(x < 0.0, x + 360.0, x)
-    x = np.where(x >= 360.0, x - 360.0, x)
-    return x
+    
+    return x % 360.0
 
 
 def wind_delta(wind_directions):

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -167,7 +167,7 @@ def wrap_180(x):
         np.array: Shifted values.
     """
 
-    return ( (x + 180.) % 360.) - 180.
+    return ((x + 180.0) % 360.0) - 180.0
 
 
 def wrap_360(x):

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -55,8 +55,8 @@ def test_tand():
 
 
 def test_wrap_180():
-    assert wrap_180(-180.0) == 180.0
-    assert wrap_180(180.0) == 180.0
+    assert wrap_180(-180.0) == -180.0
+    assert wrap_180(180.0) == -180.0
     assert wrap_180(-181.0) == 179.0
     assert wrap_180(-179.0) == -179.0
     assert wrap_180(179.0) == 179.0


### PR DESCRIPTION
Is ready to merge

**Feature or improvement description**
In some other work, found these implementations of the wrap functions which are 2/3x faster then what we have now.  Useful in codes that call this like flasc.  Also, using modulus allows a broader range of inputs to be wrapped into range

One small change is new version of 180 wrap is [-180,180) instead of (-180,180] as previously implemented.   But this is more consistent with the [0,360) wrap I think.  Corrected the unit test for this and all other tests pass.



**Test results, if applicable**
Ran timing tests in a notebook

![image](https://user-images.githubusercontent.com/6117702/192425686-b3b99ee5-92b9-43b8-80b7-7fcfd5c97351.png)
