### PR TITLE
Enable heterogeneous inflows in yaw optimization routines

### DIFF
--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -265,6 +265,8 @@ def power(
     for turb_type in turb_types:
         # Using a masked array, apply the thrust coefficient for all turbines of the current
         # type to the main thrust coefficient array
+        if (rotor_effective_velocities < 0.).any():
+            print("Some rotor effective velocities are negative.")
         p += (
             power_interp[turb_type](rotor_effective_velocities)
             * (turbine_type_map == turb_type)
@@ -665,7 +667,9 @@ class Turbine(BaseClass):
         )
         self.power_interp = interp1d(
             wind_speeds,
-            inner_power
+            inner_power,
+            bounds_error=False,
+            fill_value=0
         )
 
         """

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -265,8 +265,6 @@ def power(
     for turb_type in turb_types:
         # Using a masked array, apply the thrust coefficient for all turbines of the current
         # type to the main thrust coefficient array
-        if (rotor_effective_velocities < 0.).any():
-            print("Some rotor effective velocities are negative.")
         p += (
             power_interp[turb_type](rotor_effective_velocities)
             * (turbine_type_map == turb_type)

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -595,6 +595,10 @@ class FlorisInterface(LoggerBase):
                 "Can't run function `FlorisInterface.get_turbine_powers` without "
                 "first running `FlorisInterface.calculate_wake`."
             )
+        # Check for negative velocities, which could indicate bad model
+        # parameters or turbines very closely spaced.
+        if (self.turbine_effective_velocities < 0.).any():
+            print("WARNING: Some rotor effective velocities are negative.")
 
         turbine_powers = power(
             ref_density_cp_ct=self.floris.farm.ref_density_cp_cts,

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -598,7 +598,7 @@ class FlorisInterface(LoggerBase):
         # Check for negative velocities, which could indicate bad model
         # parameters or turbines very closely spaced.
         if (self.turbine_effective_velocities < 0.).any():
-            print("WARNING: Some rotor effective velocities are negative.")
+            self.logger.warning("WARNING: Some rotor effective velocities are negative.")
 
         turbine_powers = power(
             ref_density_cp_ct=self.floris.farm.ref_density_cp_cts,

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -598,7 +598,7 @@ class FlorisInterface(LoggerBase):
         # Check for negative velocities, which could indicate bad model
         # parameters or turbines very closely spaced.
         if (self.turbine_effective_velocities < 0.).any():
-            self.logger.warning("WARNING: Some rotor effective velocities are negative.")
+            self.logger.warning("Some rotor effective velocities are negative.")
 
         turbine_powers = power(
             ref_density_cp_ct=self.floris.farm.ref_density_cp_cts,

--- a/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimization_base.py
@@ -338,7 +338,9 @@ class YawOptimization:
             / self._normalization_length
         )
 
-    def _calculate_farm_power(self, yaw_angles=None, wd_array=None, turbine_weights=None):
+    def _calculate_farm_power(self, yaw_angles=None, wd_array=None, turbine_weights=None,
+            heterogeneous_speed_multipliers=None
+        ):
         """
         Calculate the wind farm power production assuming the predefined
         probability distribution (self.unc_options/unc_pmf), with the
@@ -358,6 +360,9 @@ class YawOptimization:
             yaw_angles = self._yaw_angles_baseline_subset
         if turbine_weights is None:
             turbine_weights = self._turbine_weights_subset
+        if heterogeneous_speed_multipliers is not None:
+            fi_subset.floris.flow_field.\
+                heterogenous_inflow_config['speed_multipliers'] = heterogeneous_speed_multipliers
 
         # Ensure format [incompatible with _subset notation]
         yaw_angles = self._unpack_variable(yaw_angles, subset=True)

--- a/floris/tools/optimization/yaw_optimization/yaw_optimizer_scipy.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimizer_scipy.py
@@ -108,6 +108,14 @@ class YawOptimizationScipy(YawOptimization):
                 yaw_template = np.tile(yaw_template, (1, 1, 1))
                 turbine_weights = np.tile(turbine_weights, (1, 1, 1))
 
+                # Handle heterogeneous inflow, if there is one
+                if (hasattr(self.fi.floris.flow_field, 'heterogenous_inflow_config') and 
+                    self.fi.floris.flow_field.heterogenous_inflow_config is not None):
+                    het_sm_orig = np.array(self.fi.floris.flow_field.heterogenous_inflow_config['speed_multipliers'])
+                    het_sm = het_sm_orig[nwdi,:].reshape(1,-1)
+                else:
+                    het_sm = None
+
                 # Define cost function
                 def cost(x):
                     x_full = np.array(yaw_template, copy=True)
@@ -116,7 +124,8 @@ class YawOptimizationScipy(YawOptimization):
                         - 1.0 * self._calculate_farm_power(
                             yaw_angles=x_full,
                             wd_array=[wd],
-                            turbine_weights=turbine_weights
+                            turbine_weights=turbine_weights,
+                            heterogeneous_speed_multipliers=het_sm
                         )[0, 0] / J0
                     )
 

