### PR TITLE
Allow switching on and off contour plot numerical labels at top level

### DIFF
--- a/examples/02_visualizations.py
+++ b/examples/02_visualizations.py
@@ -18,10 +18,6 @@ import numpy as np
 
 import floris.tools.visualization as wakeviz
 from floris.tools import FlorisInterface
-from floris.tools.visualization import (
-    calculate_horizontal_plane_with_turbines,
-    visualize_cut_plane,
-)
 
 
 """
@@ -78,13 +74,28 @@ cross_plane = fi.calculate_cross_plane(
 # Create the plots
 fig, ax_list = plt.subplots(3, 1, figsize=(10, 8))
 ax_list = ax_list.flatten()
-wakeviz.visualize_cut_plane(horizontal_plane, ax=ax_list[0], title="Horizontal")
-wakeviz.visualize_cut_plane(y_plane, ax=ax_list[1], title="Streamwise profile")
-wakeviz.visualize_cut_plane(cross_plane, ax=ax_list[2], title="Spanwise profile")
+wakeviz.visualize_cut_plane(
+    horizontal_plane,
+    ax=ax_list[0],
+    label_contours=True,
+    title="Horizontal"
+)
+wakeviz.visualize_cut_plane(
+    y_plane,
+    ax=ax_list[1],
+    label_contours=True,
+    title="Streamwise profile"
+)
+wakeviz.visualize_cut_plane(
+    cross_plane,
+    ax=ax_list[2],
+    label_contours=True,
+    title="Spanwise profile"
+)
 
 # Some wake models may not yet have a visualization method included, for these cases can use
 # a slower version which scans a turbine model to produce the horizontal flow
-horizontal_plane_scan_turbine = calculate_horizontal_plane_with_turbines(
+horizontal_plane_scan_turbine = wakeviz.calculate_horizontal_plane_with_turbines(
     fi,
     x_resolution=20,
     y_resolution=10,
@@ -92,9 +103,10 @@ horizontal_plane_scan_turbine = calculate_horizontal_plane_with_turbines(
 )
 
 fig, ax = plt.subplots()
-visualize_cut_plane(
+wakeviz.visualize_cut_plane(
     horizontal_plane_scan_turbine,
     ax=ax,
+    label_contours=True,
     title="Horizontal (coarse turbine scan method)",
 )
 

--- a/examples/16_heterogeneous_inflow.py
+++ b/examples/16_heterogeneous_inflow.py
@@ -70,17 +70,30 @@ cross_plane_2d = fi_2d.calculate_cross_plane(
 # Create the plots
 fig, ax_list = plt.subplots(3, 1, figsize=(10, 8))
 ax_list = ax_list.flatten()
-visualize_cut_plane(horizontal_plane_2d, ax=ax_list[0], title="Horizontal", color_bar=True)
+visualize_cut_plane(
+    horizontal_plane_2d,
+    ax=ax_list[0],
+    title="Horizontal",
+    color_bar=True,
+    label_contours=True
+)
 ax_list[0].set_xlabel('x')
 ax_list[0].set_ylabel('y')
-visualize_cut_plane(y_plane_2d, ax=ax_list[1], title="Streamwise profile", color_bar=True)
+visualize_cut_plane(
+    y_plane_2d,
+    ax=ax_list[1],
+    title="Streamwise profile",
+    color_bar=True,
+    label_contours=True
+)
 ax_list[1].set_xlabel('x')
 ax_list[1].set_ylabel('z')
 visualize_cut_plane(
     cross_plane_2d,
     ax=ax_list[2],
     title="Spanwise profile at 500m downstream",
-    color_bar=True
+    color_bar=True,
+    label_contours=True
 )
 ax_list[2].set_xlabel('y')
 ax_list[2].set_ylabel('z')
@@ -136,7 +149,8 @@ visualize_cut_plane(
     horizontal_plane_3d,
     ax=ax_list[0],
     title="Horizontal",
-    color_bar=True
+    color_bar=True,
+    label_contours=True
 )
 ax_list[0].set_xlabel('x')
 ax_list[0].set_ylabel('y')
@@ -144,7 +158,8 @@ visualize_cut_plane(
     y_plane_3d,
     ax=ax_list[1],
     title="Streamwise profile",
-    color_bar=True
+    color_bar=True,
+    label_contours=True
 )
 ax_list[1].set_xlabel('x')
 ax_list[1].set_ylabel('z')
@@ -152,7 +167,8 @@ visualize_cut_plane(
     cross_plane_3d,
     ax=ax_list[2],
     title="Spanwise profile at 500m downstream",
-    color_bar=True
+    color_bar=True,
+    label_contours=True
 )
 ax_list[2].set_xlabel('y')
 ax_list[2].set_ylabel('z')

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -151,7 +151,13 @@ def add_turbine_id_labels(fi: FlorisInterface, ax: plt.Axes, **kwargs):
         )
 
 
-def line_contour_cut_plane(cut_plane, ax=None, levels=None, colors=None, **kwargs):
+def line_contour_cut_plane(
+    cut_plane,
+    ax=None,
+    levels=None,
+    colors=None,
+    label_contours=False,
+    **kwargs):
     """
     Visualize a cut_plane as a line contour plot.
 
