### PR TITLE
Update documentation references list

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,56 +1,252 @@
 ---
 ---
 
-@inproceedings{holdgraf_evidence_2014,
-	address = {Brisbane, Australia, Australia},
-	title = {Evidence for {Predictive} {Coding} in {Human} {Auditory} {Cortex}},
-	booktitle = {International {Conference} on {Cognitive} {Neuroscience}},
-	publisher = {Frontiers in Neuroscience},
-	author = {Holdgraf, Christopher Ramsay and de Heer, Wendy and Pasley, Brian N. and Knight, Robert T.},
-	year = {2014}
+@article{abkar2015influence,
+    title={Influence of atmospheric stability on wind-turbine wakes: A large-eddy simulation study},
+    author={Abkar, Mahdi and Port{\'e}-Agel, Fernando},
+    journal={Physics of fluids},
+    volume={27},
+    number={3},
+    pages={035104},
+    year={2015},
+    publisher={AIP Publishing LLC}
 }
 
-@article{holdgraf_rapid_2016,
-	title = {Rapid tuning shifts in human auditory cortex enhance speech intelligibility},
-	volume = {7},
-	issn = {2041-1723},
-	url = {http://www.nature.com/doifinder/10.1038/ncomms13654},
-	doi = {10.1038/ncomms13654},
-	number = {May},
-	journal = {Nature Communications},
-	author = {Holdgraf, Christopher Ramsay and de Heer, Wendy and Pasley, Brian N. and Rieger, Jochem W. and Crone, Nathan and Lin, Jack J. and Knight, Robert T. and Theunissen, Frédéric E.},
-	year = {2016},
-	pages = {13654},
-	file = {Holdgraf et al. - 2016 - Rapid tuning shifts in human auditory cortex enhance speech intelligibility.pdf:C\:\\Users\\chold\\Zotero\\storage\\MDQP3JWE\\Holdgraf et al. - 2016 - Rapid tuning shifts in human auditory cortex enhance speech intelligibility.pdf:application/pdf}
+@article{bastankhah2014new,
+    title={A new analytical model for wind-turbine wakes},
+    author={Bastankhah, Majid and Port{\'e}-Agel, Fernando},
+    journal={Renewable Energy},
+    volume={70},
+    pages={116--123},
+    year={2014},
+    publisher={Elsevier}
 }
 
-@inproceedings{holdgraf_portable_2017,
-	title = {Portable learning environments for hands-on computational instruction using container-and cloud-based technology to teach data science},
-	volume = {Part F1287},
-	isbn = {978-1-4503-5272-7},
-	doi = {10.1145/3093338.3093370},
-	abstract = {© 2017 ACM. There is an increasing interest in learning outside of the traditional classroom setting. This is especially true for topics covering computational tools and data science, as both are challenging to incorporate in the standard curriculum. These atypical learning environments offer new opportunities for teaching, particularly when it comes to combining conceptual knowledge with hands-on experience/expertise with methods and skills. Advances in cloud computing and containerized environments provide an attractive opportunity to improve the effciency and ease with which students can learn. This manuscript details recent advances towards using commonly-Available cloud computing services and advanced cyberinfrastructure support for improving the learning experience in bootcamp-style events. We cover the benets (and challenges) of using a server hosted remotely instead of relying on student laptops, discuss the technology that was used in order to make this possible, and give suggestions for how others could implement and improve upon this model for pedagogy and reproducibility.},
-	booktitle = {{ACM} {International} {Conference} {Proceeding} {Series}},
-	author = {Holdgraf, Christopher Ramsay and Culich, A. and Rokem, A. and Deniz, F. and Alegro, M. and Ushizima, D.},
-	year = {2017},
-	keywords = {Teaching, Bootcamps, Cloud computing, Data science, Docker, Pedagogy}
+@article{bastankhah2016experimental,
+    title={Experimental and theoretical study of wind turbine wakes in yawed conditions},
+    author={Bastankhah, Majid and Port{\'e}-Agel, Fernando},
+    journal={Journal of Fluid Mechanics},
+    volume={806},
+    pages={506--541},
+    year={2016},
+    publisher={Cambridge University Press}
 }
 
-@article{holdgraf_encoding_2017,
-	title = {Encoding and decoding models in cognitive electrophysiology},
-	volume = {11},
-	issn = {16625137},
-	doi = {10.3389/fnsys.2017.00061},
-	abstract = {© 2017 Holdgraf, Rieger, Micheli, Martin, Knight and Theunissen. Cognitive neuroscience has seen rapid growth in the size and complexity of data recorded from the human brain as well as in the computational tools available to analyze this data. This data explosion has resulted in an increased use of multivariate, model-based methods for asking neuroscience questions, allowing scientists to investigate multiple hypotheses with a single dataset, to use complex, time-varying stimuli, and to study the human brain under more naturalistic conditions. These tools come in the form of “Encoding” models, in which stimulus features are used to model brain activity, and “Decoding” models, in which neural features are used to generated a stimulus output. Here we review the current state of encoding and decoding models in cognitive electrophysiology and provide a practical guide toward conducting experiments and analyses in this emerging field. Our examples focus on using linear models in the study of human language and audition. We show how to calculate auditory receptive fields from natural sounds as well as how to decode neural recordings to predict speech. The paper aims to be a useful tutorial to these approaches, and a practical introduction to using machine learning and applied statistics to build models of neural activity. The data analytic approaches we discuss may also be applied to other sensory modalities, motor systems, and cognitive systems, and we cover some examples in these areas. In addition, a collection of Jupyter notebooks is publicly available as a complement to the material covered in this paper, providing code examples and tutorials for predictive modeling in python. The aimis to provide a practical understanding of predictivemodeling of human brain data and to propose best-practices in conducting these analyses.},
-	journal = {Frontiers in Systems Neuroscience},
-	author = {Holdgraf, Christopher Ramsay and Rieger, J.W. and Micheli, C. and Martin, S. and Knight, R.T. and Theunissen, F.E.},
-	year = {2017},
-	keywords = {Decoding models, Encoding models, Electrocorticography (ECoG), Electrophysiology/evoked potentials, Machine learning applied to neuroscience, Natural stimuli, Predictive modeling, Tutorials}
+@article{niayifar2016analytical,
+    title={Analytical modeling of wind farms: A new approach for power prediction},
+    author={Niayifar, Amin and Port{\'e}-Agel, Fernando},
+    journal={Energies},
+    volume={9},
+    number={9},
+    pages={741},
+    year={2016},
+    publisher={Multidisciplinary Digital Publishing Institute}
 }
 
-@book{ruby,
-  title     = {The Ruby Programming Language},
-  author    = {Flanagan, David and Matsumoto, Yukihiro},
-  year      = {2008},
-  publisher = {O'Reilly Media}
+@article{dilip2017wind,
+    title={Wind turbine wake mitigation through blade pitch offset},
+    author={Dilip, Deepu and Port{\'e}-Agel, Fernando},
+    journal={Energies},
+    volume={10},
+    number={6},
+    pages={757},
+    year={2017},
+    publisher={Multidisciplinary Digital Publishing Institute}
+}
+
+@Article{blondel2020alternative,
+    AUTHOR = {Blondel, F. and Cathelain, M.},
+    TITLE = {An alternative form of the super-Gaussian wind turbine wake model},
+    JOURNAL = {Wind Energy Science Discussions},
+    VOLUME = {2020},
+    YEAR = {2020},
+    PAGES = {1--16},
+    URL = {https://www.wind-energ-sci-discuss.net/wes-2019-99/},
+    DOI = {10.5194/wes-2019-99}
+}
+
+@inproceedings{Cathelain2020calibration,
+	author = {M. Cathelain and F. Blondel and P.A. Joulin and P. Bozonnet},
+	title = {Calibration of a super-Gaussian wake model with a focus on near-wake characteristics},
+	doi = {10.1088/1742-6596/1618/6/062008},
+	year = 2020,
+	number={1},
+	month = {sep},
+	publisher = {{IOP} Publishing},
+	volume = {1618},
+	pages = {062008},
+	booktitle={Journal of Physics: Conference Series},
+	organization={IOP Publishing: Conference Series}
+}
+
+@article{qian2018new,
+    title={A new analytical wake model for yawed wind turbines},
+    author={Qian, Guo-Wei and Ishihara, Takeshi},
+    journal={Energies},
+    volume={11},
+    number={3},
+    pages={665},
+    year={2018},
+    publisher={Multidisciplinary Digital Publishing Institute}
+}
+
+@article{martinez2019aerodynamics,
+    title={The aerodynamics of the curled wake: A simplified model in view of flow control},
+    author={Mart{\'\i}nez-Tossas, Luis A and Annoni, Jennifer and Fleming, Paul A and Churchfield, Matthew J},
+    journal={Wind Energy Science (Online)},
+    volume={4},
+    number={NREL/JA-5000-73451},
+    year={2019},
+    publisher={National Renewable Energy Lab.(NREL), Golden, CO (United States)}
+}
+
+@article{fleming2018simulation,
+    AUTHOR = {Fleming, P. and Annoni, J. and Churchfield, M. and Martinez-Tossas, L. A. and Gruchalla, K. and Lawson, M. and Moriarty, P.},
+    TITLE = {A simulation study demonstrating the importance of large-scale trailing vortices in wake steering},
+    JOURNAL = {Wind Energy Science},
+    VOLUME = {3},
+    YEAR = {2018},
+    NUMBER = {1},
+    PAGES = {243--255},
+    URL = {https://www.wind-energ-sci.net/3/243/2018/},
+    DOI = {10.5194/wes-3-243-2018}
+}
+
+@inproceedings{gebraad2014data,
+    title={A data-driven model for wind plant power optimization by yaw control},
+    author={Gebraad, Pieter MO and Teeuwisse, FW and van Wingerden, Jan-Willem and Fleming, Paul A and Ruben, Shalom D and Marden, Jason R and Pao, Lucy Y},
+    booktitle={2014 American Control Conference},
+    pages={3128--3134},
+    year={2014},
+    organization={IEEE}
+}
+
+@article{gebraad2016wind,
+    title={Wind plant power optimization through yaw control using a parametric model for wake effects—a CFD simulation study},
+    author={Gebraad, Pieter MO and Teeuwisse, FW and Van Wingerden, JW and Fleming, Paul A and Ruben, SD and Marden, JR and Pao, LY},
+    journal={Wind Energy},
+    volume={19},
+    number={1},
+    pages={95--114},
+    year={2016},
+    publisher={Wiley Online Library}
+}
+
+@Article{annoni2018analysis,
+AUTHOR = {Annoni, J. and Fleming, P. and Scholbrock, A. and Roadman, J. and Dana, S. and Adcock, C. and Porte-Agel, F. and Raach, S. and Haizmann, F. and Schlipf, D.},
+TITLE = {Analysis of control-oriented wake modeling tools  using lidar field results},
+JOURNAL = {Wind Energy Science},
+VOLUME = {3},
+YEAR = {2018},
+NUMBER = {2},
+PAGES = {819--831},
+URL = {https://www.wind-energ-sci.net/3/819/2018/},
+DOI = {10.5194/wes-3-819-2018}
+}
+
+@article{crespo1996turbulence,
+  title={Turbulence characteristics in wind-turbine wakes},
+  author={Crespo, A and Hernandez, J},
+  journal={Journal of wind engineering and industrial aerodynamics},
+  volume={61},
+  number={1},
+  pages={71--85},
+  year={1996},
+  publisher={Elsevier}
+}
+
+@inproceedings{gunn2016limitations,
+  title={Limitations to the validity of single wake superposition in wind farm yield assessment},
+  author={Gunn, Kester and Stock-Williams, Clym and Burke, M and Willden, Richard and Vogel, C and Hunter, W and Stallard, T and Robinson, N and Schmidt, SR},
+  booktitle={Journal of Physics: Conference Series},
+  number={1},
+  year={2016},
+  organization={IOP Publishing: Conference Series}
+}
+
+@Article{King2019Controls,
+  author  = {Jennifer King and Paul Fleming and Ryan King and Luis A. Martinez-Tossas},
+  title   = {Controls-Oriented Model to Capture Secondary Effects of Wake Steering},
+  journal = {Submitted to Wind Energy Science},
+  year    = {2019}
+}
+
+@article{jimenez2010application,
+  title={Application of a LES technique to characterize the wake deflection of a wind turbine in yaw},
+  author={Jim{\'e}nez, {\'A}ngel and Crespo, Antonio and Migoya, Emilio},
+  journal={Wind energy},
+  volume={13},
+  number={6},
+  pages={559--572},
+  year={2010},
+  publisher={Wiley Online Library}
+}
+
+@book{jensen1983note,
+  title={A note on wind generator interaction},
+  author={Jensen, Niels Otto},
+  year={1983},
+  publisher={Ris{\o} National Laboratory}
+}
+
+@inproceedings{bay2020towards,
+  title={Towards flow control: an assessment of the curled wake model in the FLORIS framework},
+  author={Bay, Christopher J. and King, Jennifer and Mart{\`i}nez-Tossas, Luis A. and Mudafort, Rafael and Hulsman, Paul and K{\"u}hn, Martin and Fleming, Paul},
+  booktitle={Journal of Physics: Conference Series},
+  year={2020},
+  organization={IOP Publishing}
+}
+
+@techreport{wharton2010assessing,
+  title={Assessing atmospheric stability and the impacts on wind characteristics at an onshore wind farm},
+  author={Wharton, Sonia and Lundquist, JK},
+  year={2010},
+  institution={Lawrence Livermore National Lab.(LLNL), Livermore, CA (United States)}
+}
+
+@Article{fleming2019initial,
+AUTHOR = {Fleming, P. and King, J. and Dykes, K. and Simley, E. and Roadman, J. and Scholbrock, A. and Murphy, P. and Lundquist, J. K. and Moriarty, P. and Fleming, K. and van Dam, J. and Bay, C. and Mudafort, R. and Lopez, H. and Skopek, J. and Scott, M. and Ryan, B. and Guernsey, C. and Brake, D.},
+TITLE = {Initial results from a field campaign of wake steering applied at a commercial
+wind farm -- Part 1},
+JOURNAL = {Wind Energy Science},
+VOLUME = {4},
+YEAR = {2019},
+NUMBER = {2},
+PAGES = {273--285},
+URL = {https://www.wind-energ-sci.net/4/273/2019/},
+DOI = {10.5194/wes-4-273-2019}
+}
+
+@Article{fleming2019continued,
+AUTHOR = {Fleming, P. and King, J. and Simley, E. and Roadman, J. and Scholbrock, A. and Murphy, P. and Lundquist, J. K. and Moriarty, P. and Fleming, K. and van Dam, J. and Bay, C. and Mudafort, R. and Jager, D. and Skopek, J. and Scott, M. and Ryan, B. and Guernsey, C. and Brake, D.},
+TITLE = {Continued Results from a Field Campaign of Wake Steering
+Applied at a Commercial Wind Farm: Part 2},
+JOURNAL = {Wind Energy Science Discussions},
+VOLUME = {2020},
+YEAR = {2020},
+PAGES = {1--24},
+URL = {https://www.wind-energ-sci-discuss.net/wes-2019-104/},
+DOI = {10.5194/wes-2019-104}
+}
+
+@article{ainslie1988calculating,
+  title={Calculating the flowfield in the wake of wind turbines},
+  author={Ainslie, John F},
+  journal={Journal of Wind Engineering and Industrial Aerodynamics},
+  volume={27},
+  number={1-3},
+  pages={213--224},
+  year={1988},
+  publisher={Elsevier}
+}
+
+@InProceedings{nygaard2020modelling,
+  author       = {Nygaard, Nicolai Gayle and Steen, S{\o}ren Trads and Poulsen, Lina and Pedersen, Jesper Gr{\o}nnegaard},
+  booktitle    = {Journal of Physics: Conference Series},
+  title        = {Modelling cluster wakes and wind farm blockage},
+  year         = {2020},
+  number       = {6},
+  organization = {IOP Publishing},
+  pages        = {062072},
+  volume       = {1618},
 }

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -250,3 +250,24 @@ DOI = {10.5194/wes-2019-104}
   pages        = {062072},
   volume       = {1618},
 }
+
+@article{bastankhah_2021, 
+  title={Analytical solution for the cumulative wake of wind turbines in wind farms}, 
+  volume={911}, 
+  DOI={10.1017/jfm.2020.1037}, 
+  journal={Journal of Fluid Mechanics}, 
+  publisher={Cambridge University Press}, 
+  author={Bastankhah, Majid and Welch, Bridget L. and Martínez-Tossas, Luis A. and King, Jennifer and Fleming, Paul}, 
+  year={2021}, 
+  pages={A53}}
+
+@Article{bay_2022,
+AUTHOR = {Bay, C. J. and Fleming, P. and Doekemeijer, B. and King, J. and Churchfield, M. and Mudafort, R.},
+TITLE = {Addressing deep array effects and impacts to wake steering with the cumulative-curl wake model},
+JOURNAL = {Wind Energy Science Discussions},
+VOLUME = {2022},
+YEAR = {2022},
+PAGES = {1--28},
+URL = {https://wes.copernicus.org/preprints/wes-2022-17/},
+DOI = {10.5194/wes-2022-17}
+}

--- a/floris/simulation/wake_combination/max.py
+++ b/floris/simulation/wake_combination/max.py
@@ -24,7 +24,7 @@ class MAX(BaseModel):
     :cite:`max-gunn2016limitations`.
 
     References:
-        .. bibliography:: /source/zrefs.bib
+        .. bibliography:: /references.bib
             :style: unsrt
             :filter: docname in docnames
             :keyprefix: max-

--- a/floris/simulation/wake_deflection/gauss.py
+++ b/floris/simulation/wake_deflection/gauss.py
@@ -65,7 +65,7 @@ class GaussVelocityDeflection(BaseModel):
                 See property on super-class for more details.
 
     References:
-        .. bibliography:: /source/zrefs.bib
+        .. bibliography:: /references.bib
             :style: unsrt
             :filter: docname in docnames
             :keyprefix: gdm-

--- a/floris/simulation/wake_deflection/jimenez.py
+++ b/floris/simulation/wake_deflection/jimenez.py
@@ -31,7 +31,7 @@ class JimenezVelocityDeflection(BaseModel):
     :cite:`jdm-jimenez2010application`.
 
     References:
-        .. bibliography:: /source/zrefs.bib
+        .. bibliography:: /references.bib
             :style: unsrt
             :filter: docname in docnames
             :keyprefix: jdm-

--- a/floris/simulation/wake_turbulence/crespo_hernandez.py
+++ b/floris/simulation/wake_turbulence/crespo_hernandez.py
@@ -48,7 +48,7 @@ class CrespoHernandez(BaseModel):
                 turbulence.
 
     References:
-        .. bibliography:: /source/zrefs.bib
+        .. bibliography:: /references.bib
             :style: unsrt
             :filter: docname in docnames
             :keyprefix: cht-

--- a/floris/simulation/wake_velocity/cumulative_gauss_curl.py
+++ b/floris/simulation/wake_velocity/cumulative_gauss_curl.py
@@ -26,6 +26,15 @@ from floris.utilities import cosd, sind, tand
 
 @define
 class CumulativeGaussCurlVelocityDeficit(BaseModel):
+    """
+    The cumulative curl model ...
+
+    References:
+    .. bibliography:: /source/zrefs.bib
+        :style: unsrt
+        :filter: docname in docnames
+        :keyprefix: gdm-
+    """
 
     a_s: float = field(default=0.179367259)
     b_s: float = field(default=0.0118889215)

--- a/floris/simulation/wake_velocity/cumulative_gauss_curl.py
+++ b/floris/simulation/wake_velocity/cumulative_gauss_curl.py
@@ -27,7 +27,9 @@ from floris.utilities import cosd, sind, tand
 @define
 class CumulativeGaussCurlVelocityDeficit(BaseModel):
     """
-    The cumulative curl model ...
+    The cumulative curl model is an implementation of the model described in
+    :cite:`gdm-bay_2022`, which itself is based on the cumulative model of
+    :cite:`bastankhah_2021`
 
     References:
     .. bibliography:: /source/zrefs.bib

--- a/floris/simulation/wake_velocity/cumulative_gauss_curl.py
+++ b/floris/simulation/wake_velocity/cumulative_gauss_curl.py
@@ -32,7 +32,7 @@ class CumulativeGaussCurlVelocityDeficit(BaseModel):
     :cite:`bastankhah_2021`
 
     References:
-    .. bibliography:: /source/zrefs.bib
+    .. bibliography:: /references.bib
         :style: unsrt
         :filter: docname in docnames
         :keyprefix: gdm-

--- a/floris/simulation/wake_velocity/jensen.py
+++ b/floris/simulation/wake_velocity/jensen.py
@@ -35,7 +35,7 @@ class JensenVelocityDeficit(BaseModel):
         wake.
 
     References:
-        .. bibliography:: /source/zrefs.bib
+        .. bibliography:: /references.bib
             :style: unsrt
             :filter: docname in docnames
             :keyprefix: jvm-

--- a/floris/tools/wind_rose.py
+++ b/floris/tools/wind_rose.py
@@ -40,7 +40,7 @@ class WindRose:
     for visualizing wind roses.
 
     References:
-        .. bibliography:: /source/zrefs.bib
+        .. bibliography:: /references.bib
             :style: unsrt
             :filter: docname in docnames
             :keyprefix: wr-


### PR DESCRIPTION
**Feature or improvement description**
This pull request updates the references listing in the documentation to include the references from the [v2 docs](https://github.com/NREL/floris/blob/v2/docs/source/zrefs.bib). It replaces references to `zrefs.bib`, the old file name, with `references.bib`. Finally, references for the cumulative-curl model are added.