--- a/floris/tools/optimization/yaw_optimization/yaw_optimizer_scipy.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimizer_scipy.py
@@ -109,9 +109,11 @@ class YawOptimizationScipy(YawOptimization):
                 turbine_weights = np.tile(turbine_weights, (1, 1, 1))
 
                 # Handle heterogeneous inflow, if there is one
-                if (hasattr(self.fi.floris.flow_field, 'heterogenous_inflow_config') and 
+                if (hasattr(self.fi.floris.flow_field, 'heterogenous_inflow_config') and
                     self.fi.floris.flow_field.heterogenous_inflow_config is not None):
-                    het_sm_orig = np.array(self.fi.floris.flow_field.heterogenous_inflow_config['speed_multipliers'])
+                    het_sm_orig = np.array(
+                        self.fi.floris.flow_field.heterogenous_inflow_config['speed_multipliers']
+                    )
                     het_sm = het_sm_orig[nwdi,:].reshape(1,-1)
                 else:
                     het_sm = None

--- a/floris/tools/optimization/yaw_optimization/yaw_optimizer_sr.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimizer_sr.py
@@ -141,9 +141,11 @@ class YawOptimizationSR(YawOptimization, LoggerBase):
         if not np.all(idx):
             # Now calculate farm powers for conditions we haven't yet evaluated previously
             start_time = timerpc()
-            if (hasattr(self.fi.floris.flow_field, 'heterogenous_inflow_config') and 
+            if (hasattr(self.fi.floris.flow_field, 'heterogenous_inflow_config') and
                 self.fi.floris.flow_field.heterogenous_inflow_config is not None):
-                het_sm_orig = np.array(self.fi.floris.flow_field.heterogenous_inflow_config['speed_multipliers'])
+                het_sm_orig = np.array(
+                    self.fi.floris.flow_field.heterogenous_inflow_config['speed_multipliers']
+                )
                 het_sm = np.tile(het_sm_orig, (Ny, 1))[~idx, :]
             else:
                 het_sm = None

--- a/floris/tools/optimization/yaw_optimization/yaw_optimizer_sr.py
+++ b/floris/tools/optimization/yaw_optimization/yaw_optimizer_sr.py
@@ -141,10 +141,17 @@ class YawOptimizationSR(YawOptimization, LoggerBase):
         if not np.all(idx):
             # Now calculate farm powers for conditions we haven't yet evaluated previously
             start_time = timerpc()
+            if (hasattr(self.fi.floris.flow_field, 'heterogenous_inflow_config') and 
+                self.fi.floris.flow_field.heterogenous_inflow_config is not None):
+                het_sm_orig = np.array(self.fi.floris.flow_field.heterogenous_inflow_config['speed_multipliers'])
+                het_sm = np.tile(het_sm_orig, (Ny, 1))[~idx, :]
+            else:
+                het_sm = None
             farm_powers[~idx, :] = self._calculate_farm_power(
                 wd_array=wd_array_subset[~idx],
                 turbine_weights=turbine_weights_subset[~idx, :, :],
                 yaw_angles=yaw_angles_subset[~idx, :, :],
+                heterogeneous_speed_multipliers=het_sm
             )
             self.time_spent_in_floris += (timerpc() - start_time)
 


### PR DESCRIPTION
Neither Serial Refine nor the scipy minimize routine for yaw angle optimization currently work with a heterogeneous inflow (the issue for Serial Refine is identified in #673). This pull request addresses that. 

Additionally, turbine.py is updated to allow power to be extrapolated outside of the specified range in the turbine input file. Sampling with a wind speed outside of the interpolation range returns a power of 0. Finally, a minor update is made to turbine.py to warn the user if the `rotor_effective_velocities` contains any negative entries, which can happen in situations where turbines are very close together.

To reproduce the existing error with heterogeneous inflows and yaw optimizations, run
```
# Copyright 2021 NREL

# Licensed under the Apache License, Version 2.0 (the "License"); you may not
# use this file except in compliance with the License. You may obtain a copy of
# the License at http://www.apache.org/licenses/LICENSE-2.0

# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
# License for the specific language governing permissions and limitations under
# the License.

# See https://floris.readthedocs.io for documentation

import numpy as np

from floris.tools import FlorisInterface
from floris.tools.optimization.yaw_optimization.yaw_optimizer_scipy import YawOptimizationScipy
from floris.tools.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR


"""
This example showcases the heterogeneous inflow capabilities of FLORIS
when multiple wind speeds and direction are considered.
"""


# Define the speed ups of the heterogeneous inflow, and their locations.
# For the 2-dimensional case, this requires x and y locations.
# The speed ups are multipliers of the ambient wind speed.
x_locs = [-300.0, -300.0, 2600.0, 2600.0]
y_locs = [ -300.0, 300.0, -300.0, 300.0]

# Initialize FLORIS with the given input file via FlorisInterface.
# Note the heterogeneous inflow is defined in the input file.
#fi = FlorisInterface("inputs/gch_heterogeneous_inflow.yaml")
fi = FlorisInterface("inputs/gch.yaml")

# Set shear to 0.0 to highlight the heterogeneous inflow
fi.reinitialize(
    wind_shear=0.0,
    wind_speeds=[8.0],
    wind_directions=[270.],
    layout_x=[0, 0],
    layout_y=[-250., 250.],
)

# To change the number of wind directions however it is necessary to make a matching
# change to the dimensions of the het map
speed_multipliers = [[2.0, 1.0, 2.0, 1.0], [2.0, 1.0, 2.0, 1.0]] # Expand to two wind directions
heterogenous_inflow_config = {
    'speed_multipliers': speed_multipliers,
    'x': x_locs,
    'y': y_locs,
}
fi.reinitialize(
    wind_directions=[270.0, 180.0],
    wind_speeds=[8.0],
    heterogenous_inflow_config=heterogenous_inflow_config # Or, None
)
fi.calculate_wake()
turbine_powers = np.round(fi.get_turbine_powers() / 1000.)
print('With wind directions now set to 270 and 180 deg')
print(f'T0: {turbine_powers[:, :, 0].flatten()} kW')
print(f'T1: {turbine_powers[:, :, 1].flatten()} kW')

print("Serial refine:")
yaw_opt = YawOptimizationSR(
    fi=fi,
    minimum_yaw_angle=0.0,  # Allowable yaw angles lower bound
    maximum_yaw_angle=20.0,  # Allowable yaw angles upper bound
    Ny_passes=[5, 4],
    exclude_downstream_turbines=True,
    exploit_layout_symmetry=True,
)

df_opt = yaw_opt.optimize()
print(df_opt)


print("\nScipy optimize:")
yaw_opt = YawOptimizationScipy(
    fi=fi,
    minimum_yaw_angle=0.0,  # Allowable yaw angles lower bound
    maximum_yaw_angle=20.0,  # Allowable yaw angles upper bound
)

df_opt = yaw_opt.optimize()
print(df_opt)
```

As an example of a negative wind speed raising a power interpolation error, run
```
import numpy as np

from floris.tools import FlorisInterface

fi = FlorisInterface("inputs/emgauss.yaml")

fi.reinitialize(layout_x = [0, 5*126, 10*126], layout_y = [0, 0, 0], wind_speeds=[3])

# Alter initial wake width to something unreasonably low
fi_dict = fi.floris.as_dict()
fi_dict['wake']['wake_velocity_parameters']['empirical_gauss']\
    ['sigma_0_D'] = 0.01
fi = FlorisInterface(fi_dict)

fi.calculate_wake()

print(fi.get_turbine_powers()/1000)
```
Closes #673 

Ready for review/merge.