### PR TITLE
Feature: Include WD and WS dependency in ambient turbulence intensity

### DIFF
--- a/examples/test_turbulence_intensity_table.py
+++ b/examples/test_turbulence_intensity_table.py
@@ -34,22 +34,26 @@ The power of both turbines for each wind direction is then plotted
 # Instantiate FLORIS using either the GCH or CC model
 fi = FlorisInterface("inputs/gch.yaml") # GCH model matched to the default "legacy_gauss" of V2
 
-# # Option one: 
-# fi.reinitialize(
-#     wind_directions=[260.0, 270.0, 280.0],
-#     wind_speeds=[7.0, 9.0],
-#     turbulence_intensity=0.06
-# )
-# fi.calculate_wake()
-# farm_powers = fi.get_farm_power()
-# print(f"Farm powers: {farm_powers}")
+# Option one:
+ws_array = np.array([6.0, 7.0, 8.0, 9.0])
+ti_array = np.array([0.10, 0.09, 0.08, 0.07])
+farm_powers = []
+for wsii, ws in enumerate(ws_array):
+    fi.reinitialize(
+        wind_directions=[270.0],
+        wind_speeds=[ws],
+        turbulence_intensity=ti_array[wsii]
+    )
+    fi.calculate_wake()
+    farm_powers.append(float(fi.get_farm_power()))
+print(f"Farm powers (old method): {np.round(farm_powers)}")
 
 # Option two: as a table
 fi.reinitialize(
-    wind_directions=[260.0, 270.0, 280.0],
-    wind_speeds=[7.0, 9.0],
-    turbulence_intensity=[[0.08, 0.06], [0.081, 0.064], [0.079, 0.058]]
+    wind_directions=[270.0],
+    wind_speeds=ws_array,
+    turbulence_intensity=ti_array[None, :],
 )
 fi.calculate_wake()
-farm_powers = fi.get_farm_power()
-print(f"Farm powers: {farm_powers}")
+farm_powers = fi.get_farm_power().flatten()
+print(f"Farm powers (new method): {np.round(farm_powers)}")

--- a/examples/test_turbulence_intensity_table.py
+++ b/examples/test_turbulence_intensity_table.py
@@ -1,0 +1,55 @@
+# Copyright 2022 NREL
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# See https://floris.readthedocs.io for documentation
+
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from floris.tools import FlorisInterface
+
+
+"""
+04_sweep_wind_directions
+
+This example demonstrates vectorization of wind direction.
+A vector of wind directions is passed to the intialize function
+and the powers of the two simulated turbines is computed for all
+wind directions in one call
+
+The power of both turbines for each wind direction is then plotted
+
+"""
+
+# Instantiate FLORIS using either the GCH or CC model
+fi = FlorisInterface("inputs/gch.yaml") # GCH model matched to the default "legacy_gauss" of V2
+
+# # Option one: 
+# fi.reinitialize(
+#     wind_directions=[260.0, 270.0, 280.0],
+#     wind_speeds=[7.0, 9.0],
+#     turbulence_intensity=0.06
+# )
+# fi.calculate_wake()
+# farm_powers = fi.get_farm_power()
+# print(f"Farm powers: {farm_powers}")
+
+# Option two: as a table
+fi.reinitialize(
+    wind_directions=[260.0, 270.0, 280.0],
+    wind_speeds=[7.0, 9.0],
+    turbulence_intensity=[[0.08, 0.06], [0.081, 0.064], [0.079, 0.058]]
+)
+fi.calculate_wake()
+farm_powers = fi.get_farm_power()
+print(f"Farm powers: {farm_powers}")

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -39,7 +39,7 @@ class FlowField(BaseClass):
     wind_veer: float = field(converter=float)
     wind_shear: float = field(converter=float)
     air_density: float = field(converter=float)
-    turbulence_intensity: float = field(converter=float)
+    turbulence_intensity: NDArrayFloat = field(converter=floris_array_converter)
     reference_wind_height: float = field(converter=float)
     time_series : bool = field(default=False)
     heterogenous_inflow_config: dict = field(default=None)
@@ -214,14 +214,10 @@ class FlowField(BaseClass):
         self.v_sorted = self.v_initial_sorted.copy()
         self.w_sorted = self.w_initial_sorted.copy()
 
