### PR TITLE
Add parallel computing interface for farm simulation and yaw optimization

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -108,11 +108,6 @@ Construct wind farm yaw settings for a full wind rose based on the
 optimized yaw settings at a single wind speed. Then, compare
 results to the baseline no-yaw configuration.
 
-### 12_optimize_yaw.py
-Construct wind farm yaw settings for a full wind rose based on the
-optimized yaw settings at a single wind speed. Then, compare
-results to the baseline no-yaw configuration.
-
 ### 12_optimize_yaw_in_parallel.py
 Comparable to the above but perform all the computations using
 parallel processing. In the current example, use 16 cores

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -108,6 +108,17 @@ Construct wind farm yaw settings for a full wind rose based on the
 optimized yaw settings at a single wind speed. Then, compare
 results to the baseline no-yaw configuration.
 
+### 12_optimize_yaw.py
+Construct wind farm yaw settings for a full wind rose based on the
+optimized yaw settings at a single wind speed. Then, compare
+results to the baseline no-yaw configuration.
+
+### 12_optimize_yaw_in_parallel.py
+Comparable to the above but perform all the computations using
+parallel processing. In the current example, use 16 cores
+simultaneously to calculate the AEP and perform a wake steering
+yaw angle optimization for multiple wind speeds.
+
 ### 13_optimize_yaw_with_neighboring_farm.py
 Same as above but considering the effects of a nearby wind farm.
 

--- a/examples/12_optimize_yaw_in_parallel.py
+++ b/examples/12_optimize_yaw_in_parallel.py
@@ -50,6 +50,9 @@ def load_windrose():
 
 
 if __name__ == "__main__":
+    # Parallel options
+    max_workers = 16
+
     # Load a dataframe containing the wind rose information
     df_windrose, windrose_interpolant = load_windrose()
 
