### PR TITLE
Bug Fix: Correct a misleading error message

### DIFF
--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -133,8 +133,8 @@ class Farm(BaseClass):
                     full_path = external_fn
                 else:
                     raise ValueError(
-                        f"The turbine type: {turbine} exists in both the internal and external"
-                        " turbine library."
+                        f"The turbine type: {turbine} does not exist in either the internal or"
+                        " external turbine library."
                     )
                 turbine_map[turbine] = turbine = load_yaml(full_path)
             elif isinstance(turbine, dict):

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -132,7 +132,7 @@ class Farm(BaseClass):
                 elif in_external:
                     full_path = external_fn
                 else:
-                    raise ValueError(
+                    raise FileNotFoundError(
                         f"The turbine type: {turbine} does not exist in either the internal or"
                         " external turbine library."
                     )

--- a/tests/farm_unit_test.py
+++ b/tests/farm_unit_test.py
@@ -104,6 +104,13 @@ def test_farm_external_library(sample_inputs_fixture: SampleInputs):
     with pytest.raises(ValueError):
         Farm.from_dict(farm_data)
 
+    # Demonstrate a failing case where there a turbine does not exist in either
+    farm_data = deepcopy(SampleInputs().farm)
+    farm_data["turbine_library_path"] = external_library
+    farm_data["turbine_type"] = ["nrel_15MW"] * len(farm_data["layout_x"])
+    with pytest.raises(FileNotFoundError):
+        Farm.from_dict(farm_data)
+
 
 def test_farm_unique_loading(sample_inputs_fixture: SampleInputs, caplog):
     # Setup the current location and the logging capture


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Bug Fix: Correct a misleading error message for external library checking
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This PR is a small correction to an error message that was duplicated, but left unchanged, that incorrectly states an unfound file exists in both locations. The new error is now a `FileNotFoundError` and indicates that the turbine file unable to be found in either the internal or external turbine library. Additionally, I've added a test to ensure the correct error is raised when a turbine can't be located.

## Related issue
<!--
If one exists, link to a related GitHub Issue.
-->
N/A: I made the fix instead of submitting an issue and a fix.

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
-->
- `floris/simulation/farm.py`
  - `Farm.check_turbine_type()`
- `tests/farm_unit_test.py`
  - `test_farm_external_library()`

## Additional supporting information
<!--
Add any other context about the problem here.
-->
The duplication of the error is extremely confusing when you're working with an external library that is missing a file, but it indicates that it's located in both libraries. After spending too much time getting to the bottom of it, I figured I'd make someone else's life easier in the process instead of patching it in my own workflow.

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->
All the tests pass.

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] docs/index.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
