### PR TITLE
Bug fix: erroneous rotation in turbine locations in horizontal flowfield plots

### DIFF
--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -76,14 +76,16 @@ def plot_turbines(
 
 def plot_turbines_with_fi(
     fi: FlorisInterface,
-    ax=None,
-    color=None,
-    wd=None,
-    yaw_angles=None,
+    ax: plt.Axes = None,
+    color: str = None,
+    wd: np.ndarray = None,
+    yaw_angles: np.ndarray = None,
 ):
     """
-    Wrapper function to plot turbines which extracts the data
-    from a FLORIS interface object
+    Plot the wind plant layout from turbine locations gotten from a FlorisInterface object.
+    Note that this function automatically uses the first wind direction and first wind speed.
+    Generally, it is most explicit to create a new FlorisInterface with only the single
+    wind condition that should be plotted.
 
     Args:
         fi (:py:class:`floris.tools.floris_interface.FlorisInterface`): FlorisInterface object.
@@ -102,14 +104,17 @@ def plot_turbines_with_fi(
     # Rotate yaw angles to inertial frame for plotting turbines relative to wind direction
     yaw_angles = yaw_angles - wind_delta(np.array(wd))
 
-    plot_turbines(
-        ax,
-        fi.layout_x,
-        fi.layout_y,
-        yaw_angles.flatten(),
-        fi.floris.farm.rotor_diameters.flatten(),
-        color=color,
-    )
+    if color is None:
+        color = "k"
+
+    rotor_diameters = fi.floris.farm.rotor_diameters.flatten()
+    for x, y, yaw, d in zip(fi.layout_x, fi.layout_y, yaw_angles[0,0], rotor_diameters):
+        R = d / 2.0
+        x_0 = x + np.sin(np.deg2rad(yaw)) * R
+        x_1 = x - np.sin(np.deg2rad(yaw)) * R
+        y_0 = y - np.cos(np.deg2rad(yaw)) * R
+        y_1 = y + np.cos(np.deg2rad(yaw)) * R
+        ax.plot([x_0, x_1], [y_0, y_1], color=color)
 
 
 def add_turbine_id_labels(fi: FlorisInterface, ax: plt.Axes, **kwargs):

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -49,9 +49,8 @@ def plot_turbines(
         layout_x (np.array): Wind turbine locations (east-west).
         layout_y (np.array): Wind turbine locations (north-south).
         yaw_angles (np.array): Yaw angles of each wind turbine.
-        D (float): Wind turbine rotor diameter.
-        color (str): Pyplot color option to plot the turbines.
-        wind_direction (float): Wind direction (rotates farm)
+        rotor_diameters (np.array): Wind turbine rotor diameter.
+        color (str): pyplot color option to plot the turbines.
     """
     if color is None:
         color = "k"

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import copy
 from typing import Union
+import warnings
 
 import matplotlib as mpl
 import matplotlib.colors as mplcolors
@@ -42,6 +43,8 @@ def plot_turbines(
     color: str | None = None,
 ):
     """
+    This function is deprecated and will be removed in v3.5, use `plot_turbines_with_fi` instead.
+
     Plot wind plant layout from turbine locations.
 
     Args:
@@ -52,6 +55,13 @@ def plot_turbines(
         rotor_diameters (np.array): Wind turbine rotor diameter.
         color (str): pyplot color option to plot the turbines.
     """
+    warnings.warn(
+        "The `plot_turbines` function is deprecated and will be removed in v3.5, "
+        "use `plot_turbines_with_fi` instead.",
+        DeprecationWarning,
+        stacklevel=2  # This prints the calling function and this function in the warning
+    )
+
     if color is None:
         color = "k"
 

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -40,7 +40,6 @@ def plot_turbines(
     yaw_angles,
     rotor_diameters,
     color: str | None = None,
-    wind_direction: float = 270.0,
 ):
     """
     Plot wind plant layout from turbine locations.
@@ -57,14 +56,7 @@ def plot_turbines(
     if color is None:
         color = "k"
 
-    # Rotate layout to inertial frame for plotting turbines relative to wind direction
-    coordinates_array = np.array([[x, y, 0.0] for x, y in list(zip(layout_x, layout_y))])
-    layout_x, layout_y, _, _, _ = rotate_coordinates_rel_west(
-        np.array([wind_direction]),
-        coordinates_array
-    )
-
-    for x, y, yaw, d in zip(layout_x[0,0], layout_y[0,0], yaw_angles, rotor_diameters):
+    for x, y, yaw, d in zip(layout_x, layout_y, yaw_angles, rotor_diameters):
         R = d / 2.0
         x_0 = x + np.sin(np.deg2rad(yaw)) * R
         x_1 = x - np.sin(np.deg2rad(yaw)) * R
@@ -108,7 +100,6 @@ def plot_turbines_with_fi(
         yaw_angles.flatten(),
         fi.floris.farm.rotor_diameters.flatten(),
         color=color,
-        wind_direction=fi.floris.flow_field.wind_directions[0],
     )
 
 

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -14,8 +14,8 @@
 from __future__ import annotations
 
 import copy
-from typing import Union
 import warnings
+from typing import Union
 
 import matplotlib as mpl
 import matplotlib.colors as mplcolors


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Bug fix: Turbine locations in horizontal flow field plot
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
In the release version of FLORIS `v3.4`, the turbine locations are always rotated with respect to the wind direction in functions `visualization.plot_turbines` and `visualization.plot_turbines_with_fi`. However, with the recent change in horizontal flow field plots #578 where the turbine locations remain fixed and instead the flow field rotates, this puts the turbines in the wrong locations in the plot.

## Related issue
<!--
If one exists, link to a related GitHub Issue.
-->
N/A

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
-->
Visualization.

## Additional supporting information
<!--
Add any other context about the problem here.
-->

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->
Here is a minimal script to reproduce the issue:
```
import matplotlib.pyplot as plt

import floris.tools.visualization as wakeviz
from floris.tools import FlorisInterface
from floris.tools.visualization import plot_turbines_with_fi

# Load FLORIS
fi = FlorisInterface("inputs/gch.yaml")
fi.reinitialize(wind_directions=[245.0])
horizontal_plane = fi.calculate_horizontal_plane(height=90.0)

# Create the plots
fig, ax = plt.subplots()
wakeviz.visualize_cut_plane(horizontal_plane, ax=ax, title="Horizontal")
plot_turbines_with_fi(fi=fi, ax=ax)
plt.show()
```

With the current `develop` branch and FLORIS `v3.4`, we find:
![image](https://github.com/NREL/floris/assets/22119448/008638af-b750-4dfd-824b-32da47a03726)

With this Pull Request, we find:
![image](https://github.com/NREL/floris/assets/22119448/3248b906-7974-46f4-8694-d7f63bac1da5)

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
