### PR TITLE
Disable user-provided tilt angle settings in wake calculation

### DIFF
--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -192,6 +192,11 @@ class Farm(BaseClass):
             sorted_indices[:, :, :, 0, 0],
             axis=2,
         )
+        self.tilt_angles_sorted = np.take_along_axis(
+            self.tilt_angles,
+            sorted_indices[:, :, :, 0, 0],
+            axis=2,
+        )
         self.state = State.INITIALIZED
 
     def construct_hub_heights(self):

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -116,7 +116,7 @@ class FlorisInterface(LoggerBase):
     def calculate_wake(
         self,
         yaw_angles: NDArrayFloat | list[float] | None = None,
-        tilt_angles: NDArrayFloat | list[float] | None = None,
+        # tilt_angles: NDArrayFloat | list[float] | None = None,
         # points: NDArrayFloat | list[float] | None = None,
         # track_n_upstream_wakes: bool = False,
     ) -> None:
@@ -139,14 +139,14 @@ class FlorisInterface(LoggerBase):
             )
         self.floris.farm.yaw_angles = yaw_angles
 
-        # TODO is this required?
-        if tilt_angles is not None:
-            self.floris.farm.tilt_angles = tilt_angles
-        else:
-            self.floris.farm.set_tilt_to_ref_tilt(
-                self.floris.flow_field.n_wind_directions,
-                self.floris.flow_field.n_wind_speeds
-            )
+        # # TODO is this required?
+        # if tilt_angles is not None:
+        #     self.floris.farm.tilt_angles = tilt_angles
+        # else:
+        #     self.floris.farm.set_tilt_to_ref_tilt(
+        #         self.floris.flow_field.n_wind_directions,
+        #         self.floris.flow_field.n_wind_speeds
+        #     )
 
         # Initialize solution space
         self.floris.initialize_domain()

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -116,7 +116,7 @@ class FlorisInterface(LoggerBase):
     def calculate_wake(
         self,
         yaw_angles: NDArrayFloat | list[float] | None = None,
-        # tilt_angles: NDArrayFloat | list[float] | None = None,
+        tilt_angles: NDArrayFloat | list[float] | None = None,
         # points: NDArrayFloat | list[float] | None = None,
         # track_n_upstream_wakes: bool = False,
     ) -> None:
@@ -139,14 +139,14 @@ class FlorisInterface(LoggerBase):
             )
         self.floris.farm.yaw_angles = yaw_angles
 
-        # # TODO is this required?
-        # if tilt_angles is not None:
-        #     self.floris.farm.tilt_angles = tilt_angles
-        # else:
-        #     self.floris.farm.set_tilt_to_ref_tilt(
-        #         self.floris.flow_field.n_wind_directions,
-        #         self.floris.flow_field.n_wind_speeds
-        #     )
+        # TODO is this required?
+        if tilt_angles is not None:
+            self.floris.farm.tilt_angles = tilt_angles
+        else:
+            self.floris.farm.set_tilt_to_ref_tilt(
+                self.floris.flow_field.n_wind_directions,
+                self.floris.flow_field.n_wind_speeds
+            )
 
         # Initialize solution space
         self.floris.initialize_domain()

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -116,7 +116,7 @@ class FlorisInterface(LoggerBase):
     def calculate_wake(
         self,
         yaw_angles: NDArrayFloat | list[float] | None = None,
-        tilt_angles: NDArrayFloat | list[float] | None = None,
+        # tilt_angles: NDArrayFloat | list[float] | None = None,
         # points: NDArrayFloat | list[float] | None = None,
         # track_n_upstream_wakes: bool = False,
     ) -> None:
@@ -127,13 +127,6 @@ class FlorisInterface(LoggerBase):
         Args:
             yaw_angles (NDArrayFloat | list[float] | None, optional): Turbine yaw angles.
                 Defaults to None.
-            tilt_angles (NDArrayFloat | list[float] | None, optional): Turbine tilt angles.
-                Defaults to None.
-            points: (NDArrayFloat | list[float] | None, optional): The x, y, and z
-                coordinates at which the flow field velocity is to be recorded. Defaults
-                to None.
-            track_n_upstream_wakes (bool, optional): When *True*, will keep track of the
-                number of upstream wakes a turbine is experiencing. Defaults to *False*.
         """
 
         if yaw_angles is None:
@@ -146,14 +139,14 @@ class FlorisInterface(LoggerBase):
             )
         self.floris.farm.yaw_angles = yaw_angles
 
-        # TODO is this required?
-        if tilt_angles is not None:
-            self.floris.farm.tilt_angles = tilt_angles
-        else:
-            self.floris.farm.set_tilt_to_ref_tilt(
-                self.floris.flow_field.n_wind_directions,
-                self.floris.flow_field.n_wind_speeds
-            )
+        # # TODO is this required?
+        # if tilt_angles is not None:
+        #     self.floris.farm.tilt_angles = tilt_angles
+        # else:
+        #     self.floris.farm.set_tilt_to_ref_tilt(
+        #         self.floris.flow_field.n_wind_directions,
+        #         self.floris.flow_field.n_wind_speeds
+        #     )
 
         # Initialize solution space
         self.floris.initialize_domain()

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -117,8 +117,6 @@ class FlorisInterface(LoggerBase):
         self,
         yaw_angles: NDArrayFloat | list[float] | None = None,
         # tilt_angles: NDArrayFloat | list[float] | None = None,
-        # points: NDArrayFloat | list[float] | None = None,
-        # track_n_upstream_wakes: bool = False,
     ) -> None:
         """
         Wrapper to the :py:meth:`~.Farm.set_yaw_angles` and


### PR DESCRIPTION
Comment out tilt angles from calc wake function

floris_interface's calculate_wake function currently accepts tilt_angles as an input, but does not apparently apply them.  Propose to comment these out (and not delete in the assumption we will want to offer this function some day)


## Impacted areas of the software
floris_interface.py
