### PR TITLE
Documentation fixes

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -216,7 +216,7 @@ compiling, a file should be located at ``docs/_build/html/index.html``.
 This file can be opened in any browser.
 
 ```bash
-pip install -e .["docs"]
+pip install -e ".[docs]"
 jupyter-book build docs/
 
 # Lots of output to the terminal here...

--- a/docs/empirical_gauss_model.md
+++ b/docs/empirical_gauss_model.md
@@ -10,7 +10,9 @@ have been reorganized to provide simpler tuning and data fitting.
 
 The velocity deficit at a point $(x, y, z)$ in the wake follows a Gaussian
 curve, i.e.,
+
 $$ \frac{u}{U_\infty} = 1 - Ce^{-\frac{(y-\delta_y)^2}{2\sigma_y^2} -\frac{(z-z_h-\delta_z)^2}{2\sigma_z^2}} $$
+
 where the $(x, y, z)$ origin is at the turbine location (at ground level).
 The terms $C$, $\sigma_y$, $\sigma_z$, $\delta_y$, and $\delta_z$ all depend
 on the downstream location $x$.


### PR DESCRIPTION
# Fix two mistakes in the docs
This pull request fixes two mistakes in the documentation. One is an incorrect command to install dependencies and the other is an incorrectly formatted markdown file that prevented rendering a latex equation.