### PR TITLE
Bug fix: Finalize Farm attributes

### DIFF
--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -75,10 +75,13 @@ class Farm(BaseClass):
     hub_heights: NDArrayFloat = field(init=False)
     hub_heights_sorted: NDArrayFloat = field(init=False, default=[])
 
+    turbine_type_map: NDArrayObject = field(init=False, default=[])
     turbine_type_map_sorted: NDArrayObject = field(init=False, default=[])
 
+    rotor_diameters: NDArrayFloat = field(init=False, default=[])
     rotor_diameters_sorted: NDArrayFloat = field(init=False, default=[])
 
+    TSRs: NDArrayFloat = field(init=False, default=[])
     TSRs_sorted: NDArrayFloat = field(init=False, default=[])
 
     pPs: NDArrayFloat = field(init=False, default=[])

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -62,26 +62,36 @@ class Farm(BaseClass):
     )
 
     turbine_definitions: list = field(init=False, validator=iter_validator(list, dict))
+    coordinates: List[Vec3] = field(init=False)
+    turbine_fCts: tuple = field(init=False, default=[])
+    turbine_fTilts: list = field(init=False, default=[])
+
     yaw_angles: NDArrayFloat = field(init=False)
     yaw_angles_sorted: NDArrayFloat = field(init=False)
+
     tilt_angles: NDArrayFloat = field(init=False)
     tilt_angles_sorted: NDArrayFloat = field(init=False)
-    coordinates: List[Vec3] = field(init=False)
+
     hub_heights: NDArrayFloat = field(init=False)
     hub_heights_sorted: NDArrayFloat = field(init=False, default=[])
-    turbine_fCts: tuple = field(init=False, default=[])
+
     turbine_type_map_sorted: NDArrayObject = field(init=False, default=[])
+
     rotor_diameters_sorted: NDArrayFloat = field(init=False, default=[])
+
     TSRs_sorted: NDArrayFloat = field(init=False, default=[])
+
     pPs: NDArrayFloat = field(init=False, default=[])
     pPs_sorted: NDArrayFloat = field(init=False, default=[])
+
     pTs: NDArrayFloat = field(init=False, default=[])
     pTs_sorted: NDArrayFloat = field(init=False, default=[])
+
     ref_tilt_cp_cts: NDArrayFloat = field(init=False, default=[])
     ref_tilt_cp_cts_sorted: NDArrayFloat = field(init=False, default=[])
+
     correct_cp_ct_for_tilt: NDArrayFloat = field(init=False, default=[])
     correct_cp_ct_for_tilt_sorted: NDArrayFloat = field(init=False, default=[])
-    turbine_fTilts: list = field(init=False, default=[])
 
     def __attrs_post_init__(self) -> None:
         # Turbine definitions can be supplied in three ways:

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -381,9 +381,21 @@ class Farm(BaseClass):
             axis=2
         )
         # TODO: do these need to be unsorted? Maybe we should just for completeness...
-        # self.ref_density_cp_cts_sorted = np.take_along_axis(
-        # self.ref_tilt_cp_cts_sorted = np.take_along_axis(
-        # self.correct_cp_ct_for_tilt_sorted = np.take_along_axis(
+        self.ref_density_cp_cts = np.take_along_axis(
+            self.ref_density_cp_cts_sorted,
+            unsorted_indices[:,:,:,0,0],
+            axis=2
+        )
+        self.ref_tilt_cp_cts = np.take_along_axis(
+            self.ref_tilt_cp_cts_sorted,
+            unsorted_indices[:,:,:,0,0],
+            axis=2
+        )
+        self.correct_cp_ct_for_tilt = np.take_along_axis(
+            self.correct_cp_ct_for_tilt_sorted,
+            unsorted_indices[:,:,:,0,0],
+            axis=2
+        )
         self.pPs = np.take_along_axis(
             self.pPs_sorted,
             unsorted_indices[:,:,:,0,0],

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -314,6 +314,8 @@ class Farm(BaseClass):
             sorted_coord_indices,
             axis=2
         )
+
+        # NOTE: Tilt angles are sorted twice - here and in initialize()
         self.tilt_angles_sorted = np.take_along_axis(
             self.tilt_angles * template_shape,
             sorted_coord_indices,
@@ -378,6 +380,10 @@ class Farm(BaseClass):
             unsorted_indices[:,:,:,0,0],
             axis=2
         )
+        # TODO: do these need to be unsorted? Maybe we should just for completeness...
+        # self.ref_density_cp_cts_sorted = np.take_along_axis(
+        # self.ref_tilt_cp_cts_sorted = np.take_along_axis(
+        # self.correct_cp_ct_for_tilt_sorted = np.take_along_axis(
         self.pPs = np.take_along_axis(
             self.pPs_sorted,
             unsorted_indices[:,:,:,0,0],

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -319,10 +319,9 @@ class Farm(BaseClass):
             sorted_coord_indices,
             axis=2
         )
-        self.turbine_type_names_sorted = [turb["turbine_type"] for turb in self.turbine_definitions]
         self.turbine_type_map_sorted = np.take_along_axis(
             np.reshape(
-                self.turbine_type_names_sorted * n_wind_directions,
+                [turb["turbine_type"] for turb in self.turbine_definitions] * n_wind_directions,
                 np.shape(sorted_coord_indices)
             ),
             sorted_coord_indices,


### PR DESCRIPTION
# Finalize Farm attributes and other Farm clean up
This pull request finalized three attributes on the Farm class:

```python
Farm.ref_density_cp_cts
Farm.ref_tilt_cp_cts
Farm.correct_cp_ct_for_tilt
```

Currently, these are created when the Farm attributes are expanded using the `Farm.construct_*` methods. However, these particular attributes are initially 1D with the length being the number of turbines. After the wake calculation, they must be expanded again via `Farm.finalize()` so that they have the three dimensions expected by the post-processing routines in `Turbine`, that is `(n wind directions, n wind speeds, n turbines)`.

Thanks to @marcusbecker-github for reporting this bug in #664.

Additionally, this pull request declares some Farm-class attributes that were otherwise added to the class after init. The attributes are also grouped into whether they have a corresponding `_sorted` version.

## Related issue
#664

## Impacted areas of the software
Only changes are in farm.py

## Additional supporting information
Since this is a bug, it could be released as v3.4.1 along with #663.
