### PR TITLE
Bug fix: Add variable wind shear to GCH calculations

### DIFF
--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -149,6 +149,7 @@ def sequential_solver(
                 ct_i,
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
             )
             effective_yaw_i += added_yaw
 
@@ -178,6 +179,7 @@ def sequential_solver(
                 ct_i,
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
             )
 
         if model_manager.enable_yaw_added_recovery:
@@ -377,6 +379,7 @@ def full_flow_sequential_solver(
                 ct_i,
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
             )
             effective_yaw_i += added_yaw
 
@@ -406,6 +409,7 @@ def full_flow_sequential_solver(
                 ct_i,
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
             )
 
         # NOTE: exponential
@@ -554,6 +558,7 @@ def cc_solver(
                 turb_Cts[:, :, i:i+1],
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
                 scale=2.0,
             )
             effective_yaw_i += added_yaw
@@ -584,6 +589,7 @@ def cc_solver(
                 turb_Cts[:, :, i:i+1],
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
                 scale=2.0,
             )
 
@@ -784,6 +790,7 @@ def full_flow_cc_solver(
                 turb_Cts[:, :, i:i+1],
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
                 scale=2.0,
             )
             effective_yaw_i += added_yaw
@@ -814,6 +821,7 @@ def full_flow_cc_solver(
                 turb_Cts[:, :, i:i+1],
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
                 scale=2.0,
             )
 
@@ -948,6 +956,7 @@ def turbopark_solver(
                 ct_i,
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
             )
             effective_yaw_i += added_yaw
 
@@ -1009,6 +1018,7 @@ def turbopark_solver(
                 ct_i,
                 TSR_i,
                 axial_induction_i,
+                flow_field.wind_shear,
             )
 
         if model_manager.enable_yaw_added_recovery:

--- a/floris/simulation/wake_deflection/gauss.py
+++ b/floris/simulation/wake_deflection/gauss.py
@@ -257,6 +257,7 @@ def wake_added_yaw(
     ct_i,
     tip_speed_ratio,
     axial_induction_i,
+    wind_shear,
     scale=1.0,
 ):
     """
@@ -284,7 +285,7 @@ def wake_added_yaw(
     eps_gain = 0.2
     eps = eps_gain * D  # Use set value
 
-    vel_top = ((HH + D / 2) / HH) ** 0.12 * np.ones((1, 1, 1, 1, 1))
+    vel_top = ((HH + D / 2) / HH) ** wind_shear * np.ones((1, 1, 1, 1, 1))
     Gamma_top = gamma(
         D,
         vel_top,
@@ -293,7 +294,7 @@ def wake_added_yaw(
         scale,
     )
 
-    vel_bottom = ((HH - D / 2) / HH) ** 0.12 * np.ones((1, 1, 1, 1, 1))
+    vel_bottom = ((HH - D / 2) / HH) ** wind_shear * np.ones((1, 1, 1, 1, 1))
     Gamma_bottom = -1 * gamma(
         D,
         vel_bottom,
@@ -359,6 +360,7 @@ def calculate_transverse_velocity(
     ct_i,
     tsr_i,
     axial_induction_i,
+    wind_shear,
     scale=1.0,
 ):
     """
@@ -379,8 +381,7 @@ def calculate_transverse_velocity(
     eps_gain = 0.2
     eps = eps_gain * D  # Use set value
 
-    # TODO: wind sheer is hard-coded here but should be connected to the input
-    vel_top = ((HH + D / 2) / HH) ** 0.12 * np.ones((1, 1, 1, 1, 1))
+    vel_top = ((HH + D / 2) / HH) ** wind_shear * np.ones((1, 1, 1, 1, 1))
     Gamma_top = sind(yaw) * cosd(yaw) * gamma(
         D,
         vel_top,
@@ -389,7 +390,7 @@ def calculate_transverse_velocity(
         scale,
     )
 
-    vel_bottom = ((HH - D / 2) / HH) ** 0.12 * np.ones((1, 1, 1, 1, 1))
+    vel_bottom = ((HH - D / 2) / HH) ** wind_shear * np.ones((1, 1, 1, 1, 1))
     Gamma_bottom = -1 * sind(yaw) * cosd(yaw) * gamma(
         D,
         vel_bottom,


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
--> 


# Add variable wind shear to GCH calculations
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This pull request addresses the issue in #675. The calculations for the GCH model do not account for variable wind shear and are fixed to a shear coefficient of 0.12. Specifically, this is found in the ` vel_top` and `vel_bottom` calculations in methods `wake_added_yaw` and `calculate_transverse_velocity`. A new input argument `wind_shear`, which is extracted from the `FlowField` object (`flow_field.wind_shear`), is now added to the above-mentioned methods and included in the calculations.

## Related issue
<!--
If one exists, link to a related GitHub Issue.
--> Issue #675 

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
--> floris/simulation/solver.py
floris/simulation/wake_deflection/gauss.py

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
