### PR TITLE
Add documentation for high level FLORIS architecture

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@
 title: FLORIS
 author: National Renewable Energy Laboratory
 logo: gch.gif
-copyright: '2022'
+copyright: '2023'
 only_build_toc_files: true
 
 # Force re-execution of notebooks on each build.
@@ -45,6 +45,7 @@ sphinx:
   - 'sphinx_autodoc_typehints'
   - 'sphinxcontrib.autoyaml'
   - 'sphinx.ext.napoleon'       # Formats google and numpy docstring styles
+  - 'sphinxcontrib.mermaid'
   config:
     html_theme: sphinx_book_theme
     templates_path:

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -23,5 +23,6 @@ parts:
   - caption: Developer Reference
     chapters:
     - file: dev_guide
+    - file: architecture
     - file: code_quality
     - file: api_docs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,118 @@
+
+# Architecture and Design
+
+There are a few fundamental characteristics that define the FLORIS software:
+
+- Modularity in two places:
+    - Wake model mathematical formulation
+    - Grouping of packages at the highest organization level
+- Management of abstraction:
+    - Low level code is opaque but well tested and exercised; it should be very computationally
+        efficient with low algorithmic complexity
+    - High level code should be expressive and clear even if it results in verbose or less
+        efficient code
+
+The FLORIS software consists of two primary high-level packages and a few other low level
+packages. The internal structure and hierarchy is described below.
+
+```{mermaid}
+classDiagram
+
+    class tools {
+        +FlorisInterface
+    }
+
+    class simulation {
+        +Floris
+    }
+
+    class logging_manager
+    class type_dec
+    class utilities
+
+    tools <-- logging_manager
+    simulation <-- logging_manager
+    tools <-- type_dec
+    simulation <-- type_dec
+    tools <-- utilities
+    simulation <-- utilities
+    tools <-- simulation
+```
+
+## floris.tools
+
+This is the user interface. Most operations at the user level will happen through `floris.tools`.
+This package contains a wide variety of functionality including but not limited to:
+
+- Initializing and driving a simulation with `tools.floris_interface`
+- Wake field visualization through `tools.visualization`
+- Yaw and layout optimization in `tools.optimization`
+- Parallelizing work load with `tools.parallel_computing_interface`
+
+## floris.simulation
+
+This is the core simulation package. This should primarily be used within `floris.simulation` and
+`floris.tools`, and user scripts generally won't interact directly with this package.
+
+```{mermaid}
+classDiagram
+
+    class Floris
+
+    class Farm
+
+    class FlowField {
+        array u
+        array v
+        array w
+    }
+
+    class Grid {
+        <<interface>>
+    }
+    class TurbineGrid
+    class FlowFieldPlanarGrid
+
+    class WakeModelManager {
+        <<interface>>
+    }
+    class WakeCombination {
+        dict parameters
+        function()
+    }
+    class WakeDeflection {
+        dict parameters
+        function()
+    }
+    class WakeTurbulence {
+        dict parameters
+        function()
+    }
+    class WakeVelocity {
+        dict parameters
+        function()
+    }
+
+    class Solver {
+        <<interface>>
+        dict parameters
+    }
+
+    Floris o-- Farm
+    Floris o-- FlowField
+    Floris o-- Grid
+    Floris o-- WakeModelManager
+    Floris *-- Solver
+    WakeModelManager o-- WakeCombination
+    WakeModelManager o-- WakeDeflection
+    WakeModelManager o-- WakeTurbulence
+    WakeModelManager o-- WakeVelocity
+
+    Grid <|-- TurbineGrid
+    Grid <|-- FlowFieldPlanarGrid
+
+    Solver --> Farm
+    Solver --> FlowField
+    Solver --> Grid
+    Solver --> WakeModelManager
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,13 @@
 
 # Architecture and Design
 
-There are a few fundamental characteristics that define the FLORIS software:
+Two fundamental ideas define the design of the FLORIS software:
 
-- Modularity in two places:
-    - Wake model mathematical formulation
-    - Grouping of packages at the highest organization level
-- Management of abstraction:
+- Modularity in wake model formulation
+    - Mathematical formulation should be straightforward to include
+    - Requisite solver and grid data structures should not conflict with other existing
+        wake models
+- Management of abstraction
     - Low level code is opaque but well tested and exercised; it should be very computationally
         efficient with low algorithmic complexity
     - High level code should be expressive and clear even if it results in verbose or less

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -49,12 +49,12 @@ def floris_array_converter(data: Iterable) -> np.ndarray:
         raise TypeError(e.args[0] + f". Data given: {data}")
     return a
 
-def attr_serializer(inst: type, field: Attribute, value: Any):
+def _attr_serializer(inst: type, field: Attribute, value: Any):
     if isinstance(value, np.ndarray):
         return value.tolist()
     return value
 
-def attr_floris_filter(inst: Attribute, value: Any) -> bool:
+def _attr_floris_filter(inst: Attribute, value: Any) -> bool:
     if inst.init is False:
         return False
     if value is None:
@@ -85,7 +85,6 @@ def iter_validator(iter_type, item_types: Union[Any, Tuple[Any]]) -> Callable:
         iterable_validator=attrs.validators.instance_of(iter_type),
     )
     return validator
-
 
 def convert_to_path(fn: str | Path) -> Path:
     """Converts an input string or pathlib.Path object to a fully resolved ``pathlib.Path``
@@ -164,7 +163,7 @@ class FromDictMixin:
         Returns:
             dict: All key, vaue pais required for class recreation.
         """
-        return attrs.asdict(self, filter=attr_floris_filter, value_serializer=attr_serializer)
+        return attrs.asdict(self, filter=_attr_floris_filter, value_serializer=_attr_serializer)
 
 
 # Avoids constant redefinition of the same attr.ib properties for model attributes

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ EXTRAS = {
         "sphinx-book-theme",
         "sphinx-autodoc-typehints",
         "sphinxcontrib-autoyaml",
+        "sphinxcontrib.mermaid",
     },
     "develop": {
         "pytest",


### PR DESCRIPTION
# FLORIS software architecture
This pull request adds a first-pass description of the FLORIS architecture at a relatively high level. The packages at `floris.*` are described as well as the general architecture and class relationships of `floris.simulation`. The objective is to establish the initial architecture and provide a place for ongoing descriptions of architectural changes.

As a small aside, I also made a couple of functions in `floris.type_dec` that make two functions private (prefix with `_`) that were previously denoted as public. 

## Impacted areas of the software
Developer docs and `floris.type_dec`