### PR TITLE
Feature: Add wind speed dependency in heterogeneous inflows

### DIFF
--- a/examples/16b_heterogeneity_multiple_ws_wd.py
+++ b/examples/16b_heterogeneity_multiple_ws_wd.py
@@ -29,7 +29,7 @@ when multiple wind speeds and direction are considered.
 # Define the speed ups of the heterogeneous inflow, and their locations.
 # For the 2-dimensional case, this requires x and y locations.
 # The speed ups are multipliers of the ambient wind speed.
-speed_ups = [[2.0, 1.0, 2.0, 1.0]]
+speed_ups = [[[2.0, 1.0, 2.0, 1.0]]]  # Has the shape (n_wind_directions, n_wind_speeds, n_points)
 x_locs = [-300.0, -300.0, 2600.0, 2600.0]
 y_locs = [ -300.0, 300.0, -300.0, 300.0]
 
@@ -58,19 +58,20 @@ print(f'T0: {turbine_powers[0]:.1f} kW')
 print(f'T1: {turbine_powers[1]:.1f} kW')
 print()
 
-# Since het maps are assigned for each wind direciton, it's allowable to change
-# the number of wind speeds
-fi.reinitialize(wind_speeds=[4, 8])
-fi.calculate_wake()
-turbine_powers = np.round(fi.get_turbine_powers() / 1000.)
-print('With wind speeds now set to 4 and 8 m/s')
-print(f'T0: {turbine_powers[:, :, 0].flatten()} kW')
-print(f'T1: {turbine_powers[:, :, 1].flatten()} kW')
-print()
-
 # To change the number of wind directions however it is necessary to make a matching
 # change to the dimensions of the het map
-speed_multipliers = [[2.0, 1.0, 2.0, 1.0], [2.0, 1.0, 2.0, 1.0]] # Expand to two wind directions
+speed_multipliers = [
+    [
+        [2.0, 1.0, 2.0, 1.0],  # Wind direction 270, Wind speed 7.0, four locations (x,y)
+        [2.0, 1.0, 2.0, 1.0],  # Wind direction 270, Wind speed 8.0, four locations (x,y)
+        [2.0, 1.0, 2.0, 1.0],  # Wind direction 270, Wind speed 9.0, four locations (x,y)
+    ],
+    [
+        [2.0, 1.0, 2.0, 1.0],  # Wind direction 275, Wind speed 7.0, four locations (x,y)
+        [2.0, 1.0, 2.0, 1.0],  # Wind direction 275, Wind speed 8.0, four locations (x,y)
+        [2.0, 1.0, 2.0, 1.0],  # Wind direction 275, Wind speed 9.0, four locations (x,y)
+    ],
+]
 heterogenous_inflow_config = {
     'speed_multipliers': speed_multipliers,
     'x': x_locs,
@@ -78,7 +79,7 @@ heterogenous_inflow_config = {
 }
 fi.reinitialize(
     wind_directions=[270.0, 275.0],
-    wind_speeds=[8.0],
+    wind_speeds=[7.0, 8.0, 9.0],
     heterogenous_inflow_config=heterogenous_inflow_config
 )
 fi.calculate_wake()

--- a/examples/inputs/gch_heterogeneous_inflow.yaml
+++ b/examples/inputs/gch_heterogeneous_inflow.yaml
@@ -29,10 +29,10 @@ flow_field:
   air_density: 1.225
   heterogenous_inflow_config:
     speed_multipliers:
-      - - 2.0
-        - 1.0
-        - 2.0
-        - 1.0
+      - - - 2.0
+          - 1.0
+          - 2.0
+          - 1.0
     x:
       - -300.
       - -300.

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -254,7 +254,8 @@ class FlowField(BaseClass):
             # adds an extra dimension
             for wdii in range(n_wind_directions):
                 for wsii in range(n_wind_speeds):
-                    speed_ups[wdii, wsii] = het_map[wdii][wsii](x[wdii, wsii], y[wdii, wsii], z[wdii, wsii])
+                    speed_ups[wdii, wsii] = \
+                        het_map[wdii][wsii](x[wdii, wsii], y[wdii, wsii], z[wdii, wsii])
 
         else:
             # Calculate the 2-dimensional speed ups; squeeze is needed as the generator

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -108,6 +108,11 @@ class FlowField(BaseClass):
                 "The het_map's wind direction dimension not equal to number of wind directions."
             )
 
