### PR TITLE
Configure isort and apply rules

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -58,6 +58,31 @@ to fit a specific use case or purpose. If significant development has
 happened locally, then [merge conflicts](https://www.atlassian.com/git/tutorials/using-branches/merge-conflicts)
 are likely and should be resolved as early as possible.
 
+
+## Code quality tools
+
+FLORIS is configured to use tools to automatically check and enforce
+aspects of code quality. In general, these should be adopted by all
+developers and incorporated into the development workflow. Most
+tools are configured in [pyproject.toml](https://github.com/NREL/floris/blob/main/pyproject.toml),
+but some may have a dedicated configuration file.
+
+### isort
+
+Import lines can easily get out of hand and cause unnecessary distraction
+in source code files. [isort](https://pycqa.github.io/isort/index.html)
+it used to automatically manage imports in the source code. It can be run
+directly with the following command:
+
+```bash
+isort <path to file>
+isort dir/*
+```
+
+This tool was initially configured in [#535](https://github.com/NREL/floris/pull/535),
+and additional information on specific decisions can be found there.
+
+
 ## Testing
 
 In order to maintain a level of confidence in the software, FLORIS is expected

--- a/examples/01_opening_floris_computing_power.py
+++ b/examples/01_opening_floris_computing_power.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from floris.tools import FlorisInterface
 
+
 """
 This example creates a FLORIS instance
 1) Makes a two-turbine layout

--- a/examples/02_visualizations.py
+++ b/examples/02_visualizations.py
@@ -15,8 +15,9 @@
 
 import matplotlib.pyplot as plt
 
-from floris.tools import FlorisInterface
 import floris.tools.visualization as wakeviz
+from floris.tools import FlorisInterface
+
 
 """
 This example initializes the FLORIS software, and then uses internal

--- a/examples/03_making_adjustments.py
+++ b/examples/03_making_adjustments.py
@@ -16,8 +16,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from floris.tools import FlorisInterface
 import floris.tools.visualization as wakeviz
+from floris.tools import FlorisInterface
+
 
 """
 This example makes changes to the given input file through the script.

--- a/examples/04_sweep_wind_directions.py
+++ b/examples/04_sweep_wind_directions.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from floris.tools import FlorisInterface
 
+
 """
 04_sweep_wind_directions
 

--- a/examples/05_sweep_wind_speeds.py
+++ b/examples/05_sweep_wind_speeds.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from floris.tools import FlorisInterface
 
+
 """
 05_sweep_wind_speeds
 

--- a/examples/06_sweep_wind_conditions.py
+++ b/examples/06_sweep_wind_conditions.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from floris.tools import FlorisInterface
 
+
 """
 06_sweep_wind_conditions
 

--- a/examples/07_calc_aep_from_rose.py
+++ b/examples/07_calc_aep_from_rose.py
@@ -16,7 +16,9 @@
 import numpy as np
 import pandas as pd
 from scipy.interpolate import NearestNDInterpolator
+
 from floris.tools import FlorisInterface
+
 
 """
 This example demonstrates how to calculate the Annual Energy Production (AEP)

--- a/examples/08_calc_aep_from_rose_use_class.py
+++ b/examples/08_calc_aep_from_rose_use_class.py
@@ -13,8 +13,13 @@
 # See https://floris.readthedocs.io for documentation
 
 
-from floris.tools import FlorisInterface, WindRose, wind_rose
 import floris.tools.visualization as wakeviz
+from floris.tools import (
+    FlorisInterface,
+    wind_rose,
+    WindRose
+)
+
 
 """
 This example demonstrates how to calculate the Annual Energy Production (AEP)

--- a/examples/09_compare_farm_power_with_neighbor.py
+++ b/examples/09_compare_farm_power_with_neighbor.py
@@ -13,9 +13,11 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import numpy as np
-from floris.tools import FlorisInterface
 import matplotlib.pyplot as plt
+import numpy as np
+
+from floris.tools import FlorisInterface
+
 
 """
 This example demonstrates how to use turbine_wieghts to define a set of turbines belonging to a neighboring farm which

--- a/examples/10_opt_yaw_single_ws.py
+++ b/examples/10_opt_yaw_single_ws.py
@@ -12,12 +12,14 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 from floris.tools import FlorisInterface
 from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
-    YawOptimizationSR,
+    YawOptimizationSR
 )
+
 
 """
 This example demonstrates how to perform a yaw optimization for multiple wind directions and 1 wind speed.

--- a/examples/10_opt_yaw_single_ws.py
+++ b/examples/10_opt_yaw_single_ws.py
@@ -16,9 +16,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from floris.tools import FlorisInterface
-from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
-    YawOptimizationSR
-)
+from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 
 
 """

--- a/examples/11_opt_yaw_multiple_ws.py
+++ b/examples/11_opt_yaw_multiple_ws.py
@@ -16,9 +16,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from floris.tools import FlorisInterface
-from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
-    YawOptimizationSR
-)
+from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 
 
 """

--- a/examples/11_opt_yaw_multiple_ws.py
+++ b/examples/11_opt_yaw_multiple_ws.py
@@ -12,12 +12,14 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
 from floris.tools import FlorisInterface
 from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
-    YawOptimizationSR,
+    YawOptimizationSR
 )
+
 
 """
 This example demonstrates how to perform a yaw optimization for multiple wind directions and multiple wind speeds.

--- a/examples/12_optimize_yaw.py
+++ b/examples/12_optimize_yaw.py
@@ -14,13 +14,16 @@
 
 
 from time import perf_counter as timerpc
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 from floris.tools import FlorisInterface
 from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
-    YawOptimizationSR,
+    YawOptimizationSR
 )
+
 
 """
 This example demonstrates how to perform a yaw optimization and evaluate the performance over a full wind rose.

--- a/examples/12_optimize_yaw.py
+++ b/examples/12_optimize_yaw.py
@@ -20,9 +20,7 @@ import numpy as np
 import pandas as pd
 
 from floris.tools import FlorisInterface
-from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
-    YawOptimizationSR
-)
+from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 
 
 """

--- a/examples/13_optimize_yaw_with_neighboring_farm.py
+++ b/examples/13_optimize_yaw_with_neighboring_farm.py
@@ -16,11 +16,12 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from scipy.interpolate import NearestNDInterpolator
+
 from floris.tools import FlorisInterface
 from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
-    YawOptimizationSR,
+    YawOptimizationSR
 )
-from scipy.interpolate import NearestNDInterpolator
 
 
 """

--- a/examples/13_optimize_yaw_with_neighboring_farm.py
+++ b/examples/13_optimize_yaw_with_neighboring_farm.py
@@ -19,9 +19,7 @@ import pandas as pd
 from scipy.interpolate import NearestNDInterpolator
 
 from floris.tools import FlorisInterface
-from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
-    YawOptimizationSR
-)
+from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 
 
 """

--- a/examples/14_compare_yaw_optimizers.py
+++ b/examples/14_compare_yaw_optimizers.py
@@ -18,12 +18,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from floris.tools import FlorisInterface
-from floris.tools.optimization.yaw_optimization.yaw_optimizer_scipy import (
-    YawOptimizationScipy
-)
-from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
-    YawOptimizationSR
-)
+from floris.tools.optimization.yaw_optimization.yaw_optimizer_scipy import YawOptimizationScipy
+from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 
 
 """

