### PR TITLE
Add capability to sample and plot velocity deficit profiles

### DIFF
--- a/examples/29_plot_velocity_deficit_profiles.py
+++ b/examples/29_plot_velocity_deficit_profiles.py
@@ -29,54 +29,34 @@ fi = FlorisInterface("inputs/gch.yaml")
 fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
 
 downstream_dists = D * np.array([3, 5, 7])
+homogeneous_wind_speed = 8.0
 
-velocity_deficit_profiles = fi.sample_velocity_deficit_profiles(
-    direction = 'y',
+velocity_deficit_profiles_y = fi.sample_velocity_deficit_profiles(
+    direction='y',
     downstream_dists=downstream_dists,
-    resolution=10,
-    homogeneous_wind_speed=7.0
+    homogeneous_wind_speed=homogeneous_wind_speed
 )
-
-#for df in velocity_deficit_profiles:
-#    print(df)
+# Same range as y-profiles for an easier comparison
+profile_range_z = D * np.array([0, 4]) - 90.0
+velocity_deficit_profiles_z = fi.sample_velocity_deficit_profiles(
+    direction='z',
+    downstream_dists=downstream_dists,
+    profile_range=profile_range_z,
+    homogeneous_wind_speed=homogeneous_wind_speed
+)
 
 profiles_fig = VelocityProfilesFigure(
     downstream_dists_D=downstream_dists / D,
     layout=['y', 'z']
 )
-
-downstream_dists = D * np.array([1, 3, 5, 7, 9])
-profiles_fig = VelocityProfilesFigure(
-    downstream_dists_D=downstream_dists / D,
-    layout=['z']
+profiles_fig.add_profiles(
+    velocity_deficit_profiles_y + velocity_deficit_profiles_z,
+    color='k'
 )
-
-
-downstream_dists = D * np.array([3])
-profiles_fig = VelocityProfilesFigure(
-    downstream_dists_D=downstream_dists / D,
-    layout=['y']
-)
+margin = 0.05
+profiles_fig.set_xlim([0.0 - margin, 0.6 + margin])
+profiles_fig.add_ref_lines_y_D([-0.5, 0.5])
+ref_lines_z_D = 90.0 / D + np.array([-0.5, 0.5])
+profiles_fig.add_ref_lines_z_D(ref_lines_z_D)
 
 plt.show()
-
-
-#velocity_deficit_profiles = fi.sample_velocity_deficit_profiles(
-#    direction = 'z',
-
-#    resolution=10,
-#    homogeneous_wind_speed=7.0
-#)
-#
-#for df in velocity_deficit_profiles:
-#    print(df)
-
-#horizontal_plane = fi.calculate_horizontal_plane(
-#    x_resolution=200,
-#    y_resolution=100,
-#    height=90.0,
-#)
-#
-#wakeviz.visualize_cut_plane(horizontal_plane, title="Horizontal plane")
-#
-#wakeviz.show_plots()

--- a/examples/29_plot_velocity_deficit_profiles.py
+++ b/examples/29_plot_velocity_deficit_profiles.py
@@ -1,0 +1,40 @@
+# Copyright 2021 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# See https://floris.readthedocs.io for documentation
+
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import floris.tools.visualization as wakeviz
+from floris.tools import FlorisInterface
+
+
+"""
+docstr
+"""
+
+fi = FlorisInterface("inputs/gch.yaml")
+fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
+
+fi.sample_velocity_deficit_profiles(direction = 'y', resolution=10, homogeneous_wind_speed=7.0)
+
+#horizontal_plane = fi.calculate_horizontal_plane(
+#    x_resolution=200,
+#    y_resolution=100,
+#    height=90.0,
+#)
+#
+#wakeviz.visualize_cut_plane(horizontal_plane, title="Horizontal plane")
+#
+#wakeviz.show_plots()

--- a/examples/29_plot_velocity_deficit_profiles.py
+++ b/examples/29_plot_velocity_deficit_profiles.py
@@ -27,7 +27,15 @@ docstr
 fi = FlorisInterface("inputs/gch.yaml")
 fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
 
-fi.sample_velocity_deficit_profiles(direction = 'y', resolution=10, homogeneous_wind_speed=7.0)
+velocity_deficit_profiles = fi.sample_velocity_deficit_profiles(
+    direction = 'y',
+    resolution=10,
+    homogeneous_wind_speed=7.0
+)
+
+print(velocity_deficit_profiles[0])
+print(velocity_deficit_profiles[-1])
+
 
 #horizontal_plane = fi.calculate_horizontal_plane(
 #    x_resolution=200,

--- a/examples/29_plot_velocity_deficit_profiles.py
+++ b/examples/29_plot_velocity_deficit_profiles.py
@@ -18,32 +18,51 @@ import numpy as np
 
 import floris.tools.visualization as wakeviz
 from floris.tools import FlorisInterface
+from floris.tools.visualization import VelocityProfilesFigure
 
 
 """
 docstr
 """
-
+D = 126.0
 fi = FlorisInterface("inputs/gch.yaml")
 fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
 
+downstream_dists = D * np.array([3, 5, 7])
+
 velocity_deficit_profiles = fi.sample_velocity_deficit_profiles(
     direction = 'y',
+    downstream_dists=downstream_dists,
     resolution=10,
     homogeneous_wind_speed=7.0
 )
 
-for df in velocity_deficit_profiles:
-    print(df)
+#for df in velocity_deficit_profiles:
+#    print(df)
 
-velocity_deficit_profiles = fi.sample_velocity_deficit_profiles(
-    direction = 'z',
-    resolution=10,
-    homogeneous_wind_speed=7.0
+profiles_fig = VelocityProfilesFigure(
+    downstream_dists_D=downstream_dists / D,
+    layout=['y', 'z']
 )
 
-for df in velocity_deficit_profiles:
-    print(df)
+downstream_dists = D * np.array([1, 3, 5, 7, 9])
+profiles_fig = VelocityProfilesFigure(
+    downstream_dists_D=downstream_dists / D,
+    layout=['z']
+)
+
+plt.show()
+
+
+#velocity_deficit_profiles = fi.sample_velocity_deficit_profiles(
+#    direction = 'z',
+
+#    resolution=10,
+#    homogeneous_wind_speed=7.0
+#)
+#
+#for df in velocity_deficit_profiles:
+#    print(df)
 
 #horizontal_plane = fi.calculate_horizontal_plane(
 #    x_resolution=200,

--- a/examples/29_plot_velocity_deficit_profiles.py
+++ b/examples/29_plot_velocity_deficit_profiles.py
@@ -51,6 +51,13 @@ profiles_fig = VelocityProfilesFigure(
     layout=['z']
 )
 
+
+downstream_dists = D * np.array([3])
+profiles_fig = VelocityProfilesFigure(
+    downstream_dists_D=downstream_dists / D,
+    layout=['y']
+)
+
 plt.show()
 
 

--- a/examples/29_plot_velocity_deficit_profiles.py
+++ b/examples/29_plot_velocity_deficit_profiles.py
@@ -22,7 +22,14 @@ from floris.tools.visualization import VelocityProfilesFigure
 
 
 """
-docstr
+The first part of this example illustrates how to plot velocity deficit profiles at
+several location downstream of a turbine. Here we use the following definition:
+    velocity_deficit = (homogeneous_wind_speed - u) / homogeneous_wind_speed
+        , where u is the wake velocity obtained when the incoming wind speed is the
+        same at all heights and equal to `homogeneous_wind_speed`.
+The second part of the example shows a special case of how the profiles are affected
+by a change in wind direction as well as a change in turbine location and sampling
+starting point.
 """
 
 def get_profiles(direction, resolution=100):
@@ -34,7 +41,7 @@ def get_profiles(direction, resolution=100):
     )
 
 if __name__ == '__main__':
-    D = 126.0
+    D = 126.0 # Turbine diameter
     hub_height = 90.0
     fi = FlorisInterface("inputs/gch.yaml")
     fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
@@ -42,20 +49,27 @@ if __name__ == '__main__':
     downstream_dists = D * np.array([3, 5, 7])
     homogeneous_wind_speed = 8.0
 
-    # Velocity deficit profiles can be obtained in either the cross-stream (y)
-    # or the vertical direction (z). The default profile_range is [-2 * D, 2 * D] with
-    # the default origin being (x, y, z) = (0.0, 0.0, reference_wind_height).
-    # TODO: Explain difference between starting point and coordinates seen in fig
+    # Below, `get_profiles('y')` returns three velocity deficit profiles sampled along
+    # three lines that are all parallel to the y-axis (cross-stream direction). The
+    # streamwise location of each line in given in `downstream_dists`.
+    # Similarly, `get_profiles('z')` samples profiles in the vertical direction (z) at the
+    # same streamwise locations.
     profiles = get_profiles('y') + get_profiles('z')
 
+    # Initialize a VelocityProfilesFigure. The workflow is similar to a matplotlib Figure:
+    # Initialize it, plot data, and then customize it further if needed.
+    # The provided value of `layout` puts y-profiles on the top row of the figure and
+    # z-profiles on the bottom row.
     profiles_fig = VelocityProfilesFigure(
         downstream_dists_D=downstream_dists / D,
         layout=['y', 'z'],
     )
+    # Add profiles to the figure. This method automatically determines the direction and
+    # streamwise location of each profile from the profile coordinates.
     profiles_fig.add_profiles(profiles, color='k')
 
     # Change velocity model to jensen, get the velocity deficit profiles,
-    # and add them to the figure
+    # and add them to the figure.
     floris_dict = fi.floris.as_dict()
     floris_dict['wake']['model_strings']['velocity_model'] = 'jensen'
     fi = FlorisInterface(floris_dict)
@@ -71,40 +85,71 @@ if __name__ == '__main__':
     profiles_fig.axs[0,0].legend(['gauss', 'jensen'], fontsize=11)
     profiles_fig.fig.suptitle(
         'Velocity decifit profiles from different velocity models',
-        fontsize=14
+        fontsize=14,
     )
 
-    # Show that profiles are independent of the wind direction for a single turbine.
-    # This is because x is always in the streamwise direction.
-    # Also show that the coordinates x / D, y / D and z / D returned by
-    # sample_velocity_deficit_profiles are relative to the starting point mentioned above.
-    fi = FlorisInterface("inputs/gch.yaml")
-    fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
+    # Second part of example:
+    # Case 1: Show that, if we have a single turbine, the profiles are independent of
+    # the wind direction. This is because x is defined to be in the streamwise direction
+    # in sample_velocity_deficit_profiles and VelocityProfilesFigure.
+    # Case 2: Show that the coordinates x/D, y/D and z/D returned by
+    # sample_velocity_deficit_profiles are relative to the sampling starting point.
     downstream_dists = D * np.array([3])
-    profiles = get_profiles('y', resolution=400)
-    profiles_fig = VelocityProfilesFigure(
-        downstream_dists_D=downstream_dists / D,
-        layout=['y']
-    )
-    profiles_fig.add_profiles(profiles, color='k')
+    for case in [1, 2]:
+        # Reference
+        fi = FlorisInterface("inputs/gch.yaml")
+        fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
+        profiles = get_profiles('y', resolution=400)
+        profiles_fig = VelocityProfilesFigure(
+            downstream_dists_D=downstream_dists / D,
+            layout=['y'],
+            ax_width=3.5,
+            ax_height=3.5,
+        )
+        profiles_fig.add_profiles(profiles, color='k')
 
-    fi.reinitialize(wind_directions=[315.0], layout_x=[D], layout_y=[D])
-    profiles = fi.sample_velocity_deficit_profiles(
-        direction='y',
-        downstream_dists=downstream_dists,
-        resolution=21,
-        homogeneous_wind_speed=homogeneous_wind_speed,
-        x_inertial_start=D,
-        y_inertial_start=D,
-    )
-    profiles_fig.add_profiles(
-        profiles,
-        linestyle='None',
-        marker='o',
-        color='b',
-        markerfacecolor='None',
-        markeredgewidth=1.3
-    )
-    profiles_fig.axs[0,0].legend(['WD = 270 deg', 'WD = 315 deg,\nand turbine\nmoved'])
+        if case == 1:
+            # Change wind direction compared to reference
+            wind_directions = [315.0]
+            layout_x, layout_y = [0.0], [0.0]
+            # This is the default starting point in sample_velocity_deficit_profiles
+            x_inertial_start, y_inertial_start = 0.0, 0.0
+        elif case == 2:
+            # Change turbine location compared to reference. Then, set the sampling starting
+            # point to the new turbine location using the arguments
+            # `x_inertial_start` and `y_inertial_start`.
+            wind_directions = [270.0]
+            layout_x, layout_y = [D], [D]
+            x_inertial_start, y_inertial_start = D, D
+
+        fi.reinitialize(wind_directions=wind_directions, layout_x=layout_x, layout_y=layout_y)
+        profiles = fi.sample_velocity_deficit_profiles(
+            direction='y',
+            downstream_dists=downstream_dists,
+            resolution=21,
+            homogeneous_wind_speed=homogeneous_wind_speed,
+            x_inertial_start=x_inertial_start,
+            y_inertial_start=y_inertial_start,
+        )
+        profiles_fig.add_profiles(
+            profiles,
+            linestyle='None',
+            marker='o',
+            color='b',
+            markerfacecolor='None',
+            markeredgewidth=1.3,
+        )
+
+        if case == 1:
+            profiles_fig.axs[0,0].legend(['WD = 270 deg', 'WD = 315 deg'])
+        elif case == 2:
+            profiles_fig.fig.suptitle(
+                'Legend (x, y) locations in inertial coordinates.\n'
+                'x/D and y/D relative to sampling start point',
+            )
+            profiles_fig.axs[0,0].legend([
+                'turbine location: (0, 0)\nsampling start point: (0, 0)',
+                'turbine location: (D, D)\nsampling start point: (D, D)',
+            ])
 
     plt.show()

--- a/examples/29_plot_velocity_deficit_profiles.py
+++ b/examples/29_plot_velocity_deficit_profiles.py
@@ -16,7 +16,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-import floris.tools.visualization as wakeviz
 from floris.tools import FlorisInterface
 from floris.tools.visualization import VelocityProfilesFigure
 
@@ -49,9 +48,9 @@ if __name__ == '__main__':
     downstream_dists = D * np.array([3, 5, 7])
     homogeneous_wind_speed = 8.0
 
-    # Below, `get_profiles('y')` returns three velocity deficit profiles sampled along
-    # three lines that are all parallel to the y-axis (cross-stream direction). The
-    # streamwise location of each line in given in `downstream_dists`.
+    # Below, `get_profiles('y')` returns three velocity deficit profiles. These are sampled along
+    # three corresponding lines that are all parallel to the y-axis (cross-stream direction).
+    # The streamwise location of each line is given in `downstream_dists`.
     # Similarly, `get_profiles('z')` samples profiles in the vertical direction (z) at the
     # same streamwise locations.
     profiles = get_profiles('y') + get_profiles('z')
@@ -89,14 +88,16 @@ if __name__ == '__main__':
     )
 
     # Second part of example:
-    # Case 1: Show that, if we have a single turbine, the profiles are independent of
+    # Case 1: Show that, if we have a single turbine, then the profiles are independent of
     # the wind direction. This is because x is defined to be in the streamwise direction
     # in sample_velocity_deficit_profiles and VelocityProfilesFigure.
     # Case 2: Show that the coordinates x/D, y/D and z/D returned by
     # sample_velocity_deficit_profiles are relative to the sampling starting point.
+    # By default, this starting point is at (0.0, 0.0, fi.floris.flow_field.reference_wind_height)
+    # in inertial coordinates.
     downstream_dists = D * np.array([3])
     for case in [1, 2]:
-        # Reference
+        # The first added profile is a reference
         fi = FlorisInterface("inputs/gch.yaml")
         fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
         profiles = get_profiles('y', resolution=400)
@@ -112,7 +113,7 @@ if __name__ == '__main__':
             # Change wind direction compared to reference
             wind_directions = [315.0]
             layout_x, layout_y = [0.0], [0.0]
-            # This is the default starting point in sample_velocity_deficit_profiles
+            # Same as the default starting point but specified for completeness
             x_inertial_start, y_inertial_start = 0.0, 0.0
         elif case == 2:
             # Change turbine location compared to reference. Then, set the sampling starting
@@ -122,6 +123,7 @@ if __name__ == '__main__':
             layout_x, layout_y = [D], [D]
             x_inertial_start, y_inertial_start = D, D
 
+        # Plot a second profile to show that it is equivalent to the reference
         fi.reinitialize(wind_directions=wind_directions, layout_x=layout_x, layout_y=layout_y)
         profiles = fi.sample_velocity_deficit_profiles(
             direction='y',

--- a/examples/29_plot_velocity_deficit_profiles.py
+++ b/examples/29_plot_velocity_deficit_profiles.py
@@ -33,9 +33,17 @@ velocity_deficit_profiles = fi.sample_velocity_deficit_profiles(
     homogeneous_wind_speed=7.0
 )
 
-print(velocity_deficit_profiles[0])
-print(velocity_deficit_profiles[-1])
+for df in velocity_deficit_profiles:
+    print(df)
 
+velocity_deficit_profiles = fi.sample_velocity_deficit_profiles(
+    direction = 'z',
+    resolution=10,
+    homogeneous_wind_speed=7.0
+)
+
+for df in velocity_deficit_profiles:
+    print(df)
 
 #horizontal_plane = fi.calculate_horizontal_plane(
 #    x_resolution=200,

--- a/examples/29_plot_velocity_deficit_profiles.py
+++ b/examples/29_plot_velocity_deficit_profiles.py
@@ -24,39 +24,78 @@ from floris.tools.visualization import VelocityProfilesFigure
 """
 docstr
 """
-D = 126.0
-fi = FlorisInterface("inputs/gch.yaml")
-fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
 
-downstream_dists = D * np.array([3, 5, 7])
-homogeneous_wind_speed = 8.0
+def get_profiles(direction, profile_range=None, resolution=100):
+    return fi.sample_velocity_deficit_profiles(
+        direction=direction,
+        downstream_dists=downstream_dists,
+        profile_range=profile_range,
+        resolution=resolution,
+        homogeneous_wind_speed=homogeneous_wind_speed
+    )
 
-velocity_deficit_profiles_y = fi.sample_velocity_deficit_profiles(
-    direction='y',
-    downstream_dists=downstream_dists,
-    homogeneous_wind_speed=homogeneous_wind_speed
-)
-# Same range as y-profiles for an easier comparison
-profile_range_z = D * np.array([0, 4]) - 90.0
-velocity_deficit_profiles_z = fi.sample_velocity_deficit_profiles(
-    direction='z',
-    downstream_dists=downstream_dists,
-    profile_range=profile_range_z,
-    homogeneous_wind_speed=homogeneous_wind_speed
-)
+if __name__ == '__main__':
+    D = 126.0
+    hub_height = 90.0
+    fi = FlorisInterface("inputs/gch.yaml")
+    fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
 
-profiles_fig = VelocityProfilesFigure(
-    downstream_dists_D=downstream_dists / D,
-    layout=['y', 'z']
-)
-profiles_fig.add_profiles(
-    velocity_deficit_profiles_y + velocity_deficit_profiles_z,
-    color='k'
-)
-margin = 0.05
-profiles_fig.set_xlim([0.0 - margin, 0.6 + margin])
-profiles_fig.add_ref_lines_y_D([-0.5, 0.5])
-ref_lines_z_D = 90.0 / D + np.array([-0.5, 0.5])
-profiles_fig.add_ref_lines_z_D(ref_lines_z_D)
+    downstream_dists = D * np.array([3, 5, 7])
+    homogeneous_wind_speed = 8.0
 
-plt.show()
+    # Same range as y-profiles for an easier comparison
+    profile_range_z = D * np.array([0, 4]) - hub_height
+    profiles = get_profiles('y') + get_profiles('z', profile_range_z)
+
+    profiles_fig = VelocityProfilesFigure(
+        downstream_dists_D=downstream_dists / D,
+        layout=['y', 'z'],
+    )
+    profiles_fig.add_profiles(profiles, color='k')
+
+    # Change velocity model to jensen, get the velocity deficit profiles,
+    # and plot them
+    floris_dict = fi.floris.as_dict()
+    floris_dict['wake']['model_strings']['velocity_model'] = 'jensen'
+    fi = FlorisInterface(floris_dict)
+    profiles_y = get_profiles('y', resolution=400)
+    profiles_z = get_profiles('z', profile_range_z, resolution=400)
+    profiles_fig.add_profiles(profiles_y + profiles_z, color='r')
+
+    margin = 0.05
+    profiles_fig.set_xlim([0.0 - margin, 0.6 + margin])
+    profiles_fig.add_ref_lines_y_D([-0.5, 0.5])
+    ref_lines_z_D = hub_height / D + np.array([-0.5, 0.5])
+    profiles_fig.add_ref_lines_z_D(ref_lines_z_D)
+
+    profiles_fig.axs[0,0].legend(['gauss', 'jensen'], fontsize=11)
+    profiles_fig.fig.suptitle(
+        'Velocity decifit profiles from different velocity models',
+        fontsize=14
+    )
+
+    # Profiles are independent of wind direction for a single turbine.
+    # This is because x is always in the streamwise direction
+    fi = FlorisInterface("inputs/gch.yaml")
+    fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
+    downstream_dists = D * np.array([3])
+    profiles = get_profiles('y', resolution=400)
+    profiles_fig = VelocityProfilesFigure(
+        downstream_dists_D=downstream_dists / D,
+        layout=['y']
+    )
+    profiles_fig.add_profiles(profiles, color='k')
+
+    fi.reinitialize(wind_directions=[315.0])
+    profiles = get_profiles('y', resolution=21)
+    profiles_fig.add_profiles(
+        profiles,
+        linestyle='None',
+        marker='o',
+        color='b',
+        markerfacecolor='None',
+        markeredgewidth=1.3
+    )
+    profiles_fig.axs[0,0].legend(['WD = 270 deg', 'WD = 315 deg'])
+
+    plt.show()

--- a/floris/simulation/__init__.py
+++ b/floris/simulation/__init__.py
@@ -44,7 +44,7 @@ from .grid import (
     FlowFieldPlanarGrid,
     Grid,
     PointsGrid,
-    VelocityProfileGrid,
+    LinesGrid,
     TurbineGrid,
     TurbineCubatureGrid
 )

--- a/floris/simulation/__init__.py
+++ b/floris/simulation/__init__.py
@@ -44,6 +44,7 @@ from .grid import (
     FlowFieldPlanarGrid,
     Grid,
     PointsGrid,
+    VelocityProfileGrid,
     TurbineGrid,
     TurbineCubatureGrid
 )

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -44,6 +44,7 @@ from floris.simulation import (
     VelocityProfileGrid,
     WakeModelManager,
 )
+from floris.type_dec import NDArrayFloat
 from floris.utilities import load_yaml
 
 
@@ -319,16 +320,16 @@ class Floris(BaseClass):
 
     def solve_for_velocity_deficit_profiles(
         self,
-        direction,
-        downstream_dists,
-        profile_range,
-        resolution,
-        homogeneous_wind_speed,
-        ref_rotor_diameter,
-        x_inertial_start,
-        y_inertial_start,
-        reference_height
-        ):
+        direction: str,
+        downstream_dists: NDArrayFloat | list,
+        profile_range: NDArrayFloat | list,
+        resolution: int,
+        homogeneous_wind_speed: float,
+        ref_rotor_diameter: float,
+        x_inertial_start: float,
+        y_inertial_start: float,
+        reference_height: float
+        ) -> list[pd.DataFrame]:
 
         field_grid = VelocityProfileGrid(
             direction=direction,
@@ -363,15 +364,16 @@ class Floris(BaseClass):
         else:
             full_flow_sequential_solver(self.farm, self.flow_field, field_grid, self.wake)
 
-        x = np.reshape(field_grid.x_sorted[0,0,:,0,0], (-1, resolution))
-        y = np.reshape(field_grid.y_sorted[0,0,:,0,0], (-1, resolution))
-        z = np.reshape(field_grid.z_sorted[0,0,:,0,0], (-1, resolution))
-        u = np.reshape(self.flow_field.u_sorted[0,0,:,0,0], (-1, resolution))
+        nProfiles = len(downstream_dists)
+        x = np.reshape(field_grid.x_sorted[0,0,:,0,0], (nProfiles, resolution))
+        y = np.reshape(field_grid.y_sorted[0,0,:,0,0], (nProfiles, resolution))
+        z = np.reshape(field_grid.z_sorted[0,0,:,0,0], (nProfiles, resolution))
+        u = np.reshape(self.flow_field.u_sorted[0,0,:,0,0], (nProfiles, resolution))
         velocity_deficit = (homogeneous_wind_speed - u) / homogeneous_wind_speed
 
         velocity_deficit_profiles = []
 
-        for i in range(len(downstream_dists)):
+        for i in range(nProfiles):
             df = pd.DataFrame(
                 {
                     "x/D": x[i]/ref_rotor_diameter,

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -39,6 +39,7 @@ from floris.simulation import (
     TurbineCubatureGrid,
     TurbineGrid,
     turbopark_solver,
+    VelocityProfileGrid,
     WakeModelManager,
 )
 from floris.utilities import load_yaml
@@ -313,6 +314,77 @@ class Floris(BaseClass):
             full_flow_sequential_solver(self.farm, self.flow_field, field_grid, self.wake)
 
         return self.flow_field.u_sorted[:,:,:,0,0] # Remove turbine grid dimensions
+
+    def solve_for_velocity_deficit_profiles(
+        self,
+        direction,
+        downstream_dists,
+        profile_range,
+        resolution,
+        ref_turbine_diameter,
+        x_inertial_start,
+        y_inertial_start
+        ):
+
+#        field_grid = VelocityProfileGrid(
+#            direction,
+#            downstream_dists,
+#            profile_range,
+#            resolution,
+#            ref_turbine_diameter,
+#            x_inertial_start,
+#            y_inertial_start,
+#            self.grid.x_center_of_rotation,
+#            self.grid.y_center_of_rotation,
+#            turbine_coordinates=self.farm.coordinates,
+#            reference_turbine_diameter=self.farm.rotor_diameters,
+#            grid_resolution=1,
+#            wind_directions=self.flow_field.wind_directions,
+#            wind_speeds=self.flow_field.wind_speeds,
+#            time_series=self.flow_field.time_series
+#        )
+
+# Apparently need to use keywords if multi-init
+        VelocityProfileGrid(
+            direction=direction,
+            downstream_dists=downstream_dists,
+            profile_range=profile_range,
+            resolution=resolution,
+            ref_turbine_diameter=ref_turbine_diameter,
+            x_inertial_start=x_inertial_start,
+            y_inertial_start=y_inertial_start,
+            x_center_of_rotation=self.grid.x_center_of_rotation,
+            y_center_of_rotation=self.grid.y_center_of_rotation,
+            turbine_coordinates=self.farm.coordinates,
+            reference_turbine_diameter=self.farm.rotor_diameters,
+            grid_resolution=1,
+            wind_directions=self.flow_field.wind_directions,
+            wind_speeds=self.flow_field.wind_speeds,
+            time_series=self.flow_field.time_series
+        )
+
+
+
+#        field_grid = VelocityProfileGrid(
+#            turbine_coordinates=self.farm.coordinates,
+#            reference_turbine_diameter=self.farm.rotor_diameters,
+#            wind_directions=self.flow_field.wind_directions,
+#            wind_speeds=self.flow_field.wind_speeds,
+#            grid_resolution=1,
+#            time_series=self.flow_field.time_series,
+#            x_center_of_rotation=self.grid.x_center_of_rotation,
+#            y_center_of_rotation=self.grid.y_center_of_rotation
+#        )
+
+# Worked with minimal example of VelocityProfileGrid
+#        field_grid = VelocityProfileGrid(
+#            turbine_coordinates=self.farm.coordinates,
+#            reference_turbine_diameter=self.farm.rotor_diameters,
+#            grid_resolution=1,
+#            wind_directions=self.flow_field.wind_directions,
+#            wind_speeds=self.flow_field.wind_speeds,
+#            time_series=self.flow_field.time_series,
+#        )
 
     def finalize(self):
         # Once the wake calculation is finished, unsort the values to match

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -364,16 +364,16 @@ class Floris(BaseClass):
         else:
             full_flow_sequential_solver(self.farm, self.flow_field, field_grid, self.wake)
 
-        nProfiles = len(downstream_dists)
-        x = np.reshape(field_grid.x_sorted[0,0,:,0,0], (nProfiles, resolution))
-        y = np.reshape(field_grid.y_sorted[0,0,:,0,0], (nProfiles, resolution))
-        z = np.reshape(field_grid.z_sorted[0,0,:,0,0], (nProfiles, resolution))
-        u = np.reshape(self.flow_field.u_sorted[0,0,:,0,0], (nProfiles, resolution))
+        nprofiles = len(downstream_dists)
+        x = np.reshape(field_grid.x_sorted[0,0,:,0,0], (nprofiles, resolution))
+        y = np.reshape(field_grid.y_sorted[0,0,:,0,0], (nprofiles, resolution))
+        z = np.reshape(field_grid.z_sorted[0,0,:,0,0], (nprofiles, resolution))
+        u = np.reshape(self.flow_field.u_sorted[0,0,:,0,0], (nprofiles, resolution))
         velocity_deficit = (homogeneous_wind_speed - u) / homogeneous_wind_speed
 
         velocity_deficit_profiles = []
 
-        for i in range(nProfiles):
+        for i in range(nprofiles):
             df = pd.DataFrame(
                 {
                     "x/D": x[i]/ref_rotor_diameter,

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -321,38 +321,21 @@ class Floris(BaseClass):
         downstream_dists,
         profile_range,
         resolution,
-        ref_turbine_diameter,
+        ref_rotor_diameter,
         x_inertial_start,
-        y_inertial_start
+        y_inertial_start,
+        reference_height
         ):
 
-#        field_grid = VelocityProfileGrid(
-#            direction,
-#            downstream_dists,
-#            profile_range,
-#            resolution,
-#            ref_turbine_diameter,
-#            x_inertial_start,
-#            y_inertial_start,
-#            self.grid.x_center_of_rotation,
-#            self.grid.y_center_of_rotation,
-#            turbine_coordinates=self.farm.coordinates,
-#            reference_turbine_diameter=self.farm.rotor_diameters,
-#            grid_resolution=1,
-#            wind_directions=self.flow_field.wind_directions,
-#            wind_speeds=self.flow_field.wind_speeds,
-#            time_series=self.flow_field.time_series
-#        )
-
-# Apparently need to use keywords if multi-init
         VelocityProfileGrid(
             direction=direction,
             downstream_dists=downstream_dists,
             profile_range=profile_range,
             resolution=resolution,
-            ref_turbine_diameter=ref_turbine_diameter,
+            ref_rotor_diameter=ref_rotor_diameter,
             x_inertial_start=x_inertial_start,
             y_inertial_start=y_inertial_start,
+            reference_height=reference_height,
             x_center_of_rotation=self.grid.x_center_of_rotation,
             y_center_of_rotation=self.grid.y_center_of_rotation,
             turbine_coordinates=self.farm.coordinates,
@@ -364,27 +347,6 @@ class Floris(BaseClass):
         )
 
 
-
-#        field_grid = VelocityProfileGrid(
-#            turbine_coordinates=self.farm.coordinates,
-#            reference_turbine_diameter=self.farm.rotor_diameters,
-#            wind_directions=self.flow_field.wind_directions,
-#            wind_speeds=self.flow_field.wind_speeds,
-#            grid_resolution=1,
-#            time_series=self.flow_field.time_series,
-#            x_center_of_rotation=self.grid.x_center_of_rotation,
-#            y_center_of_rotation=self.grid.y_center_of_rotation
-#        )
-
-# Worked with minimal example of VelocityProfileGrid
-#        field_grid = VelocityProfileGrid(
-#            turbine_coordinates=self.farm.coordinates,
-#            reference_turbine_diameter=self.farm.rotor_diameters,
-#            grid_resolution=1,
-#            wind_directions=self.flow_field.wind_directions,
-#            wind_speeds=self.flow_field.wind_speeds,
-#            time_series=self.flow_field.time_series,
-#        )
 
     def finalize(self):
         # Once the wake calculation is finished, unsort the values to match

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -127,11 +127,15 @@ class FlowField(BaseClass):
         # for height, using it here to apply the shear law makes that dimension store the vertical
         # wind profile.
         wind_profile_plane = (grid.z_sorted / self.reference_wind_height) ** self.wind_shear
-        dwind_profile_plane = (
-            self.wind_shear
-            * (1 / self.reference_wind_height) ** self.wind_shear
-            * (grid.z_sorted) ** (self.wind_shear - 1)
-        )
+        if self.wind_shear == 0.0:
+            # Avoid division by zero at z = 0.0 when wind_shear = 0.0
+            dwind_profile_plane = np.zeros_like(grid.z_sorted)
+        else:
+            dwind_profile_plane = (
+                self.wind_shear
+                * (1 / self.reference_wind_height) ** self.wind_shear
+                * (grid.z_sorted) ** (self.wind_shear - 1)
+            )
 
         # If no hetergeneous inflow defined, then set all speeds ups to 1.0
         if self.het_map is None:

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -770,13 +770,14 @@ class VelocityProfileGrid(Grid):
         Set points for calculation based on a series of user-supplied coordinates.
         """
         res = self.resolution
-        nProfiles = len(self.downstream_dists)
+        nprofiles = len(self.downstream_dists)
 
         # downsteam_dists are defined from the following starting point
         coordinates_inertial_start = np.array(
             [[self.x_inertial_start, self.y_inertial_start, self.reference_height]]
         )
 
+        # Starting point in rotated coordinates
         x_start, y_start, _, _, _ = rotate_coordinates_rel_west(
             self.wind_directions,
             coordinates_inertial_start,
@@ -786,7 +787,7 @@ class VelocityProfileGrid(Grid):
         x_start, y_start = x_start[0,0,0], y_start[0,0,0]
 
         downstream_dists_transpose = np.atleast_2d(self.downstream_dists).T
-        x = (x_start + downstream_dists_transpose) * np.ones((nProfiles, res))
+        x = (x_start + downstream_dists_transpose) * np.ones((nprofiles, res))
 
         if self.direction == 'y':
             y_single_profile = np.linspace(
@@ -794,8 +795,8 @@ class VelocityProfileGrid(Grid):
                 y_start + self.profile_range[1],
                 res
             )
-            y = y_single_profile * np.ones((nProfiles, res))
-            z = self.reference_height * np.ones((nProfiles, res))
+            y = y_single_profile * np.ones((nprofiles, res))
+            z = self.reference_height * np.ones((nprofiles, res))
         elif self.direction == 'z':
             z_min_profile = self.reference_height + self.profile_range[0]
             if z_min_profile <= 0.0:
@@ -806,8 +807,8 @@ class VelocityProfileGrid(Grid):
                     self.reference_height + self.profile_range[1],
                     res
             )
-            z = z_single_profile * np.ones((nProfiles, res))
-            y = y_start * np.ones((nProfiles, res))
+            z = z_single_profile * np.ones((nprofiles, res))
+            y = y_start * np.ones((nprofiles, res))
 
         self.x_sorted = x.flatten()[None,None,:,None,None]
         self.y_sorted = y.flatten()[None,None,:,None,None]

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -752,9 +752,9 @@ class VelocityProfileGrid(Grid):
     docstr
     """
     direction: str
-    downstream_dists: NDArrayFloat
-    profile_range: NDArrayFloat
-    resolution: float
+    downstream_dists: NDArrayFloat = field(converter=floris_array_converter)
+    profile_range: NDArrayFloat = field(converter=floris_array_converter)
+    resolution: int
     ref_turbine_diameter: float
     x_inertial_start: float
     y_inertial_start: float

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -771,6 +771,7 @@ class VelocityProfileGrid(Grid):
         """
         res = self.resolution
         nProfiles = len(self.downstream_dists)
+
         # downsteam_dists are defined from the following starting point
         coordinates_inertial_start = np.array(
             [[self.x_inertial_start, self.y_inertial_start, self.reference_height]]

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -86,6 +86,7 @@ class Grid(ABC):
     cubature_weights: NDArrayFloat = field(init=False, default=None)
 
     def __attrs_post_init__(self) -> None:
+        print(self.grid_resolution, type(self.grid_resolution))
         self.turbine_coordinates_array = np.array([c.elements for c in self.turbine_coordinates])
 
     @turbine_coordinates.validator
@@ -118,7 +119,7 @@ class Grid(ABC):
         # TODO move this to the grid types and off of the base class
         """Check that grid resolution is given as int or Vec3 with int components."""
         if isinstance(value, int) and \
-            isinstance(self, (TurbineGrid, TurbineCubatureGrid, PointsGrid)):
+            isinstance(self, (TurbineGrid, TurbineCubatureGrid, PointsGrid, VelocityProfileGrid)):
             return
         elif isinstance(value, Iterable) and isinstance(self, FlowFieldPlanarGrid):
             assert type(value[0]) is int
@@ -744,3 +745,44 @@ class PointsGrid(Grid):
         self.x_sorted = x[:,:,:,None,None]
         self.y_sorted = y[:,:,:,None,None]
         self.z_sorted = z[:,:,:,None,None]
+
+@define
+class VelocityProfileGrid(Grid):
+    """
+    docstr
+    """
+    direction: str
+    downstream_dists: NDArrayFloat
+    profile_range: NDArrayFloat
+    resolution: float
+    ref_turbine_diameter: float
+    x_inertial_start: float
+    y_inertial_start: float
+    x_center_of_rotation: float | None = field(default=None)
+    y_center_of_rotation: float | None = field(default=None)
+
+    def __attrs_post_init__(self) -> None:
+        super().__attrs_post_init__()
+        self.set_grid()
+
+    def set_grid(self) -> None:
+        """
+        Set points for calculation based on a series of user-supplied coordinates.
+        """
+        print(self.downstream_dists)
+
+#@define
+#class VelocityProfileGrid(Grid):
+##    x_center_of_rotation: float | None = field(default=None)
+##    y_center_of_rotation: float | None = field(default=None)
+#
+#    def __attrs_post_init__(self) -> None:
+#        super().__attrs_post_init__()
+#        self.set_grid()
+#
+#    def set_grid(self) -> None:
+#        """
+#        Set points for calculation based on a series of user-supplied coordinates.
+#        """
+#        print("Hi")
+#       # print(self.x_center_of_rotation)

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -989,8 +989,8 @@ class FlorisInterface(LoggerBase):
                 ref_rotor_diameter = rotor_diameters[0]
             else:
                 raise ValueError(
-                    "'ref_rotor_diameter' needs to be defined manually since there are multiple "
-                    "turbine types."
+                    f"Multiple rotor_diameters detected: {np.unique(rotor_diameters)}. "
+                    "Provide a single 'ref_rotor_diameter'."
                 )
 
         if downstream_dists is None:
@@ -1008,7 +1008,7 @@ class FlorisInterface(LoggerBase):
                 wind_direction = wind_directions_copy[0]
             else:
                 raise ValueError(
-                    "Multiple wind directions detected. Specify a single 'wind_direction' for "
+                    "Multiple wind directions detected. Provide a single 'wind_direction' for "
                     "which to sample the velocity profiles."
                 )
 
@@ -1018,7 +1018,7 @@ class FlorisInterface(LoggerBase):
                 # Maybe add info msg that wind_speed is homogeneous
             else:
                 raise ValueError(
-                    "Multiple wind speeds detected. Specify a single 'homogeneous_wind_speed' for "
+                    "Multiple wind speeds detected. Provide a single 'homogeneous_wind_speed' for "
                     "which to sample the velocity profiles."
                 )
 
@@ -1036,22 +1036,6 @@ class FlorisInterface(LoggerBase):
                 wind_speeds=[homogeneous_wind_speed],
                 wind_shear=0.0
         )
-
-#        print(
-#            direction,
-#            downstream_dists,
-#            profile_range,
-#            resolution,
-#            wind_direction,
-#            homogeneous_wind_speed,
-#            ref_rotor_diameter,
-#            x_inertial_start,
-#            y_inertial_start,
-#            reference_height,
-#            self.floris.flow_field.wind_directions,
-#            self.floris.flow_field.wind_speeds,
-#            self.floris.flow_field.wind_shear
-#        )
 
         velocity_deficit_profiles = self.floris.solve_for_velocity_deficit_profiles(
             direction,

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -984,12 +984,12 @@ class FlorisInterface(LoggerBase):
             raise ValueError("'direction' must be either y or z")
 
         if ref_rotor_diameter is None:
-            rotor_diameters = self.floris.farm.rotor_diameters
-            if np.all(rotor_diameters == rotor_diameters[0]):
-                ref_rotor_diameter = rotor_diameters[0]
+            unique_rotor_diameters = np.unique(self.floris.farm.rotor_diameters)
+            if len(unique_rotor_diameters) == 1:
+                ref_rotor_diameter = unique_rotor_diameters[0]
             else:
                 raise ValueError(
-                    f"Multiple rotor_diameters detected: {np.unique(rotor_diameters)}. "
+                    f"Multiple rotor_diameters detected: {unique_rotor_diameters}. "
                     "Provide a single 'ref_rotor_diameter'."
                 )
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -989,7 +989,7 @@ class FlorisInterface(LoggerBase):
                 ref_rotor_diameter = rotor_diameters[0]
             else:
                 raise ValueError(
-                    "'ref_rotor_diameter' needs to be defined manually since there are multiple"
+                    "'ref_rotor_diameter' needs to be defined manually since there are multiple "
                     "turbine types."
                 )
 
@@ -1008,7 +1008,7 @@ class FlorisInterface(LoggerBase):
                 wind_direction = wind_directions_copy[0]
             else:
                 raise ValueError(
-                    "Multiple wind directions detected. Specify a single 'wind_direction' for"
+                    "Multiple wind directions detected. Specify a single 'wind_direction' for "
                     "which to sample the velocity profiles."
                 )
 
@@ -1018,7 +1018,7 @@ class FlorisInterface(LoggerBase):
                 # Maybe add info msg that wind_speed is homogeneous
             else:
                 raise ValueError(
-                    "Multiple wind speeds detected. Specify a single 'homogeneous_wind_speed' for"
+                    "Multiple wind speeds detected. Specify a single 'homogeneous_wind_speed' for "
                     "which to sample the velocity profiles."
                 )
 
@@ -1058,6 +1058,7 @@ class FlorisInterface(LoggerBase):
             downstream_dists,
             profile_range,
             resolution,
+            homogeneous_wind_speed,
             ref_rotor_diameter,
             x_inertial_start,
             y_inertial_start,
@@ -1070,9 +1071,7 @@ class FlorisInterface(LoggerBase):
                 wind_shear=wind_shear_copy
         )
 
-        print(velocity_deficit_profiles) # Placeholder
-
-#        return velocity_deficit_profiles
+        return velocity_deficit_profiles
 
     @property
     def layout_x(self):

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -1018,7 +1018,7 @@ class FlorisInterface(LoggerBase):
                 self.logger.warning(
                     "'homogeneous_wind_speed' not provided. Setting it to the single wind speed "
                     "found in 'wind_speeds'. Note that the inflow is always homogeneous when "
-                    "calculateing the velocity deficit profiles. This is done by temporarily "
+                    "calculating the velocity deficit profiles. This is done by temporarily "
                     "setting 'wind_shear' to 0.0"
                 )
             else:

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -950,6 +950,50 @@ class FlorisInterface(LoggerBase):
 
         return self.floris.solve_for_points(x, y, z)
 
+    def sample_velocity_deficit_profiles(
+            self,
+            direction='y',
+            downstream_dists=None,
+            profile_range=None,
+            resolution=100,
+            ref_turbine_diameter=None,
+            x_inertial_start=None,
+            y_inertial_start=None
+            ):
+        """
+        Extract velocity deficit profiles
+
+        Args:
+            x (1DArrayFloat | list): x-locations of points where flow is desired.
+            y (1DArrayFloat | list): y-locations of points where flow is desired.
+            z (1DArrayFloat | list): z-locations of points where flow is desired.
+
+        Returns:
+            3DArrayFloat containing wind speed with dimensions
+            (# of wind directions, # of wind speeds, # of sample points)
+        """
+
+        if downstream_dists is None:
+            downstream_dists = ref_turbine_diameter * np.array([3, 5, 7, 9])
+
+        if profile_range is None:
+            profile_range = ref_turbine_diameter * np.array([-2, 2])
+
+        if direction not in ('y', 'z'):
+            raise ValueError("'direction' must be either y or z")
+
+        velocity_deficit_profiles = self.floris.solve_for_velocity_deficit_profiles(
+            direction,
+            downstream_dists,
+            profile_range,
+            resolution,
+            ref_turbine_diameter,
+            x_inertial_start,
+            y_inertial_start
+        )
+
+        return velocity_deficit_profiles
+
     @property
     def layout_x(self):
         """

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -959,29 +959,44 @@ class FlorisInterface(LoggerBase):
             wind_direction: float = None,
             homogeneous_wind_speed: float = None,
             ref_rotor_diameter: float = None,
-            x_inertial_start: float = None,
-            y_inertial_start: float = None,
-            reference_height: float = None
+            x_inertial_start: float = 0.0,
+            y_inertial_start: float = 0.0,
+            reference_height: float = None,
     ) -> list[pd.DataFrame]:
         """
-        Extract velocity deficit profiles
+        Extract velocity deficit profiles at a set of downstream distances from a starting point
+        (usually a turbine location). For each downstream distance, a profile is sampled along
+        a line in either the cross-stream direction (y) or the vertical direction (z).
+        Velocity deficit is here defined as (homogeneous_wind_speed - u)/homogeneous_wind_speed,
+        where u is the wake velocity obtained when wind_shear = 0.0.
 
         Args:
-            downstream_dists: Streamwise location for each velocity profile. Default starting point
-                is at (x, y) = (0, 0).
-
-
-            reference_height: If 'direction' is y, then 'reference_height' defines the height of the
-                xy-plane in which the velocity profiles are sampled. If 'direction' is z, then the
-                velocity is sampled along the vertical direction with the 'profile_range' being
-                relative to the 'reference_height'.
+            direction: At each downstream location, this is the direction in which to sample the
+                profile. Either `y` or `z`.
+            downstream_dists: A list/array of streamwise locations for where to sample the profiles.
+                Default starting point in inertial coordinates is (0.0, 0.0, reference_height).
+            profile_range: Determines the extent of the line along which the profiles are sampled.
+                The range is defined about a point which lies some distance directly downstream of
+                the starting point.
+            resolution: Number of sample points in each profile.
+            wind_direction: A single wind direction.
+            homogeneous_wind_speed: A single wind speed. It is called homogeneous since 'wind_shear'
+                is temporarily set to 0.0 in this method.
+            ref_rotor_diameter: A reference rotor diameter which is used to normalize the
+                coordinates.
+            x_inertial_start: x-coordinate of starting point in the inertial coordinate system.
+            y_inertial_start: y-coordinate of starting point in the inertial coordinate system.
+            reference_height: If `direction` is y, then `reference_height` defines the height of the
+                xy-plane in which the velocity profiles are sampled. If `direction` is z, then the
+                velocity is sampled along the vertical direction with the `profile_range` being
+                relative to the `reference_height`.
         Returns:
-            3DArrayFloat containing wind speed with dimensions
-            (# of wind directions, # of wind speeds, # of sample points)
+            A list of pandas DataFrame objects where each DataFrame represents one velocity deficit
+            profile.
         """
 
-        if direction not in ('y', 'z'):
-            raise ValueError("'direction' must be either y or z")
+        if direction not in ['y', 'z']:
+            raise ValueError("`direction` must be either y or z.")
 
         if ref_rotor_diameter is None:
             unique_rotor_diameters = np.unique(self.floris.farm.rotor_diameters)
@@ -989,8 +1004,10 @@ class FlorisInterface(LoggerBase):
                 ref_rotor_diameter = unique_rotor_diameters[0]
             else:
                 raise ValueError(
-                    f"Multiple rotor_diameters detected: {unique_rotor_diameters}. "
-                    "Provide a single 'ref_rotor_diameter'."
+                    "Please provide a `ref_rotor_diameter`. This is needed to normalize the "
+                    "coordinates. Could not select a value automatically since the number of "
+                    "unique rotor diameters in the turbine layout is not 1. "
+                    f"Found the following rotor diameters: {unique_rotor_diameters}."
                 )
 
         if downstream_dists is None:
@@ -1008,30 +1025,25 @@ class FlorisInterface(LoggerBase):
                 wind_direction = wind_directions_copy[0]
             else:
                 raise ValueError(
-                    "Multiple wind directions detected. Provide a single 'wind_direction' for "
-                    "which to sample the velocity profiles."
+                    "Could not determine a wind direction for which to sample the velocity "
+                    "profiles. Either provide a single `wind_direction` as an argument to this "
+                    "method, or initialize the Floris object with a single wind direction."
                 )
 
         if homogeneous_wind_speed is None:
             if len(wind_speeds_copy) == 1:
                 homogeneous_wind_speed = wind_speeds_copy[0]
                 self.logger.warning(
-                    "'homogeneous_wind_speed' not provided. Setting it to the single wind speed "
-                    "found in 'wind_speeds'. Note that the inflow is always homogeneous when "
-                    "calculating the velocity deficit profiles. This is done by temporarily "
-                    "setting 'wind_shear' to 0.0"
+                    "`homogeneous_wind_speed` not provided. Setting it to the following wind speed "
+                    f"found in the current flow field: {wind_speeds_copy[0]} m/s. Note that the "
+                    "inflow is always homogeneous when calculating the velocity deficit profiles. "
+                    "This is done by temporarily setting `wind_shear` to 0.0"
                 )
             else:
                 raise ValueError(
-                    "Multiple wind speeds detected. Provide a single 'homogeneous_wind_speed' for "
-                    "which to sample the velocity profiles."
+                    "Could not determine a wind speed for which to sample the velocity "
+                    "profiles. Provide a single `homogeneous_wind_speed` to this method."
                 )
-
-        if x_inertial_start is None:
-            x_inertial_start = 0.0
-
-        if y_inertial_start is None:
-            y_inertial_start = 0.0
 
         if reference_height is None:
             reference_height = self.floris.flow_field.reference_wind_height
@@ -1039,7 +1051,7 @@ class FlorisInterface(LoggerBase):
         self.reinitialize(
                 wind_directions=[wind_direction],
                 wind_speeds=[homogeneous_wind_speed],
-                wind_shear=0.0
+                wind_shear=0.0,
         )
 
         velocity_deficit_profiles = self.floris.solve_for_velocity_deficit_profiles(
@@ -1051,13 +1063,13 @@ class FlorisInterface(LoggerBase):
             ref_rotor_diameter,
             x_inertial_start,
             y_inertial_start,
-            reference_height
+            reference_height,
         )
 
         self.reinitialize(
                 wind_directions=wind_directions_copy,
                 wind_speeds=wind_speeds_copy,
-                wind_shear=wind_shear_copy
+                wind_shear=wind_shear_copy,
         )
 
         return velocity_deficit_profiles

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -1001,6 +1001,7 @@ class FlorisInterface(LoggerBase):
 
         wind_directions_copy = np.array(self.floris.flow_field.wind_directions, copy=True)
         wind_speeds_copy = np.array(self.floris.flow_field.wind_speeds, copy=True)
+        wind_shear_copy = self.floris.flow_field.wind_shear
 
         if wind_direction is None:
             if len(wind_directions_copy) == 1:
@@ -1021,33 +1022,56 @@ class FlorisInterface(LoggerBase):
                     "which to sample the velocity profiles."
                 )
 
+        if x_inertial_start is None:
+            x_inertial_start = 0.0
+
+        if y_inertial_start is None:
+            y_inertial_start = 0.0
+
         if reference_height is None:
             reference_height = self.floris.flow_field.reference_wind_height
 
-        print(
+        self.reinitialize(
+                wind_directions=[wind_direction],
+                wind_speeds=[homogeneous_wind_speed],
+                wind_shear=0.0
+        )
+
+#        print(
+#            direction,
+#            downstream_dists,
+#            profile_range,
+#            resolution,
+#            wind_direction,
+#            homogeneous_wind_speed,
+#            ref_rotor_diameter,
+#            x_inertial_start,
+#            y_inertial_start,
+#            reference_height,
+#            self.floris.flow_field.wind_directions,
+#            self.floris.flow_field.wind_speeds,
+#            self.floris.flow_field.wind_shear
+#        )
+
+        velocity_deficit_profiles = self.floris.solve_for_velocity_deficit_profiles(
             direction,
             downstream_dists,
             profile_range,
             resolution,
-            wind_direction,
-            homogeneous_wind_speed,
             ref_rotor_diameter,
             x_inertial_start,
             y_inertial_start,
             reference_height
         )
 
+        self.reinitialize(
+                wind_directions=wind_directions_copy,
+                wind_speeds=wind_speeds_copy,
+                wind_shear=wind_shear_copy
+        )
 
-#        velocity_deficit_profiles = self.floris.solve_for_velocity_deficit_profiles(
-#            direction,
-#            downstream_dists,
-#            profile_range,
-#            resolution,
-#            ref_turbine_diameter,
-#            x_inertial_start,
-#            y_inertial_start
-#        )
-#
+        print(velocity_deficit_profiles) # Placeholder
+
 #        return velocity_deficit_profiles
 
     @property

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -952,17 +952,17 @@ class FlorisInterface(LoggerBase):
 
     def sample_velocity_deficit_profiles(
             self,
-            direction: NDArrayFloat = 'y',
+            direction: str = 'y',
             downstream_dists: NDArrayFloat | list = None,
             profile_range: NDArrayFloat | list = None,
-            resolution=100,
+            resolution: int = 100,
             wind_direction: float = None,
             homogeneous_wind_speed: float = None,
             ref_rotor_diameter: float = None,
             x_inertial_start: float = None,
             y_inertial_start: float = None,
             reference_height: float = None
-            ):
+    ) -> list[pd.DataFrame]:
         """
         Extract velocity deficit profiles
 
@@ -1015,7 +1015,12 @@ class FlorisInterface(LoggerBase):
         if homogeneous_wind_speed is None:
             if len(wind_speeds_copy) == 1:
                 homogeneous_wind_speed = wind_speeds_copy[0]
-                # Maybe add info msg that wind_speed is homogeneous
+                self.logger.warning(
+                    "'homogeneous_wind_speed' not provided. Setting it to the single wind speed "
+                    "found in 'wind_speeds'. Note that the inflow is always homogeneous when "
+                    "calculateing the velocity deficit profiles. This is done by temporarily "
+                    "setting 'wind_shear' to 0.0"
+                )
             else:
                 raise ValueError(
                     "Multiple wind speeds detected. Provide a single 'homogeneous_wind_speed' for "

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -721,15 +721,15 @@ class VelocityProfilesFigure():
         self.nrows = len(self.layout)
         self.ncols = len(self.downstream_dists_D)
         figsize = [0.7 + self.width_per_col * self.ncols, 1.0 + self.height_per_row * self.nrows]
-        self.fig, axs = plt.subplots(
+        self.fig, self.axs = plt.subplots(
             self.nrows,
             self.ncols,
             figsize=figsize,
             layout='tight',
             sharex='col',
-            sharey='row'
+            sharey='row',
+            squeeze=False
         )
-        self.axs = np.atleast_2d(axs)
 
         for ax in self.axs[-1]:
             ax.set_xlabel(r'$\Delta U / U_\infty$', fontsize=14)
@@ -788,7 +788,7 @@ class VelocityProfilesFigure():
                 "values with which the instance of the VelocityProfilesFigure was initialized: "
                 f"{self.downstream_dists_D}"
             )
-        return self.axs[row][col], profile_direction
+        return self.axs[row,col], profile_direction
 
     def set_xlim(self, xlim):
         for ax in self.axs[-1]:
@@ -816,7 +816,7 @@ class VelocityProfilesFigure():
         default_params = {
                 'linestyle': (0, (4, 2)),
                 'color': 'k',
-                'linewidth': 1.2
+                'linewidth': 1.1
         }
         for key in default_params:
             if key not in kwargs:

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -719,16 +719,25 @@ class VelocityProfilesFigure():
         self.nrows = len(self.layout)
         self.ncols = len(self.downstream_dists_D)
         width_per_col = 6.4 / 3
-        height_per_row = 6.4 / 2
-        figsize = [width_per_col * self.ncols, height_per_row * self.nrows]
+        height_per_row = 7.0 / 2
+        figsize = [0.5 + width_per_col * self.ncols, height_per_row * self.nrows]
         self.fig, axs = plt.subplots(
             self.nrows,
             self.ncols,
             figsize=figsize,
             layout='tight',
-            sharex='all',
+            sharex='col',
             sharey='row'
         )
+        self.axs = np.atleast_2d(axs)
+
+        for ax in self.axs[-1]:
+            ax.set_xlabel(r'$\Delta U / U_\infty$', fontsize=14)
+            ax.tick_params('x', labelsize=14)
+
+        for profile_direction, ax in zip(self.layout, self.axs[:,0]):
+            ax.set_ylabel(f'${profile_direction}/D$', fontsize=14)
+            ax.tick_params('y', labelsize=14)
 
     @layout.validator
     def layout_validator(self, instance : attrs.Attribute, value : list[str]) -> None:

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -709,6 +709,8 @@ class VelocityProfilesFigure():
     """
     downstream_dists_D: NDArrayFloat = field(converter=floris_array_converter)
     layout: list[str] = field(default=['y'])
+    width_per_col: float = field(default=2.07)
+    height_per_row: float = field(default=3.0)
 
     nrows: int = field(init=False)
     ncols: int = field(init=False)
@@ -718,9 +720,7 @@ class VelocityProfilesFigure():
     def __attrs_post_init__(self):
         self.nrows = len(self.layout)
         self.ncols = len(self.downstream_dists_D)
-        width_per_col = 6.4 / 3
-        height_per_row = 7.0 / 2
-        figsize = [0.5 + width_per_col * self.ncols, height_per_row * self.nrows]
+        figsize = [0.7 + self.width_per_col * self.ncols, 1.0 + self.height_per_row * self.nrows]
         self.fig, axs = plt.subplots(
             self.nrows,
             self.ncols,
@@ -756,7 +756,9 @@ class VelocityProfilesFigure():
 
     def match_profile_to_axes(self, df):
         x_D = np.unique(df['x/D'])
-        if len(x_D) > 1:
+        if len(x_D) == 1:
+            x_D = x_D[0]
+        else:
             raise ValueError(
                 "The streamwise location x/D must be constant for each velocity profile."
             )
@@ -769,7 +771,7 @@ class VelocityProfilesFigure():
             profile_direction = 'y'
         else:
             raise ValueError(
-                "Velocity deficit profile at x/D = {x_D} is neither in the cross-stream (y)"
+                f"Velocity deficit profile at x/D = {x_D} is neither in the cross-stream (y) "
                 "nor the vertical (z) direction."
             )
         row = self.layout.index(profile_direction)
@@ -793,23 +795,21 @@ class VelocityProfilesFigure():
             ax.set_xlim(xlim)
 
     def add_ref_lines_y_D(self, ref_lines, **kwargs):
-        try:
-            row_y = self.layout.index('y')
-        except Exception:
-            print(
+        if 'y' not in self.layout:
+            raise Exception(
                 "Could not add reference lines to cross-stream (y) velocity profiles. No "
                 "such profiles exist in the figure."
             )
+        row_y = self.layout.index('y')
         self.add_ref_lines(ref_lines, row_y, **kwargs)
 
     def add_ref_lines_z_D(self, ref_lines, **kwargs):
-        try:
-            row_z = self.layout.index('z')
-        except Exception:
-            print(
+        if 'z' not in self.layout:
+            raise Exception(
                 "Could not add reference lines to vertical (z) velocity profiles. No "
                 "such profiles exist in the figure."
             )
+        row_z = self.layout.index('z')
         self.add_ref_lines(ref_lines, row_z, **kwargs)
 
     def add_ref_lines(self, ref_lines, row, **kwargs):


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Velocity deficit profiles
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This PR adds a quick way to sample and plot velocity deficit profiles at several locations downstream of a turbine. The following definition of velocity deficit is used:
$$\frac{\Delta U}{U_\infty} = \frac{U_\infty - U}{U_\infty}$$
, where $U$ is the wake velocity obtained for a homogeneous incident wind speed of $U_\infty$ (see "Additional supporting information" for more details) .

The figure below is an output of a new example `29_plot_velocity_deficit_profiles.py`. It shows velocity deficit profiles at three locations downstream of a single nrel_5MW turbine. Coordinates $x/D$, $y/D$, and $z/D$ are in the streamwise, cross-stream, and vertical direction respectively, and normalized by the turbine diameter $D$. The dashed lines show the extent of the rotor.

<img src="https://github.com/NREL/floris/assets/93799025/e3074b9d-2ae2-4591-8985-06f386df0ece" width="600">

Use cases for this feature include:
- Comparing velocity models like in the figure above
- Comparing a velocity model to experimental data or CFD simulations

One may ask why $z$-profiles (bottom row of figure) are supported, since they are identical to the $y$-profiles in the above example. I believe they are useful if FLORIS adds support for vertical-axis wind turbines (VAWTs). VAWT wake characteristics are different in the cross-stream and vertical direction, which is why it's necessary to have both $y$- and $z$-profiles to represent the wake; see e.g. [(Ouro & Lazennec, 2021)](https://doi.org/10.1017/flo.2021.4). It may also be useful in layouts where the turbines have different hub heights.

## Additional supporting information
<!--
Add any other context about the problem here.
-->
When developing this feature, I chose between the following definitions of the (non-normalized) velocity deficit $\Delta U$:
1) $\Delta U = U_\infty - U$, where $U$ is the wake velocity obtained for a homogeneous incident wind speed of $U_\infty$, or
2) $\Delta U = U_{ABL}(z) - U$, where $U$ is the wake velocity obtained when the inflow has an Atmospheric Boundary Layer profile denoted $U_{ABL}(z)$.

Here, I concluded that $\Delta U$ would be the same in both cases. I chose definition 1 since it removed the complexity of the ABL. Practically, this is enforced by temporarily setting wind_shear = 0.0 when sampling the profiles.
<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
