### PR TITLE
Add weights to AEP wind rose

### DIFF
--- a/examples/08_calc_aep_from_rose_use_class.py
+++ b/examples/08_calc_aep_from_rose_use_class.py
@@ -65,7 +65,7 @@ print("Farm AEP (with cut_in/out specified): {:.3f} GWh".format(aep / 1.0e9))
 
 # Compute the AEP a final time, this time marking one of the turbines as 
 # belonging to another farm by setting its weight to 0
-turbine_weights = np.array([1.0, 1.0, 0.0],dtype=int)
+turbine_weights = np.array([1.0, 1.0, 0.0])
 aep = fi.get_farm_AEP_wind_rose_class(
     wind_rose=wind_rose,
     turbine_weights= turbine_weights

--- a/examples/08_calc_aep_from_rose_use_class.py
+++ b/examples/08_calc_aep_from_rose_use_class.py
@@ -12,6 +12,7 @@
 
 # See https://floris.readthedocs.io for documentation
 
+import numpy as np
 
 from floris.tools import FlorisInterface, WindRose, wind_rose
 import floris.tools.visualization as wakeviz
@@ -60,6 +61,15 @@ aep = fi.get_farm_AEP_wind_rose_class(
     cut_out_wind_speed=25.0,  # Wakes are not evaluated above this wind speed
 )
 print("Farm AEP (with cut_in/out specified): {:.3f} GWh".format(aep / 1.0e9))
+
+# Compute the AEP a final time, this time marking one of the turbines as 
+# belonging to another farm by setting its weight to 0
+turbine_weights = np.array([1.0, 1.0, 0.0],dtype=int)
+aep = fi.get_farm_AEP_wind_rose_class(
+    wind_rose=wind_rose,
+    turbine_weights= turbine_weights
+)
+print("Farm AEP (one turbine removed from power calculation): {:.3f} GWh".format(aep / 1.0e9))
 
 # Finally, we can also compute the AEP while ignoring all wake calculations.
 # This can be useful to quantity the annual wake losses in the farm. Such

--- a/examples/08_calc_aep_from_rose_use_class.py
+++ b/examples/08_calc_aep_from_rose_use_class.py
@@ -42,7 +42,8 @@ fi = FlorisInterface("inputs/gch.yaml") # GCH model
 # floris object and assign the layout, wind speed and wind direction arrays.
 D = 126.0 # Rotor diameter for the NREL 5 MW
 fi.reinitialize(
-    layout=[[0.0, 5* D, 10 * D], [0.0, 0.0, 0.0]]
+    layout_x=[0.0, 5* D, 10 * D],
+    layout_y=[0.0, 0.0, 0.0],
 )
 
 # Compute the AEP using the default settings

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -788,6 +788,7 @@ class FlorisInterface(LoggerBase):
         cut_in_wind_speed=0.001,
         cut_out_wind_speed=None,
         yaw_angles=None,
+        turbine_weights=None,
         no_wake=False,
     ) -> float:
         """
@@ -809,6 +810,19 @@ class FlorisInterface(LoggerBase):
                 The relative turbine yaw angles in degrees. If None is
                 specified, will assume that the turbine yaw angles are all
                 zero degrees for all conditions. Defaults to None.
+            turbine_weights (NDArrayFloat | list[float] | None, optional):
+                weighing terms that allow the user to emphasize power at
+                particular turbines and/or completely ignore the power 
+                from other turbines. This is useful when, for example, you are
+                modeling multiple wind farms in a single floris object. If you
+                only want to calculate the power production for one of those
+                farms and include the wake effects of the neighboring farms,
+                you can set the turbine_weights for the neighboring farms'
+                turbines to 0.0. The array of turbine powers from floris
+                is multiplied with this array in the calculation of the
+                objective function. If None, this  is an array with all values
+                1.0 and with shape equal to (n_wind_directions, n_wind_speeds,
+                n_turbines). Defaults to None.
             no_wake: (bool, optional): When *True* updates the turbine
                 quantities without calculating the wake or adding the wake to
                 the flow field. This can be useful when quantifying the loss
@@ -839,6 +853,7 @@ class FlorisInterface(LoggerBase):
             cut_in_wind_speed=cut_in_wind_speed,
             cut_out_wind_speed=cut_out_wind_speed,
             yaw_angles=yaw_angles,
+            turbine_weights=turbine_weights,
             no_wake=no_wake)
 
 


### PR DESCRIPTION
**Feature or improvement description**
Small feature improvement to allow the function get_farm_AEP_wind_rose_class to accept turbine_weights and pass through to the call to get_farm_AEP to enable modeling of turbines in another farm

**Related issue, if one exists**
Issue #540 

**Impacted areas of the software**
floris_interface.py

**Test results, if applicable**
Added usage to 08_calc_aep_from_rose_use_class.py and confirm runs successfully

