### PR TITLE
Feature: Add concurrent library to ParallelComputingInterface

### DIFF
--- a/examples/12_optimize_yaw_in_parallel.py
+++ b/examples/12_optimize_yaw_in_parallel.py
@@ -67,12 +67,13 @@ if __name__ == "__main__":
     )
 
     # Pour this into a parallel computing interface
+    parallel_interface = "concurrent"
     fi_aep_parallel = ParallelComputingInterface(
         fi=fi_aep,
         max_workers=max_workers,
         n_wind_direction_splits=max_workers,
         n_wind_speed_splits=1,
-        use_mpi4py=False,
+        interface=parallel_interface,
         print_timings=True,
     )
 
@@ -113,7 +114,7 @@ if __name__ == "__main__":
         max_workers=max_workers,
         n_wind_direction_splits=max_workers,
         n_wind_speed_splits=1,
-        use_mpi4py=False,
+        interface=parallel_interface,
         print_timings=True,
     )
 

--- a/floris/tools/parallel_computing_interface.py
+++ b/floris/tools/parallel_computing_interface.py
@@ -9,6 +9,8 @@ from floris.logging_manager import LoggerBase
 from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 from floris.tools.uncertainty_interface import FlorisInterface, UncertaintyInterface
 
+import warnings
+
 
 def _load_local_floris_object(
     fi_dict,
@@ -104,7 +106,7 @@ class ParallelComputingInterface(LoggerBase):
 
         # Set defaults for backward compatibility
         if use_mpi4py is not None:
-            DeprecationWarning("The option 'mpi4py' will be removed in a future version. Please use the option 'interface'.")
+            warnings.warn("The option 'mpi4py' will be removed in a future version. Please use the option 'interface'.")
             if use_mpi4py:
                 interface = "mpi4py"
             else:

--- a/floris/tools/parallel_computing_interface.py
+++ b/floris/tools/parallel_computing_interface.py
@@ -1,5 +1,6 @@
 # Copyright 2022 Shell
 import copy
+import warnings
 from time import perf_counter as timerpc
 
 import numpy as np
@@ -8,8 +9,6 @@ import pandas as pd
 from floris.logging_manager import LoggerBase
 from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 from floris.tools.uncertainty_interface import FlorisInterface, UncertaintyInterface
-
-import warnings
 
 
 def _load_local_floris_object(
@@ -106,12 +105,15 @@ class ParallelComputingInterface(LoggerBase):
 
         # Set defaults for backward compatibility
         if use_mpi4py is not None:
-            warnings.warn("The option 'mpi4py' will be removed in a future version. Please use the option 'interface'.")
+            warnings.warn(
+                "The option 'mpi4py' will be removed in a future version. "
+                "Please use the option 'interface'."
+            )
             if use_mpi4py:
                 interface = "mpi4py"
             else:
                 interface = "multiprocessing"
-        
+
         if interface == "mpi4py":
             import mpi4py.futures as mp
             self._PoolExecutor = mp.MPIPoolExecutor
@@ -124,7 +126,10 @@ class ParallelComputingInterface(LoggerBase):
             from concurrent.futures import ProcessPoolExecutor
             self._PoolExecutor = ProcessPoolExecutor
         else:
-            raise UserWarning(f"Interface '{interface}' not recognized. Please use 'concurrent', 'multiprocessing' or 'mpi4py'.")
+            raise UserWarning(
+                f"Interface '{interface}' not recognized. "
+                "Please use 'concurrent', 'multiprocessing' or 'mpi4py'."
+            )
 
         # Initialize floris object and copy common properties
         self.fi = fi.copy()

--- a/floris/tools/parallel_computing_interface.py
+++ b/floris/tools/parallel_computing_interface.py
@@ -84,6 +84,22 @@ class ParallelComputingInterface(LoggerBase):
         fi (FlorisInterface or UncertaintyInterface object): Interactive FLORIS object used to
             perform the wake and turbine calculations. Can either be a regular FlorisInterface
             object or can be an UncertaintyInterface object.
+        max_workers (int): Number of parallel workers, typically equal to the number of cores
+            you have on your system or HPC.
+        n_wind_direction_splits (int): Number of sectors to split the wind direction array over.
+            This is typically equal to max_workers, or a multiple of it.
+        n_wind_speed_splits (int): Number of sectors to split the wind speed array over. This is
+            typically 1 or 2. Defaults to 1.
+        interface (str): Parallel computing interface to leverage. Recommended is 'concurrent'
+            or 'multiprocessing' for local (single-system) use, and 'mpi4py' for high performance
+            computing on multiple nodes. Defaults to 'multiprocessing'.
+        use_mpi4py (bool): Deprecated option to enable/disable the usage of 'mpi4py'. This option
+            has been superseded by 'interface'.
+        propagate_flowfield_from_workers (bool): By enabling this, the flow field from every
+            floris object (one for each worker) is exported, combined and sent back to the main
+            module. This is slow so unless it's needed, it's recommended to be disabled. Defaults
+            to False.
+        print_timings (bool): Print the computation time to the console. Defaults to False.
         """
 
         # Set defaults for backward compatibility


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Feature: add `concurrent` to ParallelComputingInterface class
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This PR adds the ability to use the `concurrent` library for parallel computing. `concurrent` is an alternative to the `multiprocessing` library that is deemed to be more reliable at times, e..g, see the comments in https://stackoverflow.com/questions/20776189/concurrent-futures-vs-multiprocessing-in-python-3.

## Related issue
<!--
If one exists, link to a related GitHub Issue.
-->
No official issues reported. I have personally experienced some time-out issues with `multiprocessing` and its interaction with `streamlit`. Workers may time out due to local errors but that never escalates back up to the main process, and therefore a job may hang forever. Supposedly `concurrent` is better at handling this.

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
-->
Parallel Computing Interface.

## Additional supporting information
<!--
Add any other context about the problem here.
-->
N/A

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->
The yaw optimization in `12_optimize_yaw_in_parallel.py` with `interface = "multiprocessing"` reports:
```
===============================================================================
Total time spent for parallel calculation (16 workers): 15.342 s
  Time spent in parallel preprocessing: 0.002 s
  Time spent in parallel loop execution: 15.331 s.
  Time spent in parallel postprocessing: 0.008 s
```

with `interface = "concurrent"` I find generally a slight improvement in computation time:
```
===============================================================================
Total time spent for parallel calculation (16 workers): 14.643 s
  Time spent in parallel preprocessing: 0.002 s
  Time spent in parallel loop execution: 14.632 s.
  Time spent in parallel postprocessing: 0.009 s
```

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
