### PR TITLE
Pin Jupyter Book version

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -224,7 +224,6 @@ jupyter-book build docs/
 open docs/_build/html/index.html
 ```
 
-
 ## Deploying to pip
 
 Generally, only NREL developers will have appropriate permissions to deploy

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ REQUIRED = [
 #   pip install "floris[develop]"       installs developer packages in non-editable install
 EXTRAS = {
     "docs": {
-        "jupyter-book",
+        "jupyter-book<=0.13.3",
         "sphinx-book-theme",
         "sphinx-autodoc-typehints",
         "sphinxcontrib-autoyaml",


### PR DESCRIPTION
# Resolve a dependency version bug

This pull request pins the version of the Jupyter Book dependency used in the online documentation to v0.13.3 or less. Higher versions of Jupyter Book have a conflict with the methods we use to recursively create API documentation as described in #635.

See the live and passing version of the docs build step happening [here](https://github.com/rafmudaf/floris/actions/runs/4800147117). Before this commit, the build step failed with this error as seen [here](https://github.com/rafmudaf/floris/actions/runs/4800075458).

## Related issue
Work around for https://github.com/NREL/floris/issues/635 but does not close it

## Impacted areas of the software
Documentation build system