### PR TITLE
Add example of larger floating farm with comparison to fixed-bottom.

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -129,7 +129,7 @@ the two-turbine farm.
 
 ### 29_floating_vs_fixedbottom_farm.py
 
-Compares a fixed-bottom wind farm (with a gridded layout) to a floating 
+Compares a fixed-bottom wind farm (with a gridded layout) to a floating
 wind farm with the same layout. Includes:
 - Turbine-by-turbine power comparison for a single wind speed and direction
 - Flow visualizations for a single wind speed and direction

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -100,7 +100,7 @@ Demonstrates the definition of a floating turbine and how to enable the effects 
 on Cp and Ct. 
 
 For further examples on floating wind turbines, see also examples
-25 (vertical wake deflection by a forced tilt angle) and 29 (comparison between 
+25 (vertical wake deflection by a forced tilt angle) and 29 (comparison between
 a fixed-bottom and floating wind farm).
 
 ### 25_tilt_driven_vertical_wake_deflection.py
@@ -112,7 +112,7 @@ unrealistic tilt angle, 15 degrees, to highlight the wake deflection. Moreover, 
 of vertical deflections due to tilt has not been validated.
 
 For further examples on floating wind turbines, see also examples
-24 (effects of tilt on turbine power and thrust coefficients) and 29 
+24 (effects of tilt on turbine power and thrust coefficients) and 29
 (comparison between a fixed-bottom and floating wind farm).
 
 ### 26_empirical_gauss_velocity_deficit_parameters.py
@@ -144,7 +144,7 @@ wind farm with the same layout. Includes:
 - AEP calculations based on an example wind rose.
 
 For further examples on floating wind turbines, see also examples
-24 (effects of tilt on turbine power and thrust coefficients) and 25 
+24 (effects of tilt on turbine power and thrust coefficients) and 25
 (vertical wake deflection by a forced tilt angle).
 
 ## Optimization

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -97,7 +97,11 @@ of a turbine layout within FLORIS.
 
 ### 24_floating_turbine_models.py
 Demonstrates the definition of a floating turbine and how to enable the effects of tilt
-on Cp and Ct.
+on Cp and Ct. 
+
+For further examples on floating wind turbines, see also examples
+25 (vertical wake deflection by a forced tilt angle) and 29 (comparison between 
+a fixed-bottom and floating wind farm).
 
 ### 25_tilt_driven_vertical_wake_deflection.py
 
@@ -106,6 +110,10 @@ with the Empirical Gauss model. Note that only the Empirical Gauss model impleme
 vertical deflections at this time. Also be aware that this example uses a potentially
 unrealistic tilt angle, 15 degrees, to highlight the wake deflection. Moreover, the magnitude
 of vertical deflections due to tilt has not been validated.
+
+For further examples on floating wind turbines, see also examples
+24 (effects of tilt on turbine power and thrust coefficients) and 29 
+(comparison between a fixed-bottom and floating wind farm).
 
 ### 26_empirical_gauss_velocity_deficit_parameters.py
 
@@ -134,6 +142,10 @@ wind farm with the same layout. Includes:
 - Turbine-by-turbine power comparison for a single wind speed and direction
 - Flow visualizations for a single wind speed and direction
 - AEP calculations based on an example wind rose.
+
+For further examples on floating wind turbines, see also examples
+24 (effects of tilt on turbine power and thrust coefficients) and 25 
+(vertical wake deflection by a forced tilt angle).
 
 ## Optimization
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -97,7 +97,7 @@ of a turbine layout within FLORIS.
 
 ### 24_floating_turbine_models.py
 Demonstrates the definition of a floating turbine and how to enable the effects of tilt
-on Cp and Ct. 
+on Cp and Ct.
 
 For further examples on floating wind turbines, see also examples
 25 (vertical wake deflection by a forced tilt angle) and 29 (comparison between

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -127,6 +127,14 @@ mast across all wind directions (at a fixed free stream wind speed).
 Try different values for met_mast_option to vary the location of the met mast within
 the two-turbine farm.
 
+### 29_floating_vs_fixedbottom_farm.py
+
+Compares a fixed-bottom wind farm (with a gridded layout) to a floating 
+wind farm with the same layout. Includes:
+- Turbine-by-turbine power comparison for a single wind speed and direction
+- Flow visualizations for a single wind speed and direction
+- AEP calculations based on an example wind rose.
+
 ## Optimization
 
 These examples demonstrate use of the optimization routines

--- a/examples/25_tilt_driven_vertical_wake_deflection.py
+++ b/examples/25_tilt_driven_vertical_wake_deflection.py
@@ -41,7 +41,7 @@ num_in_row = 5
 # Figure settings
 x_bounds = [-500, 3000]
 y_bounds = [-250, 250]
-z_bounds = [0, 500]
+z_bounds = [0.001, 500]
 
 cross_plane_locations = [10, 1200, 2500]
 horizontal_plane_location=90.0

--- a/examples/26_empirical_gauss_velocity_deficit_parameters.py
+++ b/examples/26_empirical_gauss_velocity_deficit_parameters.py
@@ -42,7 +42,7 @@ def generate_wake_visualization(fi: FlorisInterface, title=None):
     # Using the FlorisInterface functions, get 2D slices.
     x_bounds = [-500, 3000]
     y_bounds = [-250, 250]
-    z_bounds = [0, 500]
+    z_bounds = [0.001, 500]
     cross_plane_locations = [10, 1200, 2500]
     horizontal_plane_location = 90.0
     streamwise_plane_location = 0.0

--- a/examples/27_empirical_gauss_deflection_parameters.py
+++ b/examples/27_empirical_gauss_deflection_parameters.py
@@ -44,7 +44,7 @@ def generate_wake_visualization(fi, title=None):
     # Using the FlorisInterface functions, get 2D slices.
     x_bounds = [-500, 3000]
     y_bounds = [-250, 250]
-    z_bounds = [0, 500]
+    z_bounds = [0.001, 500]
     cross_plane_locations = [10, 1200, 2500]
     horizontal_plane_location = 90.0
     streamwise_plane_location = 0.0
@@ -152,8 +152,6 @@ if show_flow_cuts:
 
 # Increase the maximum deflection attained
 fi_dict_mod = copy.deepcopy(fi_dict)
-
-print(fi_dict_mod['wake']['wake_deflection_parameters']['empirical_gauss'])
 
 fi_dict_mod['wake']['wake_deflection_parameters']['empirical_gauss']\
     ['horizontal_deflection_gain_D'] = 5.0

--- a/examples/29_floating_vs_fixedbottom_farm.py
+++ b/examples/29_floating_vs_fixedbottom_farm.py
@@ -17,7 +17,9 @@ import numpy as np
 import pandas as pd
 from scipy.interpolate import NearestNDInterpolator
 
+import floris.tools.visualization as wakeviz
 from floris.tools import FlorisInterface
+
 
 """
 This example demonstrates the impact of floating on turbine power and thurst
@@ -80,10 +82,40 @@ ax.set_ylabel("y coordinate [m]")
 ax.set_title("Power increase due to floating for each turbine.")
 plt.colorbar(sc, label="Increase (kW)")
 
-print("Power increase from floating over farm: {0:.2f} kW".\
+print("Power increase from floating over farm (10m/s, 270deg winds): {0:.2f} kW".\
       format(power_difference.sum()/1000))
 
-# Visualize flows
+# Visualize flows (see also 02_visualizations.py)
+horizontal_planes = []
+y_planes = []
+for fi in [fi_fixed, fi_floating]:
+    horizontal_planes.append(
+        fi.calculate_horizontal_plane(
+            x_resolution=200,
+            y_resolution=100,
+            height=90.0,
+        )
+    )
+    y_planes.append(
+        fi.calculate_y_plane(
+            x_resolution=200,
+            z_resolution=100,
+            crossstream_dist=0.0,
+        )
+    )
+
+# Create the plots
+fig, ax_list = plt.subplots(2, 1, figsize=(10, 8))
+ax_list = ax_list.flatten()
+wakeviz.visualize_cut_plane(horizontal_planes[0], ax=ax_list[0], title="Horizontal")
+wakeviz.visualize_cut_plane(y_planes[0], ax=ax_list[1], title="Streamwise profile")
+fig.suptitle("Fixed-bottom farm")
+
+fig, ax_list = plt.subplots(2, 1, figsize=(10, 8))
+ax_list = ax_list.flatten()
+wakeviz.visualize_cut_plane(horizontal_planes[1], ax=ax_list[0], title="Horizontal")
+wakeviz.visualize_cut_plane(y_planes[1], ax=ax_list[1], title="Streamwise profile")
+fig.suptitle("Floating farm")
 
 # Compute AEP (see 07_calc_aep_from_rose.py for details)
 df_wr = pd.read_csv("inputs/wind_rose.csv")

--- a/examples/XX_floating_vs_fixedbottom_farm.py
+++ b/examples/XX_floating_vs_fixedbottom_farm.py
@@ -1,0 +1,115 @@
+# Copyright 2021 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# See https://floris.readthedocs.io for documentation
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.interpolate import NearestNDInterpolator
+
+from floris.tools import FlorisInterface
+
+"""
+This example demonstrates the impact of floating on turbine power and thurst
+and wake behavior. A floating turbine in FLORIS is defined by including a
+`floating_tilt_table` in the turbine input yaml which sets the steady tilt
+angle of the turbine based on wind speed.  This tilt angle is computed for each
+turbine based on effective velocity.  This tilt angle is then passed on
+to the respective wake model.
+
+The value of the parameter ref_tilt_cp_ct is the value of tilt at which the
+ct/cp curves have been defined.
+
+With floating_correct_cp_ct_for_tilt True, the difference between the current
+tilt as interpolated from the floating tilt table is used to scale the turbine
+power and thrust.
+
+In the example below, a 20-turbine, gridded wind farm is simulated using
+the Empirical Gaussian wake model to show the effects of floating turbines on
+both turbine power and wake development.
+
+fi_fixed: Fixed bottom turbine (no tilt variation with wind speed)
+fi_floating: Floating turbine (tilt varies with wind speed)
+"""
+
+# Declare the Floris Interface for fixed bottom, provide layout
+fi_fixed = FlorisInterface("inputs_floating/emgauss_fixed.yaml")
+fi_floating = FlorisInterface("inputs_floating/emgauss_floating.yaml")
+x, y = np.meshgrid(np.linspace(0, 4*630., 5), np.linspace(0, 3*630., 4))
+for fi in [fi_fixed, fi_floating]:
+    fi.reinitialize(layout_x=x.flatten(), layout_y=y.flatten())
+
+# Compute a single wind speed and direction, power and wakes
+for fi in [fi_fixed, fi_floating]:
+    fi.reinitialize(
+        layout_x=x.flatten(),
+        layout_y=y.flatten(),
+        wind_speeds=[10],
+        wind_directions=[270]
+    )
+    fi.calculate_wake()
+
+powers_fixed = fi_fixed.get_turbine_powers()
+powers_floating = fi_floating.get_turbine_powers()
+power_difference = powers_floating - powers_fixed
+
+# Show the power differences
+fig, ax = plt.subplots()
+ax.set_aspect('equal', adjustable='box')
+sc = ax.scatter(
+    x.flatten(),
+    y.flatten(),
+    c=power_difference.flatten()/1000,
+    cmap="PuOr",
+    vmin=-100,
+    vmax=100,
+    s=200,
+)
+ax.set_xlabel("x coordinate [m]")
+ax.set_ylabel("y coordinate [m]")
+ax.set_title("Power increase due to floating for each turbine.")
+plt.colorbar(sc, label="Increase (kW)")
+
+print("Power increase from floating over farm: {0:.2f} kW".\
+      format(power_difference.sum()/1000))
+
+# Visualize flows
+
+# Compute AEP (see 07_calc_aep_from_rose.py for details)
+df_wr = pd.read_csv("inputs/wind_rose.csv")
+wd_array = np.array(df_wr["wd"].unique(), dtype=float)
+ws_array = np.array(df_wr["ws"].unique(), dtype=float)
+
+wd_grid, ws_grid = np.meshgrid(wd_array, ws_array, indexing="ij")
+freq_interp = NearestNDInterpolator(df_wr[["wd", "ws"]], df_wr["freq_val"])
+freq = freq_interp(wd_grid, ws_grid)
+freq = freq / np.sum(freq)
+
+for fi in [fi_fixed, fi_floating]:
+    fi.reinitialize(
+        wind_directions=wd_array,
+        wind_speeds=ws_array,
+    )
+
+# Compute the AEP
+aep_fixed = fi_fixed.get_farm_AEP(freq=freq)
+aep_floating = fi_floating.get_farm_AEP(freq=freq)
+print("Farm AEP (fixed bottom): {:.3f} GWh".format(aep_fixed / 1.0e9))
+print("Farm AEP (floating): {:.3f} GWh".format(aep_floating / 1.0e9))
+print("Floating AEP increase: {0:.3f} GWh ({1:.2f}%)".\
+      format((aep_floating - aep_fixed) / 1.0e9,
+             (aep_floating - aep_fixed)/aep_fixed*100
+             )
+)
+
+plt.show()

--- a/examples/inputs_floating/emgauss_fixed.yaml
+++ b/examples/inputs_floating/emgauss_fixed.yaml
@@ -1,0 +1,105 @@
+
+name: Emperical Gaussian
+description: Example of single fixed-bottom turbine
+floris_version: v3.x
+
+logging:
+  console:
+    enable: true
+    level: WARNING
+  file:
+    enable: false
+    level: WARNING
+
+solver:
+  type: turbine_grid
+  turbine_grid_points: 3
+
+farm:
+  layout_x:
+  - 0.0
+  - 630.0
+  - 1260.0
+  layout_y:
+  - 0.0
+  - 0.0
+  - 0.0
+  turbine_type:
+  - !include turbine_files/nrel_5MW_fixed.yaml
+
+flow_field:
+  air_density: 1.225
+  reference_wind_height: -1 # -1 is code for use the hub height
+  turbulence_intensity: 0.06
+  wind_directions:
+  - 270.0
+  wind_shear: 0.12
+  wind_speeds:
+  - 8.0
+  wind_veer: 0.0
+
+wake:
+  model_strings:
+    combination_model: sosfs
+    deflection_model: empirical_gauss
+    turbulence_model: wake_induced_mixing
+    velocity_model: empirical_gauss
+
+  enable_secondary_steering: false
+  enable_yaw_added_recovery: true
+  enable_transverse_velocities: false
+
+  wake_deflection_parameters:
+    gauss:
+      ad: 0.0
+      alpha: 0.58
+      bd: 0.0
+      beta: 0.077
+      dm: 1.0
+      ka: 0.38
+      kb: 0.004
+    jimenez:
+      ad: 0.0
+      bd: 0.0
+      kd: 0.05
+    empirical_gauss:
+      horizontal_deflection_gain_D: 3.0
+      vertical_deflection_gain_D: -1
+      deflection_rate: 15
+      mixing_gain_deflection: 0.0
+      yaw_added_mixing_gain: 0.0
+
+  wake_velocity_parameters:
+    cc:
+      a_s: 0.179367259
+      b_s: 0.0118889215
+      c_s1: 0.0563691592
+      c_s2: 0.13290157
+      a_f: 3.11
+      b_f: -0.68
+      c_f: 2.41
+      alpha_mod: 1.0
+    gauss:
+      alpha: 0.58
+      beta: 0.077
+      ka: 0.38
+      kb: 0.004
+    jensen:
+      we: 0.05
+    empirical_gauss:
+      wake_expansion_rates:
+      - 0.01
+      - 0.005
+      breakpoints_D:
+      - 10
+      sigma_0_D: 0.28
+      smoothing_length_D: 2.0
+      mixing_gain_velocity: 2.0
+  wake_turbulence_parameters:
+    crespo_hernandez:
+      initial: 0.1
+      constant: 0.5
+      ai: 0.8
+      downstream: -0.32
+    wake_induced_mixing:
+      atmospheric_ti_gain: 0.0

--- a/examples/inputs_floating/emgauss_floating.yaml
+++ b/examples/inputs_floating/emgauss_floating.yaml
@@ -1,0 +1,105 @@
+
+name: Emperical Gaussian
+description: Example of single floating turbine
+floris_version: v3.x
+
+logging:
+  console:
+    enable: true
+    level: WARNING
+  file:
+    enable: false
+    level: WARNING
+
+solver:
+  type: turbine_grid
+  turbine_grid_points: 3
+
+farm:
+  layout_x:
+  - 0.0
+  - 630.0
+  - 1260.0
+  layout_y:
+  - 0.0
+  - 0.0
+  - 0.0
+  turbine_type:
+  - !include turbine_files/nrel_5MW_floating.yaml
+
+flow_field:
+  air_density: 1.225
+  reference_wind_height: -1 # -1 is code for use the hub height
+  turbulence_intensity: 0.06
+  wind_directions:
+  - 270.0
+  wind_shear: 0.12
+  wind_speeds:
+  - 8.0
+  wind_veer: 0.0
+
+wake:
+  model_strings:
+    combination_model: sosfs
+    deflection_model: empirical_gauss
+    turbulence_model: wake_induced_mixing
+    velocity_model: empirical_gauss
+
+  enable_secondary_steering: false
+  enable_yaw_added_recovery: true
+  enable_transverse_velocities: false
+
+  wake_deflection_parameters:
+    gauss:
+      ad: 0.0
+      alpha: 0.58
+      bd: 0.0
+      beta: 0.077
+      dm: 1.0
+      ka: 0.38
+      kb: 0.004
+    jimenez:
+      ad: 0.0
+      bd: 0.0
+      kd: 0.05
+    empirical_gauss:
+      horizontal_deflection_gain_D: 3.0
+      vertical_deflection_gain_D: -1
+      deflection_rate: 15
+      mixing_gain_deflection: 0.0
+      yaw_added_mixing_gain: 0.0
+
+  wake_velocity_parameters:
+    cc:
+      a_s: 0.179367259
+      b_s: 0.0118889215
+      c_s1: 0.0563691592
+      c_s2: 0.13290157
+      a_f: 3.11
+      b_f: -0.68
+      c_f: 2.41
+      alpha_mod: 1.0
+    gauss:
+      alpha: 0.58
+      beta: 0.077
+      ka: 0.38
+      kb: 0.004
+    jensen:
+      we: 0.05
+    empirical_gauss:
+      wake_expansion_rates:
+      - 0.01
+      - 0.005
+      breakpoints_D:
+      - 10
+      sigma_0_D: 0.28
+      smoothing_length_D: 2.0
+      mixing_gain_velocity: 2.0
+  wake_turbulence_parameters:
+    crespo_hernandez:
+      initial: 0.1
+      constant: 0.5
+      ai: 0.8
+      downstream: -0.32
+    wake_induced_mixing:
+      atmospheric_ti_gain: 0.0


### PR DESCRIPTION
Ready for review.

Address #670 (request for more realistic example of floating wind farm, including turbine powers and visualization).

Note: uses "default" EmGauss parameters, which are subject to change and should be tuned to match observations from a particular farm.

TODO:
- [X] Create example, including necessary input files
- [X] Check tests, ruff, isort pass
- [x] Update examples index in documentation

