### PR TITLE
Infrastructure improvements

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -24,8 +24,8 @@ jobs:
         pip install -e ".[develop]"
     - uses: pre-commit/action@v3.0.0
     - name: Run tests
+      if: success() || failure()  # Run this step even if the linting step fails
       run: |
-        # pytest tests/
         # -rA displays the captured output for all tests after they're run
         # See the docs: https://doc.pytest.org/en/latest/reference/reference.html#command-line-flags
         pytest -rA tests/ --ignore tests/timing.py --ignore tests/profiling.py

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -40,4 +40,5 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,9 +9,8 @@ on:
 
 jobs:
   deploy:
-
+    if: github.repository_owner == 'NREL'
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,6 @@
 
 repos:
 
-- repo: https://github.com/timothycrosley/isort
-  rev: 5.12.0
-  hooks:
-  - id: isort
-    name: isort
-    stages: [commit]
-
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
@@ -26,3 +19,10 @@ repos:
   rev: v0.0.241
   hooks:
   - id: ruff
+
+- repo: https://github.com/timothycrosley/isort
+  rev: 5.12.0
+  hooks:
+  - id: isort
+    name: isort
+    stages: [commit]

--- a/examples/12_optimize_yaw_in_parallel.py
+++ b/examples/12_optimize_yaw_in_parallel.py
@@ -32,7 +32,7 @@ def load_floris():
     # fi = FlorisInterface("inputs/cc.yaml") # New CumulativeCurl model
 
     # Specify wind farm layout and update in the floris object
-    N = 5  # number of turbines per row and per column
+    N = 4  # number of turbines per row and per column
     X, Y = np.meshgrid(
         5.0 * fi.floris.farm.rotor_diameters_sorted[0][0][0] * np.arange(0, N, 1),
         5.0 * fi.floris.farm.rotor_diameters_sorted[0][0][0] * np.arange(0, N, 1),
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     # Load a FLORIS object for AEP calculations
     fi_aep = load_floris()
     wind_directions = np.arange(0.0, 360.0, 1.0)
-    wind_speeds=np.arange(1.0, 30.0, 1.0)
+    wind_speeds = np.arange(1.0, 25.0, 1.0)
     fi_aep.reinitialize(
         wind_directions=wind_directions,
         wind_speeds=wind_speeds,

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -76,10 +76,7 @@ def iter_validator(iter_type, item_types: Union[Any, Tuple[Any]]) -> Callable:
     Callable
         The attr.validators.deep_iterable iterable and instance validator.
     """
-    validator = attrs.validators.deep_iterable(
-        member_validator=attrs.validators.instance_of(item_types),
-        iterable_validator=attrs.validators.instance_of(iter_type),
-    )
+    validator = attrs.validators.deep_iterable(member_validator=attrs.validators.instance_of(item_types), iterable_validator=attrs.validators.instance_of(iter_type))
     return validator
 
 @define

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -76,7 +76,10 @@ def iter_validator(iter_type, item_types: Union[Any, Tuple[Any]]) -> Callable:
     Callable
         The attr.validators.deep_iterable iterable and instance validator.
     """
-    validator = attrs.validators.deep_iterable(member_validator=attrs.validators.instance_of(item_types), iterable_validator=attrs.validators.instance_of(iter_type))
+    validator = attrs.validators.deep_iterable(
+        member_validator=attrs.validators.instance_of(item_types),
+        iterable_validator=attrs.validators.instance_of(iter_type),
+    )
     return validator
 
 @define

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,8 +127,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "floris/tools/interface_utilities.py" = ["F821"]
 "floris/tools/wind_rose.py" = ["F821"]
 
-
-
 [tool.ruff.isort]
 combine-as-imports = true
 known-first-party = ["floris"]
@@ -159,6 +157,7 @@ use_parentheses = true
 lines_after_imports = 2
 line_length = 100
 order_by_type = false
+split_on_trailing_comma = true
 
 # length_sort = true
 # case_sensitive: False


### PR DESCRIPTION
**Feature or improvement description**
This pull request is a collection of minor infrastructure improvements.

1. In order to preserve isort formatting over ruff or any other tools, the pre-commit configuration swaps the order in which the hooks run and leaves isort last.
2. Due to GitHub rate limiting, the codecov upload step in the "Automated tests & code coverage" workflow can fail unexpectedly. One solution is to simply restart the workflow, but this takes time and manual intervention. Codecov recommend to include an upload token in the uploader. See [here](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954) for their description of the problem and suggested solutions.
3. PR #555 added a new example that demonstrates a performance improvement in AEP calculations by splitting the atmospheric conditions over multiple threads. The example takes about 5 minutes to run in GitHub Actions, so it noticeably slowed the completion time. Issue #563 discusses some solutions. This commit reduces the number of turbines and wind speeds.
4. An automated workflow to deploy a package to PyPI could trigger for any fork on FLORIS when a release is created. This commit restricts that workflow to only the FLORIS repository under the NREL account.
5. Since #562, the "Automated tests & code coverage" workflow stops and reports failure if the linting step fails. This means that the tests are not run until the code passes the linting check. This commit allows the tests to run regardless of the linting results. The overall workflow is still reported as a failure, but developers get feedback on validity of the results in addition to linting status.

**Related issue, if one exists**
#563