### PR TITLE
Remove deprecated user API's

### DIFF
--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -152,19 +152,6 @@ class Farm(BaseClass):
                 turbine_map[turbine["turbine_type"]] = turbine
                 full_path = turbine["turbine_type"]
 
-            # Log a warning if the reference air density doesn't exist
-            if "ref_density_cp_ct" not in turbine:
-                self.logger.warning(
-                    f"The value ref_density_cp_ct is not defined in the file {full_path}."
-                    "This value is not the simulated air density but is the density "
-                    "at which the cp/ct curves are defined. In previous versions, this "
-                    "was assumed to be 1.225. Future versions of FLORIS will give an error "
-                    "if this value is not explicitly defined. Currently, this value is "
-                    "being set to the prior default value of 1.225."
-                )
-                turbine['ref_density_cp_ct'] = 1.225
-                turbine_map[turbine["turbine_type"]] = turbine
-
         self.turbine_definitions = [
             copy.deepcopy(turbine_map[el]) if isinstance(el, str)
             else copy.deepcopy(turbine_map[el["turbine_type"]])

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -1011,14 +1011,3 @@ def generate_heterogeneous_wind_map(speed_ups, x, y, z=None):
         ]
 
     return [in_region, out_region]
-
-## Functionality removed in v3
-
-def set_rotor_diameter(self, rotor_diameter):
-    """
-    This function has been replaced and no longer works correctly, assigning an error
-    """
-    raise Exception(
-        "FlorinInterface.set_rotor_diameter has been removed in favor of "
-        "FlorinInterface.change_turbine. See examples/change_turbine/."
-    )

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -214,7 +214,6 @@ class FlorisInterface(LoggerBase):
         # with_resolution: float | None = None,
         solver_settings: dict | None = None,
         time_series: bool = False,
-        layout: tuple[list[float], list[float]] | tuple[NDArrayFloat, NDArrayFloat] | None = None,
         het_map=None,
     ):
         # Export the floris object recursively as a dictionary
@@ -243,13 +242,6 @@ class FlorisInterface(LoggerBase):
             self.het_map = het_map
 
         ## Farm
-        if layout is not None:
-            self.logger.warning(
-                "Use the `layout_x` and `layout_y` parameters in place of `layout` "
-                "because the `layout` parameter will be deprecated in 3.3."
-            )
-            layout_x = layout[0]
-            layout_y = layout[1]
         if layout_x is not None:
             farm_dict["layout_x"] = layout_x
         if layout_y is not None:

--- a/floris/tools/uncertainty_interface.py
+++ b/floris/tools/uncertainty_interface.py
@@ -335,7 +335,6 @@ class UncertaintyInterface(LoggerBase):
         reference_wind_height=None,
         turbulence_intensity=None,
         air_density=None,
-        layout=None,
         layout_x=None,
         layout_y=None,
         turbine_type=None,
@@ -344,14 +343,6 @@ class UncertaintyInterface(LoggerBase):
         """Pass to the FlorisInterface reinitialize function. To allow users
         to directly replace a FlorisInterface object with this
         UncertaintyInterface object, this function is required."""
-
-        if layout is not None:
-            self.logger.warning(
-                "Use the `layout_x` and `layout_y` parameters in place of `layout` "
-                "because the `layout` parameter will be deprecated in 3.3."
-            )
-            layout_x = layout[0]
-            layout_y = layout[1]
 
         # Just passes arguments to the floris object
         self.fi.reinitialize(

--- a/floris/turbine_library/x_20MW.yaml
+++ b/floris/turbine_library/x_20MW.yaml
@@ -5,6 +5,7 @@ pP: 1.88
 pT: 1.88
 rotor_diameter: 252.0
 TSR: 8.0
+ref_density_cp_ct: 1.225
 ref_tilt_cp_ct: 5.0
 power_thrust_table:
   power:

--- a/tests/farm_unit_test.py
+++ b/tests/farm_unit_test.py
@@ -115,19 +115,3 @@ def test_farm_external_library(sample_inputs_fixture: SampleInputs):
     farm_data["turbine_type"] = ["FAKE_TURBINE"] * N_TURBINES
     with pytest.raises(FileNotFoundError):
         Farm.from_dict(farm_data)
-
-
-def test_farm_unique_loading(sample_inputs_fixture: SampleInputs, caplog):
-    # Setup the current location and the logging capture
-    ROOT = Path(__file__).parent
-    caplog.set_level(logging.WARNING)
-
-    # Setup the turbine data
-    turbine = load_yaml(ROOT / "../floris/turbine_library/x_20MW.yaml")
-    farm_data = sample_inputs_fixture.farm
-    farm_data["turbine_type"] = [turbine, turbine, turbine]
-    _ = Farm.from_dict(farm_data)
-
-    # The x_20MW turbine is missing air density, so a warning is logged, make sure this
-    # is only logged once, per the unique turbine checking
-    assert len(caplog.records) == 1


### PR DESCRIPTION
# Remove user interface elements marked deprecated or to-be-removed
This pull request removes user-facing functions that were deprecated in v3 or v3.1 (see https://github.com/NREL/floris/discussions/488). All infrastructure has already dealt with these changes and they were left in place as a convenience to users.

## Related issue
- https://github.com/NREL/floris/discussions/488

## Impacted areas of the software
This impacts interfaces in `Floris.tools` and the turbine definition.

## Additional supporting information
The motivation for this is mostly to maintain a clean and consistent API. These could all be left in place, but the decisions to move away from them were made at one point for specific reasons. Rather than continuing to accumulate various warning messages and if-statements, I'd rather follow through with the intent and fully remove these functions acknowledging that it might cause headaches for some users.