### PR TITLE
Add helpful info to GitHub Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,33 +5,70 @@ title: 'Bug report'
 labels: "Type: Bug"
 ---
 
-**Bug description**
-<A clear and concise description of the bug.>
+<!--
+IMPORTANT NOTES
 
-**To Reproduce**
-<Update the following list with your specific information.>
-Steps to reproduce the behavior:
-1. Run '...' case with '...' settings
-2. Open '...' output
-3. See the error
+Thank you for taking the time to report a bug. If you aren't certain whether an issue
+is a bug, please first open a Discussion. Before submitting, please reread your
+description to ensure that other readers can reasonably understand the issue
+you're facing and the impact on your workflow or results.
 
-**Expected behavior**
-<A clear and concise description of what you expected to happen.>
+This form is written in GitHub's Markdown format. For a reference on this type
+of syntax, see GitHub's documentation:
+https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
 
-**Screenshots, if applicable**
-<Add screenshots to help explain your problem.>
+When including code snippets, please paste the text itself and wrap the code block with
+ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
+For example, Python code should be wrapped in ticks like this:
+```python
+def a_func():
+    return 1
 
-**Floris Version**
-<Please provide as much detail as possible including git commit or version from pip.>
+a = 1
+b = a_func()
+print(a + b)
+```
+This is preferred over screen shots since it is searchable and others can copy/paste
+the text to run it.
+-->
 
-**System Information (please complete the following information):**
- - OS: <e.g. Ubuntu 14.04 or macOS 10.12>
+# Add meaningful title here
+<!--
+A clear and concise description of the bug including what happened
+and what you expected to happen.
+-->
+
+## How to reproduce
+<!--
+Describe how another person with no context can recreate this issue.
+It is typically very helpful to reduce the problem as much as possible
+and share a minimum working example. See the note above on including
+code as text rather than screenshots.
+-->
+
+## Relevant output
+<!--
+Include any output, plots, or other means of communication here to add context to the problem.
+ -->
+
+## Floris version
+<!--
+Share your floris version and how you installed it. You can print the floris version from
+a Python REPL or script with these commands:
+```python
+import floris
+print(floris.__version__)
+```
+ -->
+
+## System Information
+<!-- Add your information here. -->
+ - OS: <e.g. Ubuntu 20.04 or macOS 10.12>
+ - Python version: <Result of `python --version`>
  - Library versions
-   * matplotlib
-   * numpy
-   * pytest
-   * scipy
-   * Sphinx
-
-**Additional context**
-<Add any other context about the problem here.>
+   - Results of `pip freeze`, for example
+   - matplotlib
+   - numpy
+   - numexpr
+   - scipy
+   - pandas

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,14 +5,49 @@ title: 'Feature request'
 labels: 'Type: Enhancement'
 ---
 
-**Is your feature request related to a problem? Please describe.**
-<A clear and concise description of the problem.>
+<!--
+IMPORTANT NOTES
 
-**Describe the solution you'd like**
-<A clear and concise description of what you want to happen.>
+Thank you for taking the time to suggest a feature. Before submitting,
+please reread your description to ensure that other readers can reasonably
+understand the motivation and proposed solution.
 
-**Describe alternatives you've considered**
-<A clear and concise description of any alternative solutions or features youve considered.>
+This form is written in GitHub's Markdown format. For a reference on this type
+of syntax, see GitHub's documentation:
+https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
 
-**Additional context**
-<Add any other context or screenshots about the feature request here.>
+When including code snippets, please paste the text itself and wrap the code block with
+ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
+For example, Python code should be wrapped in ticks like this:
+```python
+def a_func():
+    return 1
+
+a = 1
+b = a_func()
+print(a + b)
+```
+This is preferred over screen shots since it is searchable and others can copy/paste
+the text to run it.
+-->
+
+# Add meaningful title here
+<!--
+High level description of the feature request including motivation and background.
+-->
+
+## Proposed solution
+<!--
+Here's an opportunity to prototype a feature. Please include pseudocode, images, or
+any other visual aids to communicate the idea.
+-->
+
+## Alternatives considered
+<!--
+Describe workarounds or alternatives even if hacky or incomplete.
+-->
+
+## Additional context
+<!--
+Optional. Provide anything else that helps to communicate the idea here.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,67 @@
 
-<!-- Is this pull request ready to be merged? -->
-<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
-<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->
+<!--
+IMPORTANT NOTES
 
-**Feature or improvement description**
-<!-- A clear and concise description of the new code. -->
+Is this pull request ready to be merged?
+- Do the existing tests pass and new tests added for new code?
+- Is all development in a state where you are proud to share it with others and
+  willing to ask other people to take the time to review it?
+- Is it documented in such a way that a review can reasonably understand what you've
+  done and why you've done it? Can other users understand how to use your changes?
+If not but opening the pull request will facilitate development, make it a "draft" pull request
 
-**Related issue, if one exists**
-<!-- Link to a related GitHub Issue. -->
+This form is written in GitHub's Markdown format. For a reference on this type
+of syntax, see GitHub's documentation:
+https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
 
-**Impacted areas of the software**
-<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
+When including code snippets, please paste the text itself and wrap the code block with
+ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
+For example, Python code should be wrapped in ticks like this:
+```python
+def a_func():
+    return 1
 
-**Additional supporting information**
-<!-- Add any other context about the problem here. -->
+a = 1
+b = a_func()
+print(a + b)
+```
+This is preferred over screen shots since it is searchable and others can copy/paste
+the text to run it.
+-->
 
-**Test results, if applicable**
-<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
 
-<!-- Release checklist:
+# Add meaningful title here
+<!--
+Be sure to title your pull request so that readers can scan through the list of PR's and understand
+what this one involves. It should be a few well selected words to get the point across. If you have
+a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
+Keep in mind that the title will be automatically included in the release notes.
+-->
+Describe your feature here.
+
+## Related issue
+<!--
+If one exists, link to a related GitHub Issue.
+-->
+
+## Impacted areas of the software
+<!--
+List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
+-->
+
+## Additional supporting information
+<!--
+Add any other context about the problem here.
+-->
+
+## Test results, if applicable
+<!--
+Add the results from unit tests and regression tests here along with justification for any failing test cases.
+-->
+
+<!--
+__ For NREL use __
+Release checklist:
 - Update the version in
     - [ ] README.md
     - [ ] docs/index.md


### PR DESCRIPTION
# Add guidance and context to GitHub Issue and PR templates
This pull request expands on the GitHub Issue and Pull Request templates to add helpful info on what information is useful to include. It also includes a link to GitHub documentation on using Markdown.

Note that these won't be "live" until develop is merged into main. You can preview it on [my fork](https://github.com/rafmudaf/floris) by going through the process to open an issue or pull request.

## Related issue
No issue, but we've had a lot of engagement on GitHub lately and it would be helpful to show users what we're looking for as maintainers.

## Impacted areas of the software
GitHub Issue and Pull Request templates