@@ -164,6 +170,8 @@ def line_contour_cut_plane(cut_plane, ax=None, levels=None, colors=None, **kwarg
             Defaults to None.
         colors (list, optional): Strings of color specification info.
             Defaults to None.
+        label_contours (Boolean, optional): Flag to include a numerical contour labels
+            on the plot. Defaults to False.
         **kwargs: Additional parameters to pass to `ax.contour`.
     """
 
@@ -183,7 +191,8 @@ def line_contour_cut_plane(cut_plane, ax=None, levels=None, colors=None, **kwarg
         **kwargs,
     )
 
-    ax.clabel(contours, contours.levels, inline=True, fontsize=10, colors="black")
+    if label_contours:
+        ax.clabel(contours, contours.levels, inline=True, fontsize=10, colors="black")
 
     # Make equal axis
     ax.set_aspect("equal")
@@ -199,6 +208,7 @@ def visualize_cut_plane(
     levels=None,
     clevels=None,
     color_bar=False,
+    label_contours=False,
     title="",
     **kwargs
 ):
@@ -224,6 +234,8 @@ def visualize_cut_plane(
             Defaults to None.
         color_bar (Boolean, optional): Flag to include a color bar on the plot.
             Defaults to False.
+        label_contours (Boolean, optional): Flag to include a numerical contour labels
+            on the plot. Defaults to False.
         title (str, optional): User-supplied title for the plot. Defaults to "".
         **kwargs: Additional parameters to pass to line contour plot.
 
@@ -275,6 +287,7 @@ def visualize_cut_plane(
         ax=ax,
         levels=levels,
         colors="b",
+        label_contours=label_contours,
         linewidths=0.8,
         alpha=0.3,
         **kwargs
@@ -307,6 +320,7 @@ def visualize_heterogeneous_cut_plane(
     levels=None,
     clevels=None,
     color_bar=False,
+    label_contours=False,
     title="",
     plot_het_bounds=True,
     **kwargs
@@ -334,6 +348,8 @@ def visualize_heterogeneous_cut_plane(
             Defaults to None.
         color_bar (Boolean, optional): Flag to include a color bar on the plot.
             Defaults to False.
+        label_contours (Boolean, optional): Flag to include a numerical contour labels
+            on the plot. Defaults to False.
         title (str, optional): User-supplied title for the plot. Defaults to "".
         plot_het_bonds (boolean, optional): Flag to include the user-defined bounds of the
             heterogeneous wind speed area. Defaults to True.
@@ -386,6 +402,7 @@ def visualize_heterogeneous_cut_plane(
         ax=ax,
         levels=levels,
         colors="b",
+        label_contours=label_contours,
         linewidths=0.8,
         alpha=0.3,
         **kwargs


### PR DESCRIPTION
## Description

The flow visualization tools were hardcoded to plot numerical labels on the flow contour plots. This PR makes that an optional choice at the top level in the `visualize_cut_plane()` and `visualize_heterogeneous_cut_plane()` functions of tools/visualization.py, which are passed through to the mid-level function `line_contour_cut_plane()`.

I have set the default value of the new `label_contours` Boolean to False, as I believe that most users will not want the contour labels shown. However, I've now updated examples 02_visualizations.py and 16_heterogeneous_inflow.py so that `label_contours` is set to True for those examples. I have left the default value (False) in other examples involving flow plots.

## Other notes
- No changes are made to source code
- Output from most examples involving flow contour plots has changed, as the contour labels are now largely gone. The exceptions are 02 and 16, where I have reincluded the contour labels.
- The function `visualize_heterogeneous_cut_plane()` of tools/visualization.py does not appear to be called anywhere in the floris code or examples, and may be redundant. However, I have not confirmed this and have left the function in place.
- Tests pass.

## Examples
Running 02_visualizations.py with `label_contours = True` produces 
![image](https://github.com/NREL/floris/assets/39596329/21b8d807-bcfb-46a6-a965-4f091137a42c)

while setting `label_contours = False` produces
![image](https://github.com/NREL/floris/assets/39596329/1f4e9d8f-4d43-484b-9b9e-dbc8429eb123)

