### PR TITLE
Bug fix: cast reference_wind_height to float

### DIFF
--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -34,7 +34,7 @@ class FlowField(FromDictMixin):
     wind_shear: float = field(converter=float)
     air_density: float = field(converter=float)
     turbulence_intensity: float = field(converter=float)
-    reference_wind_height: float = field(converter=int)
+    reference_wind_height: float = field(converter=float)
     time_series : bool = field(default=False)
 
     n_wind_speeds: int = field(init=False)

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -34,7 +34,7 @@ class FlowField(FromDictMixin):
     wind_shear: float = field(converter=float)
     air_density: float = field(converter=float)
     turbulence_intensity: float = field(converter=float)
-    reference_wind_height: int = field(converter=int)
+    reference_wind_height: float = field(converter=int)
     time_series : bool = field(default=False)
 
     n_wind_speeds: int = field(init=False)

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -71,7 +71,7 @@ class FlorisInterface(LoggerBase):
 
         # Make a check on reference height and provide a helpful warning
         unique_heights = np.unique(self.floris.farm.hub_heights)
-        if (len(unique_heights) == 1) and (self.floris.flow_field.reference_wind_height != unique_heights[0]):
+        if (len(unique_heights) == 1) and (np.abs(self.floris.flow_field.reference_wind_height - unique_heights[0]) > 1.0e-6):
             err_msg = "The only unique hub-height is not the equal to the specified reference wind height.  If this was unintended use -1 as the reference hub height to indicate use of hub-height as reference wind height."
             self.logger.warning(err_msg, stack_info=True)
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -66,11 +66,11 @@ class FlorisInterface(LoggerBase):
         self.floris.flow_field.het_map = het_map
 
         # If ref height is -1, assign the hub height
-        if self.floris.flow_field.reference_wind_height == -1:
+        if np.abs(self.floris.flow_field.reference_wind_height + 1.0) < 1.0e-6:
             self.assign_hub_height_to_ref_height()
 
         # Make a check on reference height and provide a helpful warning
-        unique_heights = np.unique(self.floris.farm.hub_heights)
+        unique_heights = np.unique(np.round(self.floris.farm.hub_heights, decimals=6))
         if (len(unique_heights) == 1) and (np.abs(self.floris.flow_field.reference_wind_height - unique_heights[0]) > 1.0e-6):
             err_msg = "The only unique hub-height is not the equal to the specified reference wind height.  If this was unintended use -1 as the reference hub height to indicate use of hub-height as reference wind height."
             self.logger.warning(err_msg, stack_info=True)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Bug fix: the variable `reference_wind_height` is currently being forced into an integer, causing the warning message `WARNING:floris.tools.floris_interface.FlorisInterface:The only unique hub-height is not the equal to the specified reference wind height.  If this was unintended use -1 as the reference hub height to indicate use of hub-height as reference wind height.` whenever the turbine hub height is not a round number.

**Related issue, if one exists**
N/A

**Impacted areas of the software**
`FlorisInterface`

**Additional supporting information**
Note: this PR is directly towards the `main` branch since it's a bug fix. Feel free to change this to `develop` if you think it belongs there.

**Test results, if applicable**
The error no longer appears with this hotfix.

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->