+        if self.n_wind_speeds!= np.array(value).shape[1]:
+            raise ValueError(
+                "The het_map's wind speed dimension not equal to number of wind speeds."
+            )
+
 
     def __attrs_post_init__(self) -> None:
         if self.heterogenous_inflow_config is not None:


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Expand heterogeneous inflows to allow different speed-ups per ambient wind speed
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This feature allows users to specify a different speed-up factor for each ambient wind speed in the heterogeneous inflow functionality.

## Related issue
There is no dedicated issue, but the problem is nicely highlighted in this post: https://github.com/NREL/floris/pull/578#issuecomment-1537948257.

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
-->
FLORIS core simulation.

## Additional supporting information
<!--
Add any other context about the problem here.
-->
This change is API breaking, because it forces the heterogeneous inflow definition to match the shape `(n_wind_directions, n_wind_speeds, n_hetmap_coordinates)`.

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->
Here is a piece of code where I compare nominal solutions at 10.0 and 9.0 m/s with the heterogeneous inflow solutions where I use a freestream inflow of 5.0 and 6.0 m/s, respectively, with speed-up factors of 2.0 and 1.5. These two solutions in theory should be equal.

```
import numpy as np

from floris.tools import FlorisInterface
from floris.tools.visualization import visualize_cut_plane

# Initialize FLORIS with the given input file via FlorisInterface.
# Note the heterogeneous inflow is defined in the input file.
fi = FlorisInterface("inputs/gch_heterogeneous_inflow.yaml")

# Calculate nominal solutions without speed-ups
heterogenous_inflow_config = {
    'speed_multipliers': [[[1.0, 1.0, 1.0, 1.0]]],
    'x': [-5000.0, -5000.0, 5000.0, 5000.0],
    'y': [ -5000.0, 5000.0, -5000.0, 5000.0],
}
fi.reinitialize(wind_shear=0.0, layout_x=[-299, 299], layout_y=[0., 0.], heterogenous_inflow_config=heterogenous_inflow_config)

fi.reinitialize(wind_speeds=[10.0], wind_directions=[270.],)
fi.calculate_wake()
turbine_powers_10ms_270deg = fi.get_turbine_powers().flatten() / 1000.

fi.reinitialize(wind_speeds=[9.0], wind_directions=[275.],)
fi.calculate_wake()
turbine_powers_9ms_275deg = fi.get_turbine_powers().flatten() / 1000.

# Now calculate solutions with heterogeneous inflows
speed_multipliers = [
    [
        [2.0, 2.0, 2.0, 2.0],  # Wind direction 270, Wind speed 5.0, four locations (x,y)
        [1.5, 1.5, 1.5, 1.5],  # Wind direction 270, Wind speed 6.0, four locations (x,y)
    ],
    [
        [2.0, 2.0, 2.0, 2.0],  # Wind direction 275, Wind speed 5.0, four locations (x,y)
        [1.5, 1.5, 1.5, 1.5],  # Wind direction 275, Wind speed 6.0, four locations (x,y)
    ],
]
heterogenous_inflow_config["speed_multipliers"]= speed_multipliers
fi.reinitialize(
    wind_directions=[270.0, 275.0],
    wind_speeds=[5.0, 6.0],
    heterogenous_inflow_config=heterogenous_inflow_config
)
fi.calculate_wake()
turbine_powers = fi.get_turbine_powers() / 1000.
turbine_powers_5ms_270deg_hetmultiplier2 = turbine_powers[0, 0, :].flatten()
turbine_powers_6ms_275deg_hetmultiplier15 = turbine_powers[1, 1, :].flatten()

# Now cross-compare
print("Evaluation with 270 deg, 10 m/s:")
print(f"  Nominal: {turbine_powers_10ms_270deg}")
print(f"  5 m/s with heterogeneous multiplier of 2.0: {turbine_powers_5ms_270deg_hetmultiplier2}")

print("Evaluation with 275 deg, 9.0 m/s:")
print(f"  Nominal: {turbine_powers_9ms_275deg}")
print(f"  6.0 m/s with heterogeneous multiplier of 1.5: {turbine_powers_6ms_275deg_hetmultiplier15}")
```

And they are equal:
```
Evaluation with 270 deg, 10 m/s:
  Nominal: [3329.10062735  368.38870676]
  5 m/s with heterogeneous multiplier of 2.0: [3329.10062735  368.38870676]
Evaluation with 275 deg, 9.0 m/s:
  Nominal: [2430.57780918  986.0126126 ]
  6.0 m/s with heterogeneous multiplier of 1.5: [2430.57780918  986.0126126 ]
```

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
