### PR TITLE
Supress matplotlib user warning on wind rose plot

### DIFF
--- a/floris/tools/wind_rose.py
+++ b/floris/tools/wind_rose.py
@@ -1478,6 +1478,7 @@ class WindRose:
         ax.set_theta_direction(-1)
         ax.set_theta_offset(np.pi / 2.0)
         ax.set_theta_zero_location("N")
+        ax.set_xticks(np.arange(0, 2*np.pi, np.pi/4))
         ax.set_xticklabels(["N", "NE", "E", "SE", "S", "SW", "W", "NW"])
 
         return ax
@@ -1552,6 +1553,7 @@ class WindRose:
         ax.set_theta_direction(-1)
         ax.set_theta_offset(np.pi / 2.0)
         ax.set_theta_zero_location("N")
+        ax.set_xticks(np.arange(0, 2*np.pi, np.pi/4))
         ax.set_xticklabels(["N", "NE", "E", "SE", "S", "SW", "W", "NW"])
 
         return ax


### PR DESCRIPTION
# Supress matplotlib UserWarning on wind rose plot
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
The WindRose functions `plot_wind_rose` and `plot_wind_rose_ti` triggers a matplotlib UserWarning.  


Example code:
```python
from floris.tools.wind_rose import WindRose
import matplotlib.pylab as plt

wr = WindRose()
wr.make_wind_rose_from_user_data([1,2,3], [4,5,6])
wr.plot_wind_rose()

plt.show()
```
Output:
<pre>
Correcting negative Overhang:-2.5
Correcting negative Overhang:-7.5
<b>wind_rose.py:1481: UserWarning: FixedFormatter should only be used together with FixedLocator</b>
</pre>
This pull request removes this warning by explicitly setting the ticks associated with the windrose labels.


## Related issue
None

## Impacted areas of the software
wind_rose.py

## Additional supporting information
<!--
Add any other context about the problem here.
-->
Matplotlib issue, with a similar question about this UserWarning: [https://github.com/matplotlib/matplotlib/issues/18848](https://github.com/matplotlib/matplotlib/issues/18848)
## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->