--- a/examples/14_compare_yaw_optimizers.py
+++ b/examples/14_compare_yaw_optimizers.py
@@ -13,8 +13,10 @@
 # See https://floris.readthedocs.io for documentation
 
 from time import perf_counter as timerpc
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
+
 from floris.tools import FlorisInterface
 from floris.tools.optimization.yaw_optimization.yaw_optimizer_scipy import (
     YawOptimizationScipy

--- a/examples/15_optimize_layout.py
+++ b/examples/15_optimize_layout.py
@@ -14,11 +14,14 @@
 
 
 import os
+
 import numpy as np
 
 from floris.tools import FlorisInterface
+from floris.tools.optimization.layout_optimization.layout_optimization_scipy import (
+    LayoutOptimizationScipy
+)
 
-from floris.tools.optimization.layout_optimization.layout_optimization_scipy import LayoutOptimizationScipy
 
 """
 This example shows a simple layout optimization using the python module Scipy.

--- a/examples/16_heterogeneous_inflow.py
+++ b/examples/16_heterogeneous_inflow.py
@@ -19,6 +19,7 @@ from floris.tools import FlorisInterface
 from floris.tools.floris_interface import generate_heterogeneous_wind_map
 from floris.tools.visualization import visualize_cut_plane
 
+
 """
 This example showcases the heterogeneous inflow capabilities of FLORIS.
 Heterogeneous flow can be defined in either 2- or 3-dimensions.

--- a/examples/17_multiple_turbine_types.py
+++ b/examples/17_multiple_turbine_types.py
@@ -15,8 +15,9 @@
 
 import matplotlib.pyplot as plt
 
-from floris.tools import FlorisInterface
 import floris.tools.visualization as wakeviz
+from floris.tools import FlorisInterface
+
 
 """
 This example uses an input file where multiple turbine types are defined.

--- a/examples/18_check_turbine.py
+++ b/examples/18_check_turbine.py
@@ -13,11 +13,13 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import matplotlib.pyplot as plt
-import numpy as np
 import os
 
+import matplotlib.pyplot as plt
+import numpy as np
+
 from floris.tools import FlorisInterface
+
 
 """
 For each turbine in the turbine library, make a small figure showing that its power curve and power loss to yaw are reasonable and 

--- a/examples/19_streamlit_demo.py
+++ b/examples/19_streamlit_demo.py
@@ -14,12 +14,15 @@
 
 
 import matplotlib.pyplot as plt
-import streamlit as st
 import numpy as np
-# import seaborn as sns
+import streamlit as st
 
 from floris.tools import FlorisInterface
 from floris.tools.visualization import visualize_cut_plane
+
+
+# import seaborn as sns
+
 
 
 # """

--- a/examples/21_demo_time_series.py
+++ b/examples/21_demo_time_series.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from floris.tools import FlorisInterface
 
+
 """
 This example demonstrates running FLORIS in time series mode.
 

--- a/examples/22_get_wind_speed_at_turbines.py
+++ b/examples/22_get_wind_speed_at_turbines.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from floris.tools import FlorisInterface
 
+
 # Initialize FLORIS with the given input file via FlorisInterface.
 # For basic usage, FlorisInterface provides a simplified and expressive
 # entry point to the simulation routines.

--- a/floris/__init__.py
+++ b/floris/__init__.py
@@ -14,5 +14,6 @@
 
 from pathlib import Path
 
+
 with open(Path(__file__).parent / "version.py") as _version_file:
     __version__ = _version_file.read().strip()

--- a/floris/simulation/base.py
+++ b/floris/simulation/base.py
@@ -19,12 +19,16 @@ Defines the BaseClass parent class for all models to be based upon.
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, Final
+from typing import (
+    Any,
+    Dict,
+    Final
+)
 
 import attrs
 
-from floris.type_dec import FromDictMixin
 from floris.logging_manager import LoggerBase
+from floris.type_dec import FromDictMixin
 
 
 class State(Enum):

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -10,23 +10,27 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# from __future__ import annotations
+from __future__ import annotations
+
+import copy
+from pathlib import Path
 from typing import Any, List
 
 import attrs
-from attrs import define, field
 import numpy as np
-from pathlib import Path
-import copy
+from attrs import define, field
 
-from floris.type_dec import (
-    NDArrayObject,
-    floris_array_converter,
-    NDArrayFloat
+from floris.simulation import (
+    BaseClass,
+    State,
+    Turbine
 )
-from floris.utilities import Vec3, load_yaml
-from floris.simulation import BaseClass, State
-from floris.simulation import Turbine
+from floris.type_dec import (
+    floris_array_converter,
+    NDArrayFloat,
+    NDArrayObject
+)
+from floris.utilities import load_yaml, Vec3
 
 
 @define

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -16,28 +16,29 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+
 import yaml
-from floris.utilities import load_yaml
+from attrs import define, field
 
 import floris.logging_manager as logging_manager
 from floris.simulation import (
     BaseClass,
+    cc_solver,
     Farm,
-    WakeModelManager,
     FlowField,
-    Grid,
-    TurbineGrid,
     FlowFieldGrid,
     FlowFieldPlanarGrid,
-    State,
-    sequential_solver,
-    cc_solver,
-    turbopark_solver,
-    full_flow_sequential_solver,
     full_flow_cc_solver,
+    full_flow_sequential_solver,
     full_flow_turbopark_solver,
+    Grid,
+    sequential_solver,
+    State,
+    TurbineGrid,
+    turbopark_solver,
+    WakeModelManager
 )
-from attrs import define, field
+from floris.utilities import load_yaml
 
 
 @define

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -15,15 +15,15 @@
 from __future__ import annotations
 
 import attrs
-from attrs import define, field
 import numpy as np
+from attrs import define, field
 
-from floris.type_dec import (
-    FromDictMixin,
-    NDArrayFloat,
-    floris_array_converter
-)
 from floris.simulation import Grid
+from floris.type_dec import (
+    floris_array_converter,
+    FromDictMixin,
+    NDArrayFloat
+)
 
 
 @define

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -19,16 +19,17 @@ from abc import ABC, abstractmethod
 from typing import Iterable
 
 import attrs
-from attrs import define, field
 import numpy as np
+from attrs import define, field
 
-from floris.utilities import Vec3, rotate_coordinates_rel_west
-from floris.type_dec import  (
-    floris_float_type,
+from floris.type_dec import (
     floris_array_converter,
+    floris_float_type,
     NDArrayFloat,
     NDArrayInt
 )
+from floris.utilities import rotate_coordinates_rel_west, Vec3
+
 
 @define
 class Grid(ABC):

--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -11,14 +11,19 @@
 # the License.
 
 import copy
-import numpy as np
-import time
 import sys
+import time
 
-from floris.simulation import Farm
-from floris.simulation import TurbineGrid, FlowFieldGrid
-from floris.simulation import Ct, axial_induction
-from floris.simulation import FlowField
+import numpy as np
+
+from floris.simulation import (
+    axial_induction,
+    Ct,
+    Farm,
+    FlowField,
+    FlowFieldGrid,
+    TurbineGrid
+)
 from floris.simulation.turbine import average_velocity
 from floris.simulation.wake import WakeModelManager
 from floris.simulation.wake_deflection.gauss import (

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -13,23 +13,24 @@
 # See https://floris.readthedocs.io for documentation
 
 from __future__ import annotations
+
 from collections.abc import Iterable
 
 import attrs
-from attrs import define, field
 import numpy as np
+from attrs import define, field
 from scipy.interpolate import interp1d
 
+from floris.simulation import BaseClass
 from floris.type_dec import (
     floris_array_converter,
-    NDArrayFloat,
-    NDArrayFilter,
-    NDArrayInt,
-    NDArrayObject,
     FromDictMixin,
+    NDArrayFilter,
+    NDArrayFloat,
+    NDArrayInt,
+    NDArrayObject
 )
 from floris.utilities import cosd
-from floris.simulation import BaseClass
 
 
 def _filter_convert(

--- a/floris/simulation/wake.py
+++ b/floris/simulation/wake.py
@@ -16,19 +16,23 @@ import attrs
 from attrs import define, field
 
 from floris.simulation import BaseClass, BaseModel
+from floris.simulation.wake_combination import (
+    FLS,
+    MAX,
+    SOSFS
+)
 from floris.simulation.wake_deflection import (
     GaussVelocityDeflection,
     JimenezVelocityDeflection,
-    NoneVelocityDeflection,
+    NoneVelocityDeflection
 )
-from floris.simulation.wake_combination import FLS, MAX, SOSFS
 from floris.simulation.wake_turbulence import CrespoHernandez, NoneWakeTurbulence
 from floris.simulation.wake_velocity import (
-    NoneVelocityDeficit,
     CumulativeGaussCurlVelocityDeficit,
     GaussVelocityDeficit,
     JensenVelocityDeficit,
-    TurbOParkVelocityDeficit,
+    NoneVelocityDeficit,
+    TurbOParkVelocityDeficit
 )
 
 

--- a/floris/simulation/wake_combination/fls.py
+++ b/floris/simulation/wake_combination/fls.py
@@ -10,8 +10,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from attrs import define
 import numpy as np
+from attrs import define
 
 from floris.simulation import BaseModel
 

--- a/floris/simulation/wake_combination/max.py
+++ b/floris/simulation/wake_combination/max.py
@@ -10,8 +10,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from attrs import define
 import numpy as np
+from attrs import define
 
 from floris.simulation import BaseModel
 

--- a/floris/simulation/wake_combination/sosfs.py
+++ b/floris/simulation/wake_combination/sosfs.py
@@ -10,8 +10,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from attrs import define
 import numpy as np
+from attrs import define
 
 from floris.simulation import BaseModel
 

--- a/floris/simulation/wake_deflection/gauss.py
+++ b/floris/simulation/wake_deflection/gauss.py
@@ -12,14 +12,16 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+from attrs import define, field
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
+from floris.simulation import (
+    BaseModel,
+    Farm,
+    FlowField,
+    Grid,
+    Turbine
+)
 from floris.utilities import cosd, sind
 
 

--- a/floris/simulation/wake_deflection/jimenez.py
+++ b/floris/simulation/wake_deflection/jimenez.py
@@ -12,15 +12,17 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numexpr as ne
 import numpy as np
+from attrs import define, field
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
+from floris.simulation import (
+    BaseModel,
+    Farm,
+    FlowField,
+    Grid,
+    Turbine
+)
 from floris.utilities import cosd, sind
 
 

--- a/floris/simulation/wake_deflection/none.py
+++ b/floris/simulation/wake_deflection/none.py
@@ -12,12 +12,14 @@
 
 from typing import Any, Dict
 
-from attrs import define
 import numpy as np
+from attrs import define
 
-from floris.simulation import BaseModel
-from floris.simulation import FlowField
-from floris.simulation import Grid
+from floris.simulation import (
+    BaseModel,
+    FlowField,
+    Grid
+)
 
 
 @define

--- a/floris/simulation/wake_turbulence/crespo_hernandez.py
+++ b/floris/simulation/wake_turbulence/crespo_hernandez.py
@@ -12,14 +12,16 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+from attrs import define, field
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
+from floris.simulation import (
+    BaseModel,
+    Farm,
+    FlowField,
+    Grid,
+    Turbine
+)
 from floris.utilities import cosd, sind
 
 

--- a/floris/simulation/wake_turbulence/none.py
+++ b/floris/simulation/wake_turbulence/none.py
@@ -12,8 +12,8 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+from attrs import define, field
 
 from floris.simulation import BaseModel
 

--- a/floris/simulation/wake_velocity/__init__.py
+++ b/floris/simulation/wake_velocity/__init__.py
@@ -13,9 +13,7 @@
 # See https://floris.readthedocs.io for documentation
 
 
-from floris.simulation.wake_velocity.cumulative_gauss_curl import (
-    CumulativeGaussCurlVelocityDeficit
-)
+from floris.simulation.wake_velocity.cumulative_gauss_curl import CumulativeGaussCurlVelocityDeficit
 from floris.simulation.wake_velocity.gauss import GaussVelocityDeficit
 from floris.simulation.wake_velocity.jensen import JensenVelocityDeficit
 from floris.simulation.wake_velocity.none import NoneVelocityDeficit

--- a/floris/simulation/wake_velocity/__init__.py
+++ b/floris/simulation/wake_velocity/__init__.py
@@ -13,8 +13,10 @@
 # See https://floris.readthedocs.io for documentation
 
 
-from floris.simulation.wake_velocity.none import NoneVelocityDeficit
-from floris.simulation.wake_velocity.cumulative_gauss_curl import CumulativeGaussCurlVelocityDeficit
+from floris.simulation.wake_velocity.cumulative_gauss_curl import (
+    CumulativeGaussCurlVelocityDeficit
+)
 from floris.simulation.wake_velocity.gauss import GaussVelocityDeficit
 from floris.simulation.wake_velocity.jensen import JensenVelocityDeficit
+from floris.simulation.wake_velocity.none import NoneVelocityDeficit
 from floris.simulation.wake_velocity.turbopark import TurbOParkVelocityDeficit

--- a/floris/simulation/wake_velocity/cumulative_gauss_curl.py
+++ b/floris/simulation/wake_velocity/cumulative_gauss_curl.py
@@ -12,16 +12,22 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+from attrs import define, field
 from scipy.special import gamma
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
-from floris.utilities import cosd, sind, tand
+from floris.simulation import (
+    BaseModel,
+    Farm,
+    FlowField,
+    Grid,
+    Turbine
+)
+from floris.utilities import (
+    cosd,
+    sind,
+    tand
+)
 
 
 @define

--- a/floris/simulation/wake_velocity/gauss.py
+++ b/floris/simulation/wake_velocity/gauss.py
@@ -12,16 +12,22 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numexpr as ne
 import numpy as np
+from attrs import define, field
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
-from floris.utilities import cosd, sind, tand
+from floris.simulation import (
+    BaseModel,
+    Farm,
+    FlowField,
+    Grid,
+    Turbine
+)
+from floris.utilities import (
+    cosd,
+    sind,
+    tand
+)
 
 
 @define

--- a/floris/simulation/wake_velocity/jensen.py
+++ b/floris/simulation/wake_velocity/jensen.py
@@ -12,15 +12,17 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numexpr as ne
 import numpy as np
+from attrs import define, field
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
+from floris.simulation import (
+    BaseModel,
+    Farm,
+    FlowField,
+    Grid,
+    Turbine
+)
 
 
 @define

--- a/floris/simulation/wake_velocity/none.py
+++ b/floris/simulation/wake_velocity/none.py
@@ -12,12 +12,14 @@
 
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
+from attrs import define, field
 
-from floris.simulation import BaseModel
-from floris.simulation import FlowField
-from floris.simulation import Grid
+from floris.simulation import (
+    BaseModel,
+    FlowField,
+    Grid
+)
 
 
 @define

--- a/floris/simulation/wake_velocity/turbopark.py
+++ b/floris/simulation/wake_velocity/turbopark.py
@@ -10,21 +10,27 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+from pathlib import Path
 from typing import Any, Dict
 
-from attrs import define, field
 import numpy as np
-from pathlib import Path
+import scipy.io
+from attrs import define, field
 from scipy import integrate
 from scipy.interpolate import RegularGridInterpolator
-import scipy.io
 
-from floris.simulation import BaseModel
-from floris.simulation import Farm
-from floris.simulation import FlowField
-from floris.simulation import Grid
-from floris.simulation import Turbine
-from floris.utilities import cosd, sind, tand
+from floris.simulation import (
+    BaseModel,
+    Farm,
+    FlowField,
+    Grid,
+    Turbine
+)
+from floris.utilities import (
+    cosd,
+    sind,
+    tand
+)
 
 
 @define

--- a/floris/tools/__init__.py
+++ b/floris/tools/__init__.py
@@ -38,9 +38,15 @@ Examples:
 
 from .floris_interface import FlorisInterface
 from .floris_interface_legacy_reader import FlorisInterfaceLegacyV2
-from .visualization import visualize_cut_plane, visualize_quiver, plot_turbines_with_fi, plot_rotor_values
-from .wind_rose import WindRose
 from .uncertainty_interface import UncertaintyInterface
+from .visualization import (
+    plot_rotor_values,
+    plot_turbines_with_fi,
+    visualize_cut_plane,
+    visualize_quiver
+)
+from .wind_rose import WindRose
+
 
 # from floris.tools import (
     # cut_plane,

--- a/floris/tools/cc_blade_utilities.py
+++ b/floris/tools/cc_blade_utilities.py
@@ -1,12 +1,12 @@
 # functions to couple floris with CCBlade and a controller
 
-import os
 import copy
+import os
 import pickle
 from os import path
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from scipy import interpolate
 
 import floris.tools as wfct

--- a/floris/tools/cut_plane.py
+++ b/floris/tools/cut_plane.py
@@ -15,9 +15,9 @@
 
 import copy
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 from scipy.interpolate import griddata
 
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -20,14 +20,16 @@ import numpy as np
 import pandas as pd
 from scipy.interpolate import LinearNDInterpolator, NearestNDInterpolator
 
-from floris.type_dec import NDArrayFloat
-from floris.simulation import Floris
 from floris.logging_manager import LoggerBase
-
-from floris.simulation import State
-
+from floris.simulation import Floris, State
+from floris.simulation.turbine import (
+    average_velocity,
+    axial_induction,
+    Ct,
+    power
+)
 from floris.tools.cut_plane import CutPlane
-from floris.simulation.turbine import Ct, power, axial_induction, average_velocity
+from floris.type_dec import NDArrayFloat
 
 
 class FlorisInterface(LoggerBase):

--- a/floris/tools/floris_interface_legacy_reader.py
+++ b/floris/tools/floris_interface_legacy_reader.py
@@ -14,9 +14,9 @@
 
 from __future__ import annotations
 
-import os
 import copy
 import json
+import os
 from pathlib import Path
 
 from floris.tools import FlorisInterface

--- a/floris/tools/layout_functions.py
+++ b/floris/tools/layout_functions.py
@@ -18,12 +18,12 @@
 
 import math
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-
-import matplotlib.pyplot as plt
-from floris.utilities import wrap_360
 from scipy.spatial.distance import pdist, squareform
+
+from floris.utilities import wrap_360
 
 
 # All functions assume a dataframe with index turbine, and columns x and y

--- a/floris/tools/optimization/__init__.py
+++ b/floris/tools/optimization/__init__.py
@@ -1,1 +1,6 @@
-from . import other, legacy, yaw_optimization, layout_optimization
+from . import (
+    layout_optimization,
+    legacy,
+    other,
+    yaw_optimization
+)

--- a/floris/tools/optimization/layout_optimization/layout_optimization_base.py
+++ b/floris/tools/optimization/layout_optimization/layout_optimization_base.py
@@ -12,11 +12,12 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
 import matplotlib.pyplot as plt
-from shapely.geometry import Polygon, LineString
+import numpy as np
+from shapely.geometry import LineString, Polygon
 
 from ....logging_manager import LoggerBase
+
 
 class LayoutOptimization(LoggerBase):
     def __init__(self, fi, boundaries, min_dist=None, freq=None):

--- a/floris/tools/optimization/layout_optimization/layout_optimization_boundary_grid.py
+++ b/floris/tools/optimization/layout_optimization/layout_optimization_boundary_grid.py
@@ -13,12 +13,17 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import numpy as np
 import matplotlib.pyplot as plt
-from shapely.geometry import Point, Polygon, LineString
+import numpy as np
 from scipy.spatial.distance import cdist
+from shapely.geometry import (
+    LineString,
+    Point,
+    Polygon
+)
 
 from .layout_optimization_base import LayoutOptimization
+
 
 class LayoutOptimizationBoundaryGrid(LayoutOptimization):
     def __init__(

--- a/floris/tools/optimization/layout_optimization/layout_optimization_pyoptsparse.py
+++ b/floris/tools/optimization/layout_optimization/layout_optimization_pyoptsparse.py
@@ -13,12 +13,13 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import numpy as np
 import matplotlib.pyplot as plt
-from shapely.geometry import Point
+import numpy as np
 from scipy.spatial.distance import cdist
+from shapely.geometry import Point
 
 from .layout_optimization_base import LayoutOptimization
+
 
 class LayoutOptimizationPyOptSparse(LayoutOptimization):
     def __init__(

--- a/floris/tools/optimization/layout_optimization/layout_optimization_pyoptsparse_spread.py
+++ b/floris/tools/optimization/layout_optimization/layout_optimization_pyoptsparse_spread.py
@@ -13,12 +13,13 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import numpy as np
 import matplotlib.pyplot as plt
-from shapely.geometry import Point
+import numpy as np
 from scipy.spatial.distance import cdist
+from shapely.geometry import Point
 
 from .layout_optimization_base import LayoutOptimization
+
 
 class LayoutOptimizationPyOptSparse(LayoutOptimization):
     def __init__(

--- a/floris/tools/optimization/layout_optimization/layout_optimization_scipy.py
+++ b/floris/tools/optimization/layout_optimization/layout_optimization_scipy.py
@@ -12,13 +12,14 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from scipy.optimize import minimize
-from shapely.geometry import Point
 from scipy.spatial.distance import cdist
+from shapely.geometry import Point
 
 from .layout_optimization_base import LayoutOptimization
+
 
 class LayoutOptimizationScipy(LayoutOptimization):
     def __init__(

--- a/floris/tools/optimization/legacy/pyoptsparse/__init__.py
+++ b/floris/tools/optimization/legacy/pyoptsparse/__init__.py
@@ -1,1 +1,6 @@
-from . import yaw, layout, optimization, power_density
+from . import (
+    layout,
+    optimization,
+    power_density,
+    yaw
+)

--- a/floris/tools/optimization/legacy/pyoptsparse/layout.py
+++ b/floris/tools/optimization/legacy/pyoptsparse/layout.py
@@ -13,10 +13,15 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import numpy as np
 import matplotlib.pyplot as plt
-from shapely.geometry import Polygon, Point, LineString
+import numpy as np
 from scipy.spatial.distance import cdist
+from shapely.geometry import (
+    LineString,
+    Point,
+    Polygon
+)
+
 
 def _norm(val, x1, x2):
         return (val - x1) / (x2 - x1)

--- a/floris/tools/optimization/legacy/pyoptsparse/power_density.py
+++ b/floris/tools/optimization/legacy/pyoptsparse/power_density.py
@@ -15,8 +15,8 @@
 
 import sys
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 
 class PowerDensity:

--- a/floris/tools/optimization/legacy/pyoptsparse/yaw.py
+++ b/floris/tools/optimization/legacy/pyoptsparse/yaw.py
@@ -13,8 +13,8 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from scipy.stats import norm
 
 from ...visualization import visualize_cut_plane

--- a/floris/tools/optimization/legacy/scipy/__init__.py
+++ b/floris/tools/optimization/legacy/scipy/__init__.py
@@ -1,12 +1,12 @@
 from . import (
-    yaw,
-    layout,
     base_COE,
-    optimization,
-    layout_height,
-    power_density,
-    yaw_wind_rose,
-    power_density_1D,
-    yaw_wind_rose_parallel,
     derive_downstream_turbines,
+    layout,
+    layout_height,
+    optimization,
+    power_density,
+    power_density_1D,
+    yaw,
+    yaw_wind_rose,
+    yaw_wind_rose_parallel
 )

--- a/floris/tools/optimization/legacy/scipy/cluster_turbines.py
+++ b/floris/tools/optimization/legacy/scipy/cluster_turbines.py
@@ -13,8 +13,8 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 
 def cluster_turbines(fi, wind_direction=None, wake_slope=0.30, plot_lines=False):

--- a/floris/tools/optimization/legacy/scipy/derive_downstream_turbines.py
+++ b/floris/tools/optimization/legacy/scipy/derive_downstream_turbines.py
@@ -13,8 +13,8 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 
 def derive_downstream_turbines(fi, wind_direction, wake_slope=0.30, plot_lines=False):

--- a/floris/tools/optimization/legacy/scipy/layout.py
+++ b/floris/tools/optimization/legacy/scipy/layout.py
@@ -12,8 +12,8 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from scipy.optimize import minimize
 
 from .optimization import Optimization

--- a/floris/tools/optimization/legacy/scipy/layout_height.py
+++ b/floris/tools/optimization/legacy/scipy/layout_height.py
@@ -12,12 +12,12 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from scipy.optimize import minimize
 
-from .layout import LayoutOptimization
 from .base_COE import BaseCOE
+from .layout import LayoutOptimization
 
 
 class LayoutHeightOptimization(LayoutOptimization):

--- a/floris/tools/optimization/legacy/scipy/optimization.py
+++ b/floris/tools/optimization/legacy/scipy/optimization.py
@@ -12,8 +12,8 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
 
 try:

--- a/floris/tools/optimization/legacy/scipy/power_density.py
+++ b/floris/tools/optimization/legacy/scipy/power_density.py
@@ -12,8 +12,8 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from scipy.optimize import minimize
 
 from .layout import LayoutOptimization

--- a/floris/tools/optimization/legacy/scipy/power_density_1D.py
+++ b/floris/tools/optimization/legacy/scipy/power_density_1D.py
@@ -12,8 +12,8 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 from scipy.optimize import minimize
 
 from .optimization import Optimization

--- a/floris/tools/optimization/legacy/scipy/yaw.py
+++ b/floris/tools/optimization/legacy/scipy/yaw.py
@@ -13,11 +13,11 @@
 # See https://floris.readthedocs.io for documentation
 
 import numpy as np
-from scipy.stats import norm
 from scipy.optimize import minimize
+from scipy.stats import norm
 
-from .optimization import Optimization
 from .derive_downstream_turbines import derive_downstream_turbines
+from .optimization import Optimization
 
 
 class YawOptimization(Optimization):

--- a/floris/tools/optimization/legacy/scipy/yaw_clustered.py
+++ b/floris/tools/optimization/legacy/scipy/yaw_clustered.py
@@ -17,9 +17,9 @@ import copy
 import numpy as np
 import pandas as pd
 
-from .yaw import YawOptimization
-from .cluster_turbines import cluster_turbines
 from ....logging_manager import LoggerBase
+from .cluster_turbines import cluster_turbines
+from .yaw import YawOptimization
 
 
 class YawOptimizationClustered(YawOptimization, LoggerBase):

--- a/floris/tools/optimization/legacy/scipy/yaw_wind_rose.py
+++ b/floris/tools/optimization/legacy/scipy/yaw_wind_rose.py
@@ -14,11 +14,11 @@
 
 import numpy as np
 import pandas as pd
-from scipy.stats import norm
 from scipy.optimize import minimize
+from scipy.stats import norm
 
-from .optimization import Optimization
 from .derive_downstream_turbines import derive_downstream_turbines
+from .optimization import Optimization
 
 
 class YawOptimizationWindRose(Optimization):

--- a/floris/tools/optimization/legacy/scipy/yaw_wind_rose_clustered.py
+++ b/floris/tools/optimization/legacy/scipy/yaw_wind_rose_clustered.py
@@ -17,9 +17,9 @@ import copy
 import numpy as np
 import pandas as pd
 
-from .yaw_wind_rose import YawOptimizationWindRose
-from .cluster_turbines import cluster_turbines
 from ....logging_manager import LoggerBase
+from .cluster_turbines import cluster_turbines
+from .yaw_wind_rose import YawOptimizationWindRose
 
 
 class YawOptimizationWindRoseClustered(YawOptimizationWindRose, LoggerBase):

--- a/floris/tools/optimization/legacy/scipy/yaw_wind_rose_parallel.py
+++ b/floris/tools/optimization/legacy/scipy/yaw_wind_rose_parallel.py
@@ -18,8 +18,8 @@ import numpy as np
 import pandas as pd
 from scipy.optimize import minimize
 
-from .yaw_wind_rose import YawOptimizationWindRose
 from ....logging_manager import LoggerBase
+from .yaw_wind_rose import YawOptimizationWindRose
 
 
 class YawOptimizationWindRoseParallel(YawOptimizationWindRose, LoggerBase):

--- a/floris/tools/optimization/legacy/scipy/yaw_wind_rose_parallel_clustered.py
+++ b/floris/tools/optimization/legacy/scipy/yaw_wind_rose_parallel_clustered.py
@@ -12,15 +12,15 @@
 
 # See https://floris.readthedocs.io for documentation
 
+import copy
 from itertools import repeat
 
-import copy
 import numpy as np
 import pandas as pd
 from scipy.optimize import minimize
 
-from .yaw_wind_rose_clustered import YawOptimizationWindRoseClustered
 from ....logging_manager import LoggerBase
+from .yaw_wind_rose_clustered import YawOptimizationWindRoseClustered
 
 
 class YawOptimizationWindRoseParallelClustered(YawOptimizationWindRoseClustered, LoggerBase):

--- a/floris/tools/optimization/other/boundary_grid.py
+++ b/floris/tools/optimization/other/boundary_grid.py
@@ -14,7 +14,6 @@
 
 
 import numpy as np
-
 from shapely.geometry import Point, Polygon
 
 

--- a/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
@@ -19,10 +19,7 @@ from time import perf_counter as timerpc
 import numpy as np
 import pandas as pd
 
-from .yaw_optimization_tools import (
-    derive_downstream_turbines,
-    find_layout_symmetry,
-)
+from .yaw_optimization_tools import derive_downstream_turbines, find_layout_symmetry
 
 
 class YawOptimization:

--- a/floris/tools/optimization/yaw_optimization/yaw_optimization_tools.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimization_tools.py
@@ -13,8 +13,8 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 
 

--- a/floris/tools/plotting.py
+++ b/floris/tools/plotting.py
@@ -13,10 +13,10 @@
 # See https://floris.readthedocs.io for documentation
 
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-import matplotlib.pyplot as plt
 
 
 class PlotDefaults:

--- a/floris/tools/power_rose.py
+++ b/floris/tools/power_rose.py
@@ -15,9 +15,9 @@
 import os
 import pickle
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 
 from floris.utilities import wrap_180
 

--- a/floris/tools/sowfa_utilities.py
+++ b/floris/tools/sowfa_utilities.py
@@ -18,10 +18,10 @@ import re
 import numpy as np
 import pandas as pd
 
+from ..logging_manager import LoggerBase
+from ..utilities import Vec3
 from .cut_plane import CutPlane, get_plane_from_flow_data
 from .flow_data import FlowData
-from ..utilities import Vec3
-from ..logging_manager import LoggerBase
 
 
 class SowfaInterface(LoggerBase):

--- a/floris/tools/uncertainty_interface.py
+++ b/floris/tools/uncertainty_interface.py
@@ -17,9 +17,9 @@ import copy
 import numpy as np
 from scipy.stats import norm
 
+from floris.logging_manager import LoggerBase
 from floris.tools import FlorisInterface
 from floris.utilities import wrap_360
-from floris.logging_manager import LoggerBase
 
 
 class UncertaintyInterface(LoggerBase):

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -15,14 +15,15 @@ from __future__ import annotations
 
 from typing import Union
 
-import numpy as np
 import matplotlib as mpl
 import matplotlib.colors as mplcolors
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib import rcParams
 
 from floris.tools.floris_interface import FlorisInterface
 from floris.utilities import rotate_coordinates_rel_west
+
 
 def show_plots():
     plt.show()

--- a/floris/tools/wind_rose.py
+++ b/floris/tools/wind_rose.py
@@ -19,14 +19,17 @@
 import os
 import pickle
 
-import numpy as np
-import pandas as pd
 import dateutil
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
-# from pyproj import Proj
+import numpy as np
+import pandas as pd
 
 import floris.utilities as geo
+
+
+# from pyproj import Proj
+
 
 
 class WindRose:

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -12,12 +12,18 @@
 
 # See https://floris.readthedocs.io for documentation
 
-from typing import Any, Iterable, Tuple, Union, Callable
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Tuple,
+    Union
+)
 
 import attrs
-from attrs import define, Attribute
 import numpy as np
 import numpy.typing as npt
+from attrs import Attribute, define
 
 
 ### Define general data types used throughout

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -12,12 +12,12 @@
 
 # See https://floris.readthedocs.io for documentation
 
+import os
 from typing import Tuple
 
-from attrs import define, field
 import numpy as np
 import yaml
-import os
+from attrs import define, field
 
 from floris.type_dec import floris_array_converter, NDArrayFloat
 

--- a/profiling/linux_perf.py
+++ b/profiling/linux_perf.py
@@ -13,11 +13,15 @@
 # See https://floris.readthedocs.io for documentation
 
 from contextlib import contextmanager
-from subprocess import Popen
 from os import getpid
-from signal import SIGINT
-from time import sleep, time, perf_counter
 from resource import getrusage, RUSAGE_SELF
+from signal import SIGINT
+from subprocess import Popen
+from time import (
+    perf_counter,
+    sleep,
+    time
+)
 
 
 # Additional events described here:

--- a/profiling/profiling.py
+++ b/profiling/profiling.py
@@ -19,8 +19,11 @@
 # from copy import deepcopy
 
 import copy
-from floris.simulation import Floris
+
 from conftest import SampleInputs
+
+from floris.simulation import Floris
+
 
 def run_floris():
     floris = Floris.from_file("examples/example_input.yaml")

--- a/profiling/quality_metrics.py
+++ b/profiling/quality_metrics.py
@@ -14,12 +14,14 @@
 
 
 import copy
-import numpy as np
 import time
 import warnings
 
-from floris.simulation import Floris
+import numpy as np
 from linux_perf import perf
+
+from floris.simulation import Floris
+
 
 WIND_DIRECTIONS = np.arange(0, 360.0, 5)
 N_WIND_DIRECTIONS = len(WIND_DIRECTIONS)

--- a/profiling/serial_vectorize.py
+++ b/profiling/serial_vectorize.py
@@ -1,11 +1,12 @@
 
 import copy
-import numpy as np
 import time
+
 import matplotlib.pyplot as plt
+import numpy as np
+from conftest import SampleInputs
 
 from floris.simulation import Floris
-from conftest import SampleInputs
 
 
 def time_vec(input_dict):

--- a/profiling/timing.py
+++ b/profiling/timing.py
@@ -1,12 +1,14 @@
 
 import copy
-import numpy as np
 import time
+
 import matplotlib.pyplot as plt
 import memory_profiler
+import numpy as np
+from conftest import SampleInputs
 
 from floris.simulation import Floris
-from conftest import SampleInputs
+
 
 def time_profile(input_dict):
     floris = Floris.from_dict(input_dict.floris)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,6 @@ exclude = '''
 
 
 [tool.isort]
-multi_line_output = 3
-ensure_newline_before_comments = true
 sections = [
     "FUTURE",
     "STDLIB",
@@ -50,17 +48,20 @@ sections = [
     "FIRSTPARTY",
     "LOCALFOLDER"
 ]
-known_third_party = [
-    "numpy",
-    "pandas",
-    "scipy",
-    "attr"
+known_first_party = [
+    "floris"
 ]
-known_first_party = ["floris"]
+multi_line_output = 3
 combine_as_imports = true
-force_grid_wrap = 0
-include_trailing_comma = true
+force_grid_wrap = 3
+include_trailing_comma = false
 use_parentheses = true
-length_sort = true
 lines_after_imports = 2
 line_length = 88
+order_by_type = false
+
+# length_sort = true
+# case_sensitive: False
+# force_sort_within_sections: True
+# reverse_relative: True
+# sort_relative_in_force_sorted_sections: True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ force_grid_wrap = 3
 include_trailing_comma = false
 use_parentheses = true
 lines_after_imports = 2
-line_length = 88
+line_length = 100
 order_by_type = false
 
 # length_sort = true

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@
 
 
 from pathlib import Path
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 # Package meta-data.

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -14,7 +14,6 @@
 
 
 import pytest
-
 from attr import define, field
 
 from floris.simulation import BaseClass, BaseModel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,13 @@
 
 import numpy as np
 import pytest
-from floris.simulation import Floris
-from floris.simulation import FlowField
-from floris.simulation import TurbineGrid, FlowFieldGrid
+
+from floris.simulation import (
+    Floris,
+    FlowField,
+    FlowFieldGrid,
+    TurbineGrid
+)
 from floris.utilities import Vec3
 
 

--- a/tests/farm_unit_test.py
+++ b/tests/farm_unit_test.py
@@ -14,14 +14,14 @@
 
 import numpy as np
 
-from tests.conftest import SampleInputs
-from floris.utilities import Vec3
 from floris.simulation import Farm
-
+from floris.utilities import Vec3
 from tests.conftest import (
-    N_WIND_SPEEDS,
     N_WIND_DIRECTIONS,
+    N_WIND_SPEEDS,
+    SampleInputs
 )
+
 
 def test_farm_init_homogenous_turbines():
     farm_data = SampleInputs().farm

--- a/tests/floris_interface_test.py
+++ b/tests/floris_interface_test.py
@@ -1,6 +1,7 @@
 
-import numpy as np
 from pathlib import Path
+
+import numpy as np
 
 from floris.tools.floris_interface import FlorisInterface
 

--- a/tests/floris_unit_test.py
+++ b/tests/floris_unit_test.py
@@ -21,7 +21,7 @@ from floris.simulation import (
     Floris,
     FlowField,
     TurbineGrid,
-    WakeModelManager,
+    WakeModelManager
 )
 
 

--- a/tests/grid_unit_test.py
+++ b/tests/grid_unit_test.py
@@ -16,13 +16,14 @@
 import numpy as np
 import pytest
 
+from floris.utilities import Vec3
 from tests.conftest import (
     N_TURBINES,
-    N_WIND_SPEEDS,
-    TURBINE_GRID_RESOLUTION,
     N_WIND_DIRECTIONS,
+    N_WIND_SPEEDS,
+    TURBINE_GRID_RESOLUTION
 )
-from floris.utilities import Vec3
+
 
 # TODO: test the dimension expansion
 

--- a/tests/reg_tests/cumulative_curl_regression_test.py
+++ b/tests/reg_tests/cumulative_curl_regression_test.py
@@ -14,9 +14,21 @@
 
 import numpy as np
 
-from floris.simulation import Floris
-from floris.simulation import Ct, power, axial_induction, average_velocity
-from tests.conftest import N_TURBINES, N_WIND_DIRECTIONS, N_WIND_SPEEDS, print_test_values, assert_results_arrays
+from floris.simulation import (
+    average_velocity,
+    axial_induction,
+    Ct,
+    Floris,
+    power
+)
+from tests.conftest import (
+    assert_results_arrays,
+    N_TURBINES,
+    N_WIND_DIRECTIONS,
+    N_WIND_SPEEDS,
+    print_test_values
+)
+
 
 DEBUG = False
 VELOCITY_MODEL = "cc"

--- a/tests/reg_tests/gauss_regression_test.py
+++ b/tests/reg_tests/gauss_regression_test.py
@@ -14,9 +14,21 @@
 
 import numpy as np
 
-from floris.simulation import Floris
-from floris.simulation import Ct, power, axial_induction, average_velocity
-from tests.conftest import N_TURBINES, N_WIND_DIRECTIONS, N_WIND_SPEEDS, print_test_values, assert_results_arrays
+from floris.simulation import (
+    average_velocity,
+    axial_induction,
+    Ct,
+    Floris,
+    power
+)
+from tests.conftest import (
+    assert_results_arrays,
+    N_TURBINES,
+    N_WIND_DIRECTIONS,
+    N_WIND_SPEEDS,
+    print_test_values
+)
+
 
 DEBUG = False
 VELOCITY_MODEL = "gauss"

--- a/tests/reg_tests/jensen_jimenez_regression_test.py
+++ b/tests/reg_tests/jensen_jimenez_regression_test.py
@@ -14,9 +14,20 @@
 
 import numpy as np
 
-from tests.conftest import N_TURBINES, N_WIND_DIRECTIONS, N_WIND_SPEEDS
-from tests.conftest import print_test_values, assert_results_arrays
-from floris.simulation import Ct, Floris, power, axial_induction, average_velocity
+from floris.simulation import (
+    average_velocity,
+    axial_induction,
+    Ct,
+    Floris,
+    power
+)
+from tests.conftest import (
+    assert_results_arrays,
+    N_TURBINES,
+    N_WIND_DIRECTIONS,
+    N_WIND_SPEEDS,
+    print_test_values
+)
 
 
 DEBUG = False

--- a/tests/reg_tests/none_regression_test.py
+++ b/tests/reg_tests/none_regression_test.py
@@ -15,9 +15,20 @@
 import numpy as np
 import pytest
 
-from tests.conftest import N_TURBINES, N_WIND_DIRECTIONS, N_WIND_SPEEDS
-from tests.conftest import print_test_values, assert_results_arrays
-from floris.simulation import Ct, Floris, power, axial_induction, average_velocity
+from floris.simulation import (
+    average_velocity,
+    axial_induction,
+    Ct,
+    Floris,
+    power
+)
+from tests.conftest import (
+    assert_results_arrays,
+    N_TURBINES,
+    N_WIND_DIRECTIONS,
+    N_WIND_SPEEDS,
+    print_test_values
+)
 
 
 DEBUG = False

--- a/tests/reg_tests/turbopark_regression_test.py
+++ b/tests/reg_tests/turbopark_regression_test.py
@@ -14,9 +14,21 @@
 
 import numpy as np
 
-from floris.simulation import Floris
-from floris.simulation import Ct, power, axial_induction, average_velocity
-from tests.conftest import N_TURBINES, N_WIND_DIRECTIONS, N_WIND_SPEEDS, print_test_values, assert_results_arrays
+from floris.simulation import (
+    average_velocity,
+    axial_induction,
+    Ct,
+    Floris,
+    power
+)
+from tests.conftest import (
+    assert_results_arrays,
+    N_TURBINES,
+    N_WIND_DIRECTIONS,
+    N_WIND_SPEEDS,
+    print_test_values
+)
+
 
 DEBUG = False
 VELOCITY_MODEL = "turbopark"

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -18,9 +18,15 @@ import numpy as np
 import pytest
 from scipy.interpolate import interp1d
 
-from tests.conftest import WIND_SPEEDS, SampleInputs
-from floris.simulation import Ct, Turbine, power, axial_induction, average_velocity
-from floris.simulation.turbine import PowerThrustTable, _filter_convert
+from floris.simulation import (
+    average_velocity,
+    axial_induction,
+    Ct,
+    power,
+    Turbine
+)
+from floris.simulation.turbine import _filter_convert, PowerThrustTable
+from tests.conftest import SampleInputs, WIND_SPEEDS
 
 
 # size 3 x 4 x 1 x 1 x 1

--- a/tests/type_dec_unit_test.py
+++ b/tests/type_dec_unit_test.py
@@ -12,17 +12,18 @@
 
 # See https://floris.readthedocs.io for documentation
 
-import numpy as np
-import pytest
 from typing import List
 
+import numpy as np
+import pytest
 from attrs import define, field
 
 from floris.type_dec import (
-    FromDictMixin,
-    iter_validator,
     floris_array_converter,
+    FromDictMixin,
+    iter_validator
 )
+
 
 @define
 class AttrsDemoClass(FromDictMixin):

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -21,14 +21,18 @@ import pytest
 
 from floris.utilities import (
     cosd,
+    rotate_coordinates_rel_west,
     sind,
     tand,
-    wrap_180,
-    wrap_360,
     wind_delta,
-    rotate_coordinates_rel_west
+    wrap_180,
+    wrap_360
 )
-from tests.conftest import X_COORDS, Y_COORDS, Z_COORDS
+from tests.conftest import (
+    X_COORDS,
+    Y_COORDS,
+    Z_COORDS
+)
 
 
 def test_cosd():

--- a/tests/vec3_unit_test.py
+++ b/tests/vec3_unit_test.py
@@ -15,6 +15,7 @@
 
 import numpy as np
 import pytest
+
 from floris.utilities import Vec3
 
 

--- a/tests/wake_unit_tests.py
+++ b/tests/wake_unit_tests.py
@@ -15,6 +15,7 @@
 from floris.simulation import WakeModelManager
 from tests.conftest import SampleInputs
 
+
 def test_asdict(sample_inputs_fixture: SampleInputs):
 
     wake_model_manager = WakeModelManager.from_dict(sample_inputs_fixture.wake)


### PR DESCRIPTION
**Feature or improvement description**
This pull request configures [isort](https://pycqa.github.io/isort/index.html) and applies the rules to all included modules.

Here's my opinions and reasoning for certain configurations.

- `force_grid_wrap = 3`: Forces that any from-imports with more than three symbols are wrapped. This one is important to me because I like the ability to easily edit or comment out items in a list without destroying the syntax of the list. Three is somewhat arbitrary since the default is two, but intuitively it feels right. With two imports, its pretty straightforward to add a comment mid-line without completely destroying the line. It's also worth pointing out that this preference has more to do with Python syntax style like using containers in code rather than import-styles. However, the import statement syntax should match the code syntax.

```python
# For example...
from turbine import Ct, axial_induction, power

# To remove axial_induction requires to also remove power or restructure the list
from turbine import Ct #, axial_induction, power
from turbine import Ct, power #, axial_induction

# Alternatively, wrapping allows to easily remove axial_induction
from turbine import (
    Ct,
#    axial_induction,
    power
)

# 3 vs 2
# This seems like overkill but I would be happy to change to 2 for consistency
from turbine import (
    Ct,
    power
)
```

- `multi_line_output = 3`: This is consistent with the common form for indented containers in Python code.
- `combine_as_imports = true`: I find it helpful to quickly see all of the renamed packages since this provides additional context for the rest of the file. For example, `import floris.tools.visualization as wakeviz` explains quickly what is `wakeviz` in the code, so it is helpful to see all of these up front and easily parsable.

- `include_trailing_comma = false`: Personal preference, I'm not a fan of the trailing comma but this is highly subjective.
- `line_length = 88`: My preference is longer lines like 100, but 88 seems to be the de facto standard.
- `order_by_type = false`: This order imports by the perceived type based on letter case in a symbol's name (i.e. `Turbine` is a class but `turbine` is a module). Since FLORIS does not strictly adhere to this, I've disabled it.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
Most files but only the import statements.

**Additional supporting information**
This does not yet enforce the ordering via git or GitHub. It is up to the developers to run isort. However, an automated system will be put in place in the future.