-        self.turbulence_intensity_field = self.turbulence_intensity * np.ones(
-            (
-                self.n_wind_directions,
-                self.n_wind_speeds,
-                grid.n_turbines,
-                1,
-                1,
-            )
+        self.turbulence_intensity_field = np.repeat(
+            self.turbulence_intensity[:, :, None, None, None],
+            repeats=grid.n_turbines,
+            axis=2
         )
         self.turbulence_intensity_field_sorted = self.turbulence_intensity_field.copy()
 

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -76,6 +76,12 @@ class FlowField(BaseClass):
         """Using the validator method to keep the `n_wind_directions` attribute up to date."""
         self.n_wind_directions = value.size
 
+    @turbulence_intensity.validator
+    def turbulence_intensity_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:
+        """Using the validator method to format turbulence intensity to appropriate dimensions."""
+        if value.shape == ():  # If a float was specified, copy over to all conditions
+            self.turbulence_intensity = value * np.ones((self.n_wind_directions, self.n_wind_speeds))
+
     @heterogenous_inflow_config.validator
     def heterogenous_config_validator(self, instance: attrs.Attribute, value: dict | None) -> None:
         """Using the validator method to check that the heterogenous_inflow_config dictionary has

--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -76,11 +76,8 @@ def sequential_solver(
     v_wake = np.zeros_like(flow_field.v_initial_sorted)
     w_wake = np.zeros_like(flow_field.w_initial_sorted)
 
-    turbine_turbulence_intensity = (
-        flow_field.turbulence_intensity
-        * np.ones((flow_field.n_wind_directions, flow_field.n_wind_speeds, farm.n_turbines, 1, 1))
-    )
-    ambient_turbulence_intensity = flow_field.turbulence_intensity
+    turbine_turbulence_intensity = flow_field.turbulence_intensity_field
+    ambient_turbulence_intensity = flow_field.turbulence_intensity[:, :, None, None, None]
 
     # Calculate the velocity deficit sequentially from upstream to downstream turbines
     for i in range(grid.n_turbines):
@@ -453,11 +450,8 @@ def cc_solver(
     turb_u_wake = np.zeros_like(flow_field.u_initial_sorted)
     turb_inflow_field = copy.deepcopy(flow_field.u_initial_sorted)
 
-    turbine_turbulence_intensity = (
-        flow_field.turbulence_intensity
-        * np.ones((flow_field.n_wind_directions, flow_field.n_wind_speeds, farm.n_turbines, 1, 1))
-    )
-    ambient_turbulence_intensity = flow_field.turbulence_intensity
+    turbine_turbulence_intensity = flow_field.turbulence_intensity_field
+    ambient_turbulence_intensity = flow_field.turbulence_intensity[:, :, None, None, None]
 
     shape = (farm.n_turbines,) + np.shape(flow_field.u_initial_sorted)
     Ctmp = np.zeros((shape))
@@ -871,11 +865,8 @@ def turbopark_solver(
     velocity_deficit = np.zeros(shape)
     deflection_field = np.zeros_like(flow_field.u_initial_sorted)
 
-    turbine_turbulence_intensity = (
-        flow_field.turbulence_intensity
-        * np.ones((flow_field.n_wind_directions, flow_field.n_wind_speeds, farm.n_turbines, 1, 1))
-    )
-    ambient_turbulence_intensity = flow_field.turbulence_intensity
+    turbine_turbulence_intensity = flow_field.turbulence_intensity_field
+    ambient_turbulence_intensity = flow_field.turbulence_intensity[:, :, None, None, None]
 
     # Calculate the velocity deficit sequentially from upstream to downstream turbines
     for i in range(grid.n_turbines):

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -218,8 +218,8 @@ class FlorisInterface(LoggerBase):
         if turbulence_intensity is not None:
             # Ensure turbulence intensity is of appropriate dimensions
             s = (
-                self.floris.flow_field.n_wind_directions,
-                self.floris.flow_field.n_wind_speeds
+                len(flow_field_dict["wind_directions"]),
+                len(flow_field_dict["wind_speeds"])
             )
             if isinstance(turbulence_intensity, float):
                 turbulence_intensity = turbulence_intensity * np.ones(s)

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -215,11 +215,21 @@ class FlorisInterface(LoggerBase):
             flow_field_dict["wind_veer"] = wind_veer
         if reference_wind_height is not None:
             flow_field_dict["reference_wind_height"] = reference_wind_height
+
+        # If we have updated the wind direction and/or the wind speed, we must also update
+        # the turbulence intensity. We can only do this automatically if we have the same
+        # turbulence intensity for all wind directions and wind speeds.
+        if ((wind_speeds is not None) | (wind_directions is not None)) and \
+            (turbulence_intensity is None):
+            unique_turbulence_intensities = np.unique(flow_field_dict["turbulence_intensity"])
+            if len(unique_turbulence_intensities) == 1:
+                turbulence_intensity = float(unique_turbulence_intensities[0])
+
         if turbulence_intensity is not None:
             # Ensure turbulence intensity is of appropriate dimensions
             s = (
-                len(flow_field_dict["wind_directions"]),
-                len(flow_field_dict["wind_speeds"])
+                len(np.array(flow_field_dict["wind_directions"])),
+                len(np.array(flow_field_dict["wind_speeds"]))
             )
             if isinstance(turbulence_intensity, float):
                 turbulence_intensity = turbulence_intensity * np.ones(s)

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -185,7 +185,7 @@ class FlorisInterface(LoggerBase):
         wind_shear: float | None = None,
         wind_veer: float | None = None,
         reference_wind_height: float | None = None,
-        turbulence_intensity: float | None = None,
+        turbulence_intensity: float | list[float] | NDArrayFloat | None = None,
         # turbulence_kinetic_energy=None,
         air_density: float | None = None,
         # wake: WakeModelManager = None,
@@ -216,6 +216,16 @@ class FlorisInterface(LoggerBase):
         if reference_wind_height is not None:
             flow_field_dict["reference_wind_height"] = reference_wind_height
         if turbulence_intensity is not None:
+            # Ensure turbulence intensity is of appropriate dimensions
+            s = (
+                self.floris.flow_field.n_wind_directions,
+                self.floris.flow_field.n_wind_speeds
+            )
+            if isinstance(turbulence_intensity, float):
+                turbulence_intensity = turbulence_intensity * np.ones(s)
+            if not np.shape(turbulence_intensity) == s:
+                self.logger.error("Turbulence intensity array is not the right shape.")
+
             flow_field_dict["turbulence_intensity"] = turbulence_intensity
         if air_density is not None:
             flow_field_dict["air_density"] = air_density


### PR DESCRIPTION
This PR is not yet ready to be merged.

# Feature: turn turbulence_intensity into a table of which its values vary with wind direction and wind speed.
In this PR, I change `turbulence_intensity` into a 2D array with shape `(n_wind_directions, n_wind_speeds)`, while guaranteeing backward compatibility. It gives much greater freedom and better accuracy when modeling sites, at practically no downsides, I think.

## Related issue
See Issue #666 and #713.

## Impacted areas of the software
`FlowField`, `FlorisInterface`

## Additional supporting information
This nicely fits in how information is provided in the industry in terms of turbulence intensity dependency. We either receive turbulence intensity as a single value, or as a function of wind speed, or as a function of wind direction and wind speed (most commonly).

## Test results, if applicable
Using the `develop` branch and running the following code, I find:
```
import numpy as np

from floris.tools import FlorisInterface

# Instantiate FLORIS using either the GCH or CC model
fi = FlorisInterface("inputs/gch.yaml")
ws_array = np.array([6.0, 7.0, 8.0, 9.0])
ti_array = np.array([0.10, 0.09, 0.08, 0.07])
farm_powers = []
for wsii, ws in enumerate(ws_array):
    fi.reinitialize(
        wind_directions=[270.0],
        wind_speeds=[ws],
        turbulence_intensity=ti_array[wsii]
    )
    fi.calculate_wake()
    farm_powers.append(float(fi.get_farm_power()))
print(f"Farm powers (old method): {np.round(farm_powers)}")
```
The results is: `Farm powers (old method): [1214040. 1948831. 2863529. 3944825.]`

Then implementing it directly with this new PR, with the following code:
```
# Option two: as a table
fi.reinitialize(
    wind_directions=[270.0],
    wind_speeds=ws_array,
    turbulence_intensity=ti_array[None, :],
)
fi.calculate_wake()
farm_powers = fi.get_farm_power().flatten()
print(f"Farm powers (new method): {np.round(farm_powers)}")
```
We find the same values: `Farm powers (new method): [1214040. 1948831. 2863529. 3944825.]`. The big benefit is that we completely omit the need for users to implement for-loops or split/merge solutions in pre- and post-FLORIS runs.

It feels like I am getting pretty deep into the core code of FLORIS with these changes. @rafmudaf, @bayc, could you review and let me know if these changes align with your views?

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