@@ -66,8 +69,8 @@ if __name__ == "__main__":
     # Pour this into a parallel computing interface
     fi_aep_parallel = ParallelComputingInterface(
         fi=fi_aep,
-        max_workers=16,
-        n_wind_direction_splits=16,
+        max_workers=max_workers,
+        n_wind_direction_splits=max_workers,
         n_wind_speed_splits=1,
         use_mpi4py=False,
         print_timings=True,
@@ -97,7 +100,7 @@ if __name__ == "__main__":
     # Load a FLORIS object for yaw optimization
     fi_opt = load_floris()
     wind_directions = np.arange(0.0, 360.0, 3.0)
-    wind_speeds=np.arange(6.0, 14.0, 2.0)
+    wind_speeds = np.arange(6.0, 14.0, 2.0)
     fi_opt.reinitialize(
         wind_directions=wind_directions,
         wind_speeds=wind_speeds,
@@ -107,8 +110,8 @@ if __name__ == "__main__":
     # Pour this into a parallel computing interface
     fi_opt_parallel = ParallelComputingInterface(
         fi=fi_opt,
-        max_workers=16,
-        n_wind_direction_splits=16,
+        max_workers=max_workers,
+        n_wind_direction_splits=max_workers,
         n_wind_speed_splits=1,
         use_mpi4py=False,
         print_timings=True,

--- a/examples/12_optimize_yaw_in_parallel.py
+++ b/examples/12_optimize_yaw_in_parallel.py
@@ -1,0 +1,285 @@
+# Copyright 2022 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# See https://floris.readthedocs.io for documentation
+
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.interpolate import LinearNDInterpolator
+
+from floris.tools import FlorisInterface
+from floris.tools import ParallelComputingInterface
+
+"""
+This example demonstrates how to perform a yaw optimization using parallel computing.
+...
+"""
+
+def load_floris():
+    # Load the default example floris object
+    fi = FlorisInterface("inputs/gch.yaml") # GCH model matched to the default "legacy_gauss" of V2
+    # fi = FlorisInterface("inputs/cc.yaml") # New CumulativeCurl model
+
+    # Specify wind farm layout and update in the floris object
+    N = 5  # number of turbines per row and per column
+    X, Y = np.meshgrid(
+        5.0 * fi.floris.farm.rotor_diameters_sorted[0][0][0] * np.arange(0, N, 1),
+        5.0 * fi.floris.farm.rotor_diameters_sorted[0][0][0] * np.arange(0, N, 1),
+    )
+    fi.reinitialize(layout_x=X.flatten(), layout_y=Y.flatten())
+
+    return fi
+
+
+def load_windrose():
+    # Grab a linear interpolant from this wind rose
+    df = pd.read_csv("inputs/wind_rose.csv")
+    interp = LinearNDInterpolator(points=df[["wd", "ws"]], values=df["freq_val"], fill_value=0.0)
+    return df, interp
+
+
+if __name__ == "__main__":
+    # Load a dataframe containing the wind rose information
+    df_windrose, windrose_interpolant = load_windrose()
+
+    # Load a FLORIS object for AEP calculations
+    fi_aep = load_floris()
+    wind_directions = np.arange(0.0, 360.0, 1.0)
+    wind_speeds=np.arange(1.0, 30.0, 1.0)
+    fi_aep.reinitialize(
+        wind_directions=wind_directions,
+        wind_speeds=wind_speeds,
+        turbulence_intensity=0.08  # Assume 8% turbulence intensity
+    )
+
+    # Pour this into a parallel computing interface
+    fi_aep_parallel = ParallelComputingInterface(
+        fi=fi_aep,
+        max_workers=16,
+        n_wind_direction_splits=16,
+        n_wind_speed_splits=1,
+        use_mpi4py=False,
+        print_timings=True,
+    )
+
+    # Calculate frequency of occurrence for each bin and normalize sum to 1.0
+    wd_grid, ws_grid = np.meshgrid(wind_directions, wind_speeds, indexing="ij")
+    freq_grid = windrose_interpolant(wd_grid, ws_grid)
+    freq_grid = freq_grid / np.sum(freq_grid)  # Normalize to 1.0
+
+    # Calculate farm power baseline
+    farm_power_bl = fi_aep_parallel.get_farm_power()
+    aep_bl = np.sum(24 * 365 * np.multiply(farm_power_bl, freq_grid))
+
+    # Alternatively to above code, we could calculate AEP using 
+    # 'fi_aep_parallel.get_farm_AEP(...)' but then we would not have the
+    # farm power productions, which we use later on for plotting.
+
+    # First, get baseline AEP, without wake steering
+    print(" ")
+    print("===========================================================")
+    print("Calculating baseline annual energy production (AEP)...")
+    print("Baseline AEP: {:.3f} GWh.".format(aep_bl / 1.0e9))
+    print("===========================================================")
+    print(" ")
+
+    # Load a FLORIS object for yaw optimization
+    fi_opt = load_floris()
+    wind_directions = np.arange(0.0, 360.0, 3.0)
+    wind_speeds=np.arange(6.0, 14.0, 2.0)
+    fi_opt.reinitialize(
+        wind_directions=wind_directions,
+        wind_speeds=wind_speeds,
+        turbulence_intensity=0.08  # Assume 8% turbulence intensity
+    )
+
+    # Pour this into a parallel computing interface
+    fi_opt_parallel = ParallelComputingInterface(
+        fi=fi_opt,
+        max_workers=16,
+        n_wind_direction_splits=16,
+        n_wind_speed_splits=1,
+        use_mpi4py=False,
+        print_timings=True,
+    )
+
+    # Now optimize the yaw angles using the Serial Refine method
+    df_opt = fi_opt_parallel.optimize_yaw_angles(
+        minimum_yaw_angle=-25.0,
+        maximum_yaw_angle=25.0,
+        Ny_passes=[5, 4],
+        exclude_downstream_turbines=True,
+        exploit_layout_symmetry=False,
+    )
+
+
+    
+    # Assume linear ramp up at 5-6 m/s and ramp down at 13-14 m/s, add to table for linear interpolant
+    df_copy_lb = df_opt[df_opt["wind_speed"] == 6.0].copy()
+    df_copy_ub = df_opt[df_opt["wind_speed"] == 13.0].copy()
+    df_copy_lb["wind_speed"] = 5.0
+    df_copy_ub["wind_speed"] = 14.0
+    df_copy_lb["yaw_angles_opt"] *= 0.0
+    df_copy_ub["yaw_angles_opt"] *= 0.0
+    df_opt = pd.concat([df_copy_lb, df_opt, df_copy_ub], axis=0).reset_index(drop=True)
+
+    # Deal with 360 deg wrapping: solutions at 0 deg are also solutions at 360 deg
+    df_copy_360deg = df_opt[df_opt["wind_direction"] == 0.0].copy()
+    df_copy_360deg["wind_direction"] = 360.0
+    df_opt = pd.concat([df_opt, df_copy_360deg], axis=0).reset_index(drop=True)
+
+    # Derive linear interpolant from solution space
+    yaw_angles_interpolant = LinearNDInterpolator(
+        points=df_opt[["wind_direction", "wind_speed"]],
+        values=np.vstack(df_opt["yaw_angles_opt"]),
+        fill_value=0.0,
+    )
+
+    # Get optimized AEP, with wake steering
+    yaw_grid = yaw_angles_interpolant(wd_grid, ws_grid)
+    farm_power_opt = fi_aep_parallel.get_farm_power(yaw_angles=yaw_grid)
+    aep_opt = np.sum(24 * 365 * np.multiply(farm_power_opt, freq_grid))
+    aep_uplift = 100.0 * (aep_opt / aep_bl - 1)
+
+    # Alternatively to above code, we could calculate AEP using 
+    # 'fi_aep_parallel.get_farm_AEP(...)' but then we would not have the
+    # farm power productions, which we use later on for plotting.
+
+    print(" ")
+    print("===========================================================")
+    print("Calculating optimized annual energy production (AEP)...")
+    print("Optimized AEP: {:.3f} GWh.".format(aep_opt / 1.0e9))
+    print("Relative AEP uplift by wake steering: {:.3f} %.".format(aep_uplift))
+    print("===========================================================")
+    print(" ")
+
+    # Now calculate helpful variables and then plot wind rose information
+    farm_energy_bl = np.multiply(freq_grid, farm_power_bl)
+    farm_energy_opt = np.multiply(freq_grid, farm_power_opt)
+    df = pd.DataFrame({
+        "wd": wd_grid.flatten(),
+        "ws": ws_grid.flatten(),
+        "freq_val": freq_grid.flatten(),
+        "farm_power_baseline": farm_power_bl.flatten(),
+        "farm_power_opt": farm_power_opt.flatten(),
+        "farm_power_relative": farm_power_opt.flatten() / farm_power_bl.flatten(),
+        "farm_energy_baseline": farm_energy_bl.flatten(),
+        "farm_energy_opt": farm_energy_opt.flatten(),
+        "energy_uplift": (farm_energy_opt - farm_energy_bl).flatten(),
+        "rel_energy_uplift": farm_energy_opt.flatten() / np.sum(farm_energy_bl)
+    })
+
+    # Plot power and AEP uplift across wind direction
+    wd_step = np.diff(fi_aep.floris.flow_field.wind_directions)[0]  # Useful variable for plotting
+    fig, ax = plt.subplots(nrows=3, sharex=True)
+
+    df_8ms = df[df["ws"] == 8.0].reset_index(drop=True)
+    pow_uplift = 100 * (
+        df_8ms["farm_power_opt"] / df_8ms["farm_power_baseline"] - 1
+    )
+    ax[0].bar(
+        x=df_8ms["wd"],
+        height=pow_uplift,
+        color="darkgray",
+        edgecolor="black",
+        width=wd_step,
+    )
+    ax[0].set_ylabel("Power uplift \n at 8 m/s (%)")
+    ax[0].grid(True)
+
+    dist = df.groupby("wd").sum().reset_index()
+    ax[1].bar(
+        x=dist["wd"],
+        height=100 * dist["rel_energy_uplift"],
+        color="darkgray",
+        edgecolor="black",
+        width=wd_step,
+    )
+    ax[1].set_ylabel("Contribution to \n AEP uplift (%)")
+    ax[1].grid(True)
+
+    ax[2].bar(
+        x=dist["wd"],
+        height=dist["freq_val"],
+        color="darkgray",
+        edgecolor="black",
+        width=wd_step,
+    )
+    ax[2].set_xlabel("Wind direction (deg)")
+    ax[2].set_ylabel("Frequency of \n occurrence (-)")
+    ax[2].grid(True)
+    plt.tight_layout()
+
+    # Plot power and AEP uplift across wind direction
+    fig, ax = plt.subplots(nrows=3, sharex=True)
+
+    df_avg = df.groupby("ws").mean().reset_index(drop=False)
+    mean_power_uplift = 100.0 * (df_avg["farm_power_relative"] - 1.0)
+    ax[0].bar(
+        x=df_avg["ws"],
+        height=mean_power_uplift,
+        color="darkgray",
+        edgecolor="black",
+        width=0.95,
+    )
+    ax[0].set_ylabel("Mean power \n uplift (%)")
+    ax[0].grid(True)
+
+    dist = df.groupby("ws").sum().reset_index()
+    ax[1].bar(
+        x=dist["ws"],
+        height=100 * dist["rel_energy_uplift"],
+        color="darkgray",
+        edgecolor="black",
+        width=0.95,
+    )
+    ax[1].set_ylabel("Contribution to \n AEP uplift (%)")
+    ax[1].grid(True)
+
+    ax[2].bar(
+        x=dist["ws"],
+        height=dist["freq_val"],
+        color="darkgray",
+        edgecolor="black",
+        width=0.95,
+    )
+    ax[2].set_xlabel("Wind speed (m/s)")
+    ax[2].set_ylabel("Frequency of \n occurrence (-)")
+    ax[2].grid(True)
+    plt.tight_layout()
+
+    # Now plot yaw angle distributions over wind direction up to first three turbines
+    wd_plot = np.arange(0.0, 360.001, 1.0)
+    for ti in range(np.min([fi_aep.floris.farm.n_turbines, 3])):
+        fig, ax = plt.subplots(figsize=(6, 3.5))
+        ws_to_plot = [6.0, 9.0, 12.0]
+        colors = ["maroon", "dodgerblue", "grey"]
+        styles = ["-o", "-v", "-o"]
+        for ii, ws in enumerate(ws_to_plot):
+            ax.plot(
+                wd_plot,
+                yaw_angles_interpolant(wd_plot, ws * np.ones_like(wd_plot))[:, ti],
+                styles[ii],
+                color=colors[ii],
+                markersize=3,
+                label="For wind speed of {:.1f} m/s".format(ws),
+            )
+        ax.set_ylabel("Assigned yaw offsets (deg)")
+        ax.set_xlabel("Wind direction (deg)")
+        ax.set_title("Turbine {:d}".format(ti))
+        ax.grid(True)
+        ax.legend()
+        plt.tight_layout()
+
+    plt.show()

--- a/floris/tools/__init__.py
+++ b/floris/tools/__init__.py
@@ -38,6 +38,7 @@ Examples:
 
 from .floris_interface import FlorisInterface
 from .floris_interface_legacy_reader import FlorisInterfaceLegacyV2
+from .parallel_computing_interface import ParallelComputingInterface
 from .visualization import visualize_cut_plane, visualize_quiver, plot_turbines_with_fi, plot_rotor_values
 from .wind_rose import WindRose
 from .uncertainty_interface import UncertaintyInterface

--- a/floris/tools/optimization/yaw_optimization/yaw_optimizer_sr.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimizer_sr.py
@@ -211,7 +211,7 @@ class YawOptimizationSR(YawOptimization):
         farm_powers = self._calc_powers_with_memory(evaluation_grid)
         return farm_powers
 
-    def optimize(self): 
+    def optimize(self, print_progress=True): 
         """
         Find the yaw angles that maximize the power production for every wind direction,
         wind speed and turbulence intensity.
@@ -223,7 +223,8 @@ class YawOptimizationSR(YawOptimization):
             for turbine_depth in range(self.nturbs):
                 p = 100.0 * ii / (len(self.Ny_passes) * self.nturbs)
                 ii += 1
-                print("[Serial Refine] Processing pass={:d}, turbine_depth={:d} ({:.1f} %)".format(Nii, turbine_depth, p))
+                if print_progress:
+                    print("[Serial Refine] Processing pass={:d}, turbine_depth={:d} ({:.1f} %)".format(Nii, turbine_depth, p))
 
                 # Create grid to evaluate yaw angles for one turbine == turbine_depth
                 evaluation_grid = self._generate_evaluation_grid(pass_depth=Nii, turbine_depth=turbine_depth)

--- a/floris/tools/parallel_computing_interface.py
+++ b/floris/tools/parallel_computing_interface.py
@@ -49,6 +49,7 @@ def _optimize_yaw_angles_serial(
     exclude_downstream_turbines,
     exploit_layout_symmetry,
     verify_convergence,
+    print_progress,
 ):
     fi_opt = _load_local_floris_object(*fi_information)
     yaw_opt = YawOptimizationSR(
@@ -63,7 +64,10 @@ def _optimize_yaw_angles_serial(
         exploit_layout_symmetry=exploit_layout_symmetry,
         verify_convergence=verify_convergence,
     )
-    return yaw_opt.optimize()
+
+    # Perform optimization but silence print statements to avoid cluttering
+    df_opt = yaw_opt.optimize(print_progress=print_progress)
+    return df_opt
 
 
 class ParallelComputingInterface(LoggerBase):
@@ -383,6 +387,7 @@ class ParallelComputingInterface(LoggerBase):
         exclude_downstream_turbines=True,
         exploit_layout_symmetry=True,
         verify_convergence=False,
+        print_worker_progress=False,  # Recommended disabled to avoid clutter. Useful for debugging
     ):   
 
         # Prepare the inputs to each core for multiprocessing module
@@ -400,6 +405,7 @@ class ParallelComputingInterface(LoggerBase):
                 exclude_downstream_turbines,
                 exploit_layout_symmetry,
                 verify_convergence,
+                print_worker_progress,
             )
         t1 = timerpc()
 

--- a/floris/tools/parallel_computing_interface.py
+++ b/floris/tools/parallel_computing_interface.py
@@ -105,10 +105,16 @@ class ParallelComputingInterface(LoggerBase):
                 self.fi.floris.farm.n_turbines
             ))
 
+        # Prepare settings
+        n_wind_direction_splits = self.n_wind_direction_splits
+        n_wind_direction_splits = np.min([n_wind_direction_splits, self.fi.floris.flow_field.n_wind_directions])
+        n_wind_speed_splits = self.n_wind_speed_splits
+        n_wind_speed_splits = np.min([n_wind_speed_splits, self.fi.floris.flow_field.n_wind_speeds])
+    
         # Prepare the input arguments for parallel execution
         fi_dict = self.fi.floris.as_dict()
-        wind_direction_id_splits = np.array_split(np.arange(self.fi.floris.flow_field.n_wind_directions), self.n_wind_direction_splits)
-        wind_speed_id_splits = np.array_split(np.arange(self.fi.floris.flow_field.n_wind_speeds), self.n_wind_speed_splits)
+        wind_direction_id_splits = np.array_split(np.arange(self.fi.floris.flow_field.n_wind_directions), n_wind_direction_splits)
+        wind_speed_id_splits = np.array_split(np.arange(self.fi.floris.flow_field.n_wind_speeds), n_wind_speed_splits)
         multiargs = []
         for wd_id_split in wind_direction_id_splits:
             for ws_id_split in wind_speed_id_splits:

--- a/floris/tools/parallel_computing_interface.py
+++ b/floris/tools/parallel_computing_interface.py
@@ -16,18 +16,16 @@ from floris.logging_manager import LoggerBase
 def _load_local_floris_object(
     fi_dict,
     het_map=None,
-    unc_options=None,
     unc_pmfs=None,
     fix_yaw_in_relative_frame=False
 ):
     # Load local FLORIS object
-    if ((unc_options is None) & (unc_pmfs is None)):
+    if unc_pmfs is None:
         fi = FlorisInterface(fi_dict, het_map=het_map)
     else:
         fi = UncertaintyInterface(
             fi_dict,
             het_map=het_map,
-            unc_options=unc_options,
             unc_pmfs=unc_pmfs,
             fix_yaw_in_relative_frame=fix_yaw_in_relative_frame,
         )
@@ -123,9 +121,9 @@ class ParallelComputingInterface(LoggerBase):
 
                 # Prepare lightweight data to pass along
                 if isinstance(self.fi, FlorisInterface):
-                    fi_information = (fi_dict_split, self.fi.het_map, None, None, None)
+                    fi_information = (fi_dict_split, self.fi.het_map, None, None)
                 else:
-                    fi_information = (fi_dict_split, self.fi.het_map, self.fi.unc_options, self.fi.unc_pmfs, self.fi.fix_yaw_in_relative_frame)
+                    fi_information = (fi_dict_split, self.fi.fi.het_map, self.fi.unc_pmfs, self.fi.fix_yaw_in_relative_frame)
                 multiargs.append((fi_information, yaw_angles_subset))
 
         return multiargs

--- a/floris/tools/parallel_computing_interface.py
+++ b/floris/tools/parallel_computing_interface.py
@@ -1,0 +1,336 @@
+# Copyright 2022 Shell
+import copy
+from time import perf_counter as timerpc
+
+import multiprocessing as mp
+import numpy as np
+import pandas as pd
+
+from floris.tools import FlorisInterface
+from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import (
+    YawOptimizationSR,
+)
+
+from floris.logging_manager import LoggerBase
+
+
+def _get_turbine_powers_serial(fi_dict, yaw_angles):
+    fi = FlorisInterface(fi_dict)
+    fi.calculate_wake(yaw_angles=yaw_angles)
+    return fi.get_turbine_powers()
+
+def _optimize_yaw_angles_serial(
+    fi_opt,
+    minimum_yaw_angle=0.0,
+    maximum_yaw_angle=25.0,
+    yaw_angles_baseline=None,
+    x0=None,
+    Ny_passes=[5, 4],  # Optimization options
+    turbine_weights=None,
+    exclude_downstream_turbines=True,
+    exploit_layout_symmetry=True,
+    verify_convergence=False,
+):
+    yaw_opt = YawOptimizationSR(
+        fi=fi_opt,
+        minimum_yaw_angle=minimum_yaw_angle,
+        maximum_yaw_angle=maximum_yaw_angle,
+        yaw_angles_baseline=yaw_angles_baseline,
+        x0=x0,
+        Ny_passes=Ny_passes,
+        turbine_weights=turbine_weights,
+        exclude_downstream_turbines=exclude_downstream_turbines,
+        exploit_layout_symmetry=exploit_layout_symmetry,
+        verify_convergence=verify_convergence,
+    )
+    return yaw_opt.optimize()
+
+
+class ParallelComputingInterface(LoggerBase):
+    def __init__(self, configuration, max_workers, n_wind_direction_splits, n_wind_speed_splits=1, het_map=None, use_mpi4py=False, print_timings=False):
+        """A wrapper around the nominal floris_interface class that adds
+        parallel computing to common FlorisInterface properties.
+
+        Args:
+        configuration (:py:obj:`dict` or FlorisInterface object): The Floris
+            object, configuration dictarionary, JSON file, or YAML file. The
+            configuration should have the following inputs specified.
+                - **flow_field**: See `floris.simulation.flow_field.FlowField` for more details.
+                - **farm**: See `floris.simulation.farm.Farm` for more details.
+                - **turbine**: See `floris.simulation.turbine.Turbine` for more details.
+                - **wake**: See `floris.simulation.wake.WakeManager` for more details.
+                - **logging**: See `floris.simulation.floris.Floris` for more details.
+        """
+
+        # Load the correct library
+        if use_mpi4py:
+            import mpi4py.futures as mp
+            self._PoolExecutor = mp.PoolExecutor
+        else:
+            import multiprocessing as mp
+            self._PoolExecutor = mp.Pool
+            if n_cores is None:
+                n_cores = mp.cpu_count()
+
+        # Initialize floris object
+        if isinstance(configuration, FlorisInterface):
+            self.fi = configuration
+        else:
+            self.fi = FlorisInterface(configuration, het_map=het_map)
+
+        # Save to self
+        self.n_wind_direction_splits = n_wind_direction_splits
+        self.n_wind_speed_splits = n_wind_speed_splits
+        self.max_workers = max_workers
+        self.print_timings = print_timings
+
+    def _preprocess_dicts(self, yaw_angles):
+        # Format yaw angles
+        if yaw_angles is None:
+            yaw_angles = np.zeros((
+                self.fi.floris.flow_field.n_wind_directions,
+                self.fi.floris.flow_field.n_wind_speeds,
+                self.fi.floris.farm.n_turbines
+            ))
+
+        # Prepare the input arguments for parallel execution
+        fi_dict = self.fi.floris.as_dict()
+        wind_direction_id_splits = np.array_split(np.arange(self.fi.floris.flow_field.n_wind_directions), self.n_wind_direction_splits)
+        wind_speed_id_splits = np.array_split(np.arange(self.fi.floris.flow_field.n_wind_speeds), self.n_wind_speed_splits)
+        multiargs = []
+        for wd_id_split in wind_direction_id_splits:
+            for ws_id_split in wind_speed_id_splits:
+                fi_dict_split = copy.deepcopy(fi_dict)
+                wind_directions = self.fi.floris.flow_field.wind_directions[wd_id_split]
+                wind_speeds = self.fi.floris.flow_field.wind_speeds[ws_id_split]
+                yaw_angles_subset = yaw_angles[wd_id_split, ws_id_split, :]
+                fi_dict_split["flow_field"]["wind_directions"] = wind_directions
+                fi_dict_split["flow_field"]["wind_speeds"] = wind_speeds
+                multiargs.append((copy.deepcopy(fi_dict_split), yaw_angles_subset))
+
+        return multiargs
+
+    def calculate_wake(self):
+        raise UserWarning("'calculate_wake' not supported. Please use 'get_turbine_powers' or 'get_farm_power' directly.")
+
+    def get_turbine_powers(self, yaw_angles=None):
+        # Retrieve multiargs: preprocessing
+        t0 = timerpc()
+        multiargs = self._preprocess_dicts(yaw_angles)
+        t_preparation = timerpc() - t0
+
+        # Perform parallel calculation
+        t1 = timerpc()
+        with self._PoolExecutor(self.max_workers) as p:
+            out = p.starmap(_get_turbine_powers_serial, multiargs)
+        t_execution = timerpc() - t1
+        
+        # Merge solutions and print output
+        t2 = timerpc()
+        turbine_powers = np.concatenate(
+            [
+                np.concatenate(out[self.n_wind_speed_splits*(ii):self.n_wind_speed_splits*(ii+1)], axis=1)
+                for ii in range(self.n_wind_direction_splits)
+            ],
+            axis=0
+        )
+        t_postprocessing = timerpc() - t2
+        t_total = timerpc() - t0
+
+        if self.print_timing:
+            print("==================================================================================")
+            print("Total time spent for parallel calculation ({:d} workers): {:.3f} s".format(self.max_workers, t_total))
+            print("  Time spent in parallel preprocessing: {:.3f} s".format(t_preparation))
+            print("  Time spent in parallel loop execution: {:.3f} s.".format(t_execution))
+            print("  Time spent in parallel postprocessing: {:.3f} s".format(t_postprocessing))
+
+        return turbine_powers
+
+    def get_farm_power(self, yaw_angles=None, turbine_weights=None):
+        if turbine_weights is None:
+            # Default to equal weighing of all turbines when turbine_weights is None
+            turbine_weights = np.ones(
+                (
+                    self.fi.floris.flow_field.n_wind_directions,
+                    self.fi.floris.flow_field.n_wind_speeds,
+                    self.fi.floris.farm.n_turbines
+                )
+            )
+        elif len(np.shape(turbine_weights)) == 1:
+            # Deal with situation when 1D array is provided
+            turbine_weights = np.tile(
+                turbine_weights,
+                (
+                    self.fi.floris.flow_field.n_wind_directions,
+                    self.fi.floris.flow_field.n_wind_speeds,
+                    1
+                )
+            )
+
+        # Calculate all turbine powers and apply weights
+        turbine_powers = self.get_turbine_powers(yaw_angles=yaw_angles)
+        turbine_powers = np.multiply(turbine_weights, turbine_powers)
+
+        return np.sum(turbine_powers, axis=2)
+
+    def get_farm_AEP(
+        self,
+        freq,
+        cut_in_wind_speed=0.001,
+        cut_out_wind_speed=None,
+        yaw_angles=None,
+        turbine_weights=None,
+        no_wake=False,
+    ) -> float:
+        """
+        Estimate annual energy production (AEP) for distributions of wind speed, wind
+        direction, frequency of occurrence, and yaw offset.
+
+        Args:
+            freq (NDArrayFloat): NumPy array with shape (n_wind_directions,
+                n_wind_speeds) with the frequencies of each wind direction and
+                wind speed combination. These frequencies should typically sum
+                up to 1.0 and are used to weigh the wind farm power for every
+                condition in calculating the wind farm's AEP.
+            cut_in_wind_speed (float, optional): Wind speed in m/s below which
+                any calculations are ignored and the wind farm is known to
+                produce 0.0 W of power. Note that to prevent problems with the
+                wake models at negative / zero wind speeds, this variable must
+                always have a positive value. Defaults to 0.001 [m/s].
+            cut_out_wind_speed (float, optional): Wind speed above which the
+                wind farm is known to produce 0.0 W of power. If None is
+                specified, will assume that the wind farm does not cut out
+                at high wind speeds. Defaults to None.
+            yaw_angles (NDArrayFloat | list[float] | None, optional):
+                The relative turbine yaw angles in degrees. If None is
+                specified, will assume that the turbine yaw angles are all
+                zero degrees for all conditions. Defaults to None.
+            turbine_weights (NDArrayFloat | list[float] | None, optional):
+                weighing terms that allow the user to emphasize power at
+                particular turbines and/or completely ignore the power 
+                from other turbines. This is useful when, for example, you are
+                modeling multiple wind farms in a single floris object. If you
+                only want to calculate the power production for one of those
+                farms and include the wake effects of the neighboring farms,
+                you can set the turbine_weights for the neighboring farms'
+                turbines to 0.0. The array of turbine powers from floris
+                is multiplied with this array in the calculation of the
+                objective function. If None, this  is an array with all values
+                1.0 and with shape equal to (n_wind_directions, n_wind_speeds,
+                n_turbines). Defaults to None.
+            no_wake: (bool, optional): When *True* updates the turbine
+                quantities without calculating the wake or adding the wake to
+                the flow field. This can be useful when quantifying the loss
+                in AEP due to wakes. Defaults to *False*.
+
+        Returns:
+            float:
+                The Annual Energy Production (AEP) for the wind farm in
+                watt-hours.
+        """
+
+        # If no_wake==True, ignore parallelization because it's fast enough
+        if no_wake:
+            return self.fi.get_farm_AEP(
+                freq=freq,
+                cut_in_wind_speed=cut_in_wind_speed,
+                cut_out_wind_speed=cut_out_wind_speed,
+                yaw_angles=yaw_angles,
+                turbine_weights=turbine_weights,
+                no_wake=no_wake
+            )
+
+        # Verify dimensions of the variable "freq"
+        if not (
+            (np.shape(freq)[0] == self.fi.floris.flow_field.n_wind_directions)
+            & (np.shape(freq)[1] == self.fi.floris.flow_field.n_wind_speeds)
+            & (len(np.shape(freq)) == 2)
+        ):
+            raise UserWarning(
+                "'freq' should be a two-dimensional array with dimensions (n_wind_directions, n_wind_speeds)."
+            )
+
+        # Check if frequency vector sums to 1.0. If not, raise a warning
+        if np.abs(np.sum(freq) - 1.0) > 0.001:
+            self.logger.warning("WARNING: The frequency array provided to get_farm_AEP() does not sum to 1.0. ")
+
+        # Copy the full wind speed array from the floris object and initialize
+        # the the farm_power variable as an empty array.
+        wind_speeds = np.array(self.fi.floris.flow_field.wind_speeds, copy=True)
+        farm_power = np.zeros((self.fi.floris.flow_field.n_wind_directions, len(wind_speeds)))
+
+        # Determine which wind speeds we must evaluate in floris
+        conditions_to_evaluate = wind_speeds >= cut_in_wind_speed
+        if cut_out_wind_speed is not None:
+            conditions_to_evaluate = conditions_to_evaluate & (wind_speeds < cut_out_wind_speed)
+
+        # Evaluate the conditions in floris
+        if np.any(conditions_to_evaluate):
+            wind_speeds_subset = wind_speeds[conditions_to_evaluate]
+            yaw_angles_subset = None
+            if yaw_angles is not None:
+                yaw_angles_subset = yaw_angles[:, conditions_to_evaluate]
+            self.fi.reinitialize(wind_speeds=wind_speeds_subset)
+            farm_power[:, conditions_to_evaluate] = (
+                self.get_farm_power(yaw_angles=yaw_angles_subset, turbine_weights=turbine_weights)
+            )
+
+        # Finally, calculate AEP in GWh
+        aep = np.sum(np.multiply(freq, farm_power) * 365 * 24)
+
+        # Reset the FLORIS object to the full wind speed array
+        self.fi.reinitialize(wind_speeds=wind_speeds)
+
+        return aep
+
+    def optimize_yaw_angles(
+        self,
+        minimum_yaw_angle=-25.0,
+        maximum_yaw_angle=25.0,
+        yaw_angles_baseline=None,
+        x0=None,
+        Ny_passes=[5,4],
+        turbine_weights=None,
+        exclude_downstream_turbines=True,
+        exploit_layout_symmetry=True,
+        verify_convergence=False,
+    ):   
+
+        # Prepare the inputs to each core for multiprocessing module
+        t0 = timerpc()
+        multiargs = self._preprocess_dicts()
+        for ii in range(len(multiargs)):
+            multiargs[ii] = (
+                multiargs[ii][0],
+                minimum_yaw_angle,
+                maximum_yaw_angle,
+                yaw_angles_baseline,
+                x0,
+                Ny_passes,
+                turbine_weights,
+                exclude_downstream_turbines,
+                exploit_layout_symmetry,
+                verify_convergence,
+            )
+        t1 = timerpc()
+
+        # Optimize yaw angles using parallel processing
+        print("Optimizing yaw angles with {:d} workers.".format(self.max_workers))
+        with self._PoolExecutor(self.max_workers) as p:
+            df_opt_splits = p.starmap(_optimize_yaw_angles_serial, multiargs)
+        end_time = timerpc()
+        t2 = timerpc()
+        print("Optimization finished in {:.2f} seconds.".format(t_tot))
+
+        # Combine all solutions from multiprocessing into single dataframe
+        df_opt = pd.concat(df_opt_splits, axis=0)
+        t3 = timerpc()
+
+        if self.print_timing:
+            print("==================================================================================")
+            print("Total time spent for parallel calculation ({:d} workers): {:.3f} s".format(self.max_workers, t3 - t0))
+            print("  Time spent in parallel preprocessing: {:.3f} s".format(t1 - t0))
+            print("  Time spent in parallel loop execution: {:.3f} s.".format(t2 - t1))
+            print("  Time spent in parallel postprocessing: {:.3f} s".format(t3 - t2))
+
+        return df_opt


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This PR adds a parallel computing interface at the tools level to enable parallel computing of turbine powers, wind farm powers, and yaw optimizations. It does not change anything to the internal FLORIS code, which makes it a much easier integration than #403. I have been using this internally for quick parallel computing solutions using `multiprocessing` for single-node jobs/local parallelization, but this class also supports `mpi4py` for multinode calculations like FLORIS v2 used to.

**Related issue, if one exists**
#401 


**Impacted areas of the software**
FLORIS tools library

**Additional supporting information**
The Parallel Computing Interface class is built similarly to the UncertaintyInterface class. It can be loaded up and then interacted with like a regular `FlorisInterface` object, but then the underlying code performs the computations in parallel rather than in serial. In larger problems and especially in yaw optimizations, this can provide significant speed-up.

**Test results, if applicable**
This PR adds an example file that calculates the optimal yaw angles and the resulting AEP uplift using parallel processing, "12_optimize_yaw_in_parallel.py".

With a maximum of one core, the total time for the yaw angle optimization (using SR) and for the AEP calculation are, respectively:
```
==============================================
[Yaw optimization with SR]
Total time spent for parallel calculation (1 workers): 280.834 s
  Time spent in parallel preprocessing: 0.001 s
  Time spent in parallel loop execution: 280.831 s.
  Time spent in parallel postprocessing: 0.002 s
==============================================
[AEP calculation]
Total time spent for parallel calculation (1 workers): 35.606 s
  Time spent in parallel preprocessing: 0.007 s
  Time spent in parallel loop execution: 35.596 s.
  Time spent in parallel postprocessing: 0.004 s
```

And in parallel with 16 cores on my laptop:
```
==============================================
[Yaw optimization with SR]
Total time spent for parallel calculation (16 workers): 87.727 s
  Time spent in parallel preprocessing: 0.003 s
  Time spent in parallel loop execution: 87.720 s.
  Time spent in parallel postprocessing: 0.004 s
==============================================
[AEP calculation]
Total time spent for parallel calculation (16 workers): 11.781 s
  Time spent in parallel preprocessing: 0.012 s
  Time spent in parallel loop execution: 11.763 s.
  Time spent in parallel postprocessing: 0.006 s
```

And the example produces the results:
![image](https://user-images.githubusercontent.com/22119448/211356095-cc5ed06e-17b0-4de7-8d22-8d957b8c24cc.png)

![image](https://user-images.githubusercontent.com/22119448/211356150-0d0bc95c-c11d-40d4-9995-bb4a217142fd.png)

![image](https://user-images.githubusercontent.com/22119448/211356196-b217f102-08c1-430e-9990-e2080e36f4c1.png)

<!-- Release checklist:
- Update the version in
    - [ ] README.rst
    - [ ] docs/index.rst
    - [ ] floris/VERSION
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->