### PR TITLE
Support relative paths in YAML configuration files

### DIFF
--- a/.github/workflows/check-working-examples.yaml
+++ b/.github/workflows/check-working-examples.yaml
@@ -48,27 +48,6 @@ jobs:
           fi
         done
 
-        # Run all Jupyter notebooks
-        for i in *.ipynb; do
-
-          # Convert this notebook to a Python script
-          if ! jupyter nbconvert --to script $i; then
-            # On conversion error, report and go to the next notebook
-            error_results="${error_results}"$'\n'" - Error converting ${i} to Python script"
-            continue
-          fi
-
-          # Get the basename of the notebook since the converted script will have the same basename
-          script_name=`basename $i .ipynb`
-
-          # Run the converted script
-          if ! python "${script_name}.py"; then
-            error_results="${error_results}"$'\n'" - ${i}"
-            error_found=1
-          fi
-
-        done
-
         if [[ $error_found ]]; then
           echo "${error_results}"
         fi

--- a/examples/18_check_turbine.py
+++ b/examples/18_check_turbine.py
@@ -13,7 +13,7 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import os
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -38,12 +38,13 @@ fi.reinitialize(layout_x=[0], layout_y=[0])
 # Apply wind speeds
 fi.reinitialize(wind_speeds=ws_array)
 
-# Get a list of available turbine models
-turbines = os.listdir('../floris/turbine_library')
-turbines = [t for t in turbines if 'yaml' in t]
-turbines = [t.strip('.yaml') for t in turbines]
-# Remove multi-dimensional Cp/Ct turbine definitions as they require different handling
-turbines = [i for i in turbines if ('multi_dim' not in i)]
+# Get a list of available turbine models provided through FLORIS, and remove
+# multi-dimensional Cp/Ct turbine definitions as they require different handling
+turbines = [
+    t.stem
+    for t in fi.floris.farm.internal_turbine_library.iterdir()
+    if t.suffix == ".yaml" and ("multi_dim" not in t.stem)
+]
 
 # Declare a set of figures for comparing cp and ct across models
 fig_cp_ct, axarr_cp_ct = plt.subplots(2,1,sharex=True,figsize=(10,10))

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -52,6 +52,18 @@ class Farm(BaseClass):
     Wake, FlowField) and packages everything into the appropriate data
     type. Farm should also be used as an entry point to probe objects
     for generating output.
+
+    Args:
+        layout_x (NDArrayFloat): A sequence of x-axis locations for the turbines that can be
+            converted to a 1-D :py:obj:`numpy.ndarray`.
+        layout_y (NDArrayFloat): A sequence of y-axis locations for the turbines that can be
+            converted to a 1-D :py:obj:`numpy.ndarray`.
+        turbine_type (list[dict | str]): A list of turbine definition dictionaries, or string
+            references to the filename of the turbine type in either the FLORIS-provided turbine
+            library (.../floris/turbine_library/), or a user-provided
+            :py:attr:`turbine_library_path`.
+        turbine_library_path (:obj:`str`): Either an absolute file path to the turbine library, or a
+            path relative to the file that is running the analysis.
     """
 
     layout_x: NDArrayFloat = field(converter=floris_array_converter)
@@ -97,6 +109,8 @@ class Farm(BaseClass):
     correct_cp_ct_for_tilt: NDArrayFloat = field(init=False, default=[])
     correct_cp_ct_for_tilt_sorted: NDArrayFloat = field(init=False, default=[])
 
+    interal_turbine_library: Path = field(init=False, default=default_turbine_library_path)
+
     def __attrs_post_init__(self) -> None:
         # Turbine definitions can be supplied in three ways:
         # - A string selecting a turbine in the floris turbine library
@@ -128,7 +142,7 @@ class Farm(BaseClass):
                     continue
 
                 # Check if the file exists in the internal and/or external library
-                internal_fn = (default_turbine_library_path / t).with_suffix(".yaml")
+                internal_fn = (self.interal_turbine_library / t).with_suffix(".yaml")
                 external_fn = (self.turbine_library_path / t).with_suffix(".yaml")
                 in_internal = internal_fn.exists()
                 in_external = external_fn.exists()
@@ -248,8 +262,9 @@ class Farm(BaseClass):
         )
 
     def construct_turbine_map(self):
-        if 'multi_dimensional_cp_ct' in self.turbine_definitions[0].keys() \
-            and self.turbine_definitions[0]['multi_dimensional_cp_ct'] is True:
+        multi_key = "multi_dimensional_cp_ct"
+        if multi_key in self.turbine_definitions[0] and self.turbine_definitions[0][multi_key]:
+            # TODO: Need to load this with the turbine library location
             self.turbine_map = [
                 TurbineMultiDimensional.from_dict(turb) for turb in self.turbine_definitions
             ]

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -109,7 +109,7 @@ class Farm(BaseClass):
     correct_cp_ct_for_tilt: NDArrayFloat = field(init=False, default=[])
     correct_cp_ct_for_tilt_sorted: NDArrayFloat = field(init=False, default=[])
 
-    interal_turbine_library: Path = field(init=False, default=default_turbine_library_path)
+    internal_turbine_library: Path = field(init=False, default=default_turbine_library_path)
 
     def __attrs_post_init__(self) -> None:
         # Turbine definitions can be supplied in three ways:
@@ -142,7 +142,7 @@ class Farm(BaseClass):
                     continue
 
                 # Check if the file exists in the internal and/or external library
-                internal_fn = (self.interal_turbine_library / t).with_suffix(".yaml")
+                internal_fn = (self.internal_turbine_library / t).with_suffix(".yaml")
                 external_fn = (self.turbine_library_path / t).with_suffix(".yaml")
                 in_internal = internal_fn.exists()
                 in_external = external_fn.exists()
@@ -267,7 +267,7 @@ class Farm(BaseClass):
             self.turbine_map = []
             for turb in self.turbine_definitions:
                 try:
-                    _turb = {**turb, **{"turbine_library_path": self.interal_turbine_library}}
+                    _turb = {**turb, **{"turbine_library_path": self.internal_turbine_library}}
                     self.turbine_map.append(TurbineMultiDimensional.from_dict(_turb))
                 except FileNotFoundError:
                     _turb = {**turb, **{"turbine_library_path": self.turbine_library_path}}

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -266,11 +266,11 @@ class Farm(BaseClass):
         if multi_key in self.turbine_definitions[0] and self.turbine_definitions[0][multi_key]:
             self.turbine_map = []
             for turb in self.turbine_definitions:
+                _turb = {**turb, **{"turbine_library_path": self.internal_turbine_library}}
                 try:
-                    _turb = {**turb, **{"turbine_library_path": self.internal_turbine_library}}
                     self.turbine_map.append(TurbineMultiDimensional.from_dict(_turb))
                 except FileNotFoundError:
-                    _turb = {**turb, **{"turbine_library_path": self.turbine_library_path}}
+                    _turb["turbine_library_path"] = self.turbine_library_path
                     self.turbine_map.append(TurbineMultiDimensional.from_dict(_turb))
         else:
             self.turbine_map = [Turbine.from_dict(turb) for turb in self.turbine_definitions]

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -264,10 +264,14 @@ class Farm(BaseClass):
     def construct_turbine_map(self):
         multi_key = "multi_dimensional_cp_ct"
         if multi_key in self.turbine_definitions[0] and self.turbine_definitions[0][multi_key]:
-            # TODO: Need to load this with the turbine library location
-            self.turbine_map = [
-                TurbineMultiDimensional.from_dict(turb) for turb in self.turbine_definitions
-            ]
+            self.turbine_map = []
+            for turb in self.turbine_definitions:
+                try:
+                    _turb = {**turb, **{"turbine_library_path": self.interal_turbine_library}}
+                    self.turbine_map.append(TurbineMultiDimensional.from_dict(_turb))
+                except FileNotFoundError:
+                    _turb = {**turb, **{"turbine_library_path": self.turbine_library_path}}
+                    self.turbine_map.append(TurbineMultiDimensional.from_dict(_turb))
         else:
             self.turbine_map = [Turbine.from_dict(turb) for turb in self.turbine_definitions]
 

--- a/floris/simulation/turbine_multi_dim.py
+++ b/floris/simulation/turbine_multi_dim.py
@@ -424,6 +424,15 @@ class TurbineMultiDimensional(Turbine):
             the width/height of the grid of points on the rotor as a ratio of
             the rotor radius.
             Defaults to 0.5.
+        power_thrust_data_file (:py:obj:`str`): The path and name of the file containing the
+            multidimensional power thrust curve. The path may be an absolute location or a relative
+            path to where FLORIS is being run.
+        multi_dimensional_cp_ct (:py:obj:`bool`, optional): Indicates if the turbine definition is
+            single dimensional (False) or multidimensional (True).
+        turbine_library_path (:py:obj:`pathlib.Path`, optional): The
+            :py:attr:`Farm.turbine_library_path` or :py:attr:`Farm.internal_turbine_library_path`,
+            whichever is being used to load turbine definitions.
+            Defaults to the current file location.
     """
     power_thrust_data_file: str = field(default=None)
     multi_dimensional_cp_ct: bool = field(default=False)

--- a/floris/simulation/turbine_multi_dim.py
+++ b/floris/simulation/turbine_multi_dim.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Iterable
+from pathlib import Path
 
+import attrs
 import numpy as np
 import pandas as pd
 from attrs import define, field
@@ -423,9 +425,12 @@ class TurbineMultiDimensional(Turbine):
             the rotor radius.
             Defaults to 0.5.
     """
-
     power_thrust_data_file: str = field(default=None)
     multi_dimensional_cp_ct: bool = field(default=False)
+    turbine_library_path: Path = field(
+        default=Path(".").resolve(),
+        validator=attrs.validators.instance_of(Path)
+    )
 
     # rloc: float = float_attrib()  # TODO: goes here or on the Grid?
     # use_points_on_perimeter: bool = bool_attrib()
@@ -447,6 +452,10 @@ class TurbineMultiDimensional(Turbine):
     #     self.use_points_on_perimeter = False
 
     def __attrs_post_init__(self) -> None:
+        # Solidify the data file path and name
+        self.power_thrust_data_file = (
+            self.turbine_library_path / self.power_thrust_data_file
+        ).resolve()
 
         # Read in the multi-dimensional data supplied by the user.
         df = pd.read_csv(self.power_thrust_data_file)

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 
 import numpy as np
@@ -55,7 +56,16 @@ class FlorisInterface(LoggerBase):
         self.configuration = configuration
 
         if isinstance(self.configuration, (str, Path)):
-            self.floris = Floris.from_file(self.configuration)
+            try:
+                self.floris = Floris.from_file(self.configuration)
+            except FileNotFoundError:
+                # If the file cannot be found, then attempt the configuration path relative to the
+                # file location from which FlorisInterface was attempted to be run. If successful,
+                # update self.configuration to an aboslute, working file path and name.
+                base_fn = Path(inspect.stack()[-1].filename).resolve().parent
+                config = (base_fn / self.configuration).resolve()
+                self.floris = Floris.from_file(config)
+                self.configuration = config
 
         elif isinstance(self.configuration, dict):
             self.floris = Floris.from_dict(self.configuration)

--- a/floris/turbine_library/iea_15MW_floating_multi_dim_cp_ct.yaml
+++ b/floris/turbine_library/iea_15MW_floating_multi_dim_cp_ct.yaml
@@ -8,7 +8,7 @@ TSR: 8.0
 ref_density_cp_ct: 1.225
 ref_tilt_cp_ct: 6.0
 multi_dimensional_cp_ct: True
-power_thrust_data_file: '../floris/turbine_library/iea_15MW_multi_dim_Tp_Hs.csv'
+power_thrust_data_file: 'iea_15MW_multi_dim_Tp_Hs.csv'
 floating_tilt_table:
   tilt:
     - 5.747296314800103


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Enable Relative File Paths in YAML Configurations
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This PR enables users to successfully define relative paths in 3 locations:
- `FlorisInterface` configuration file. The configuration file will now attempt to be located as-is and as a path relative to the file being run, so users can run `python examples/30_multi_dimensional_cp_ct.py` or `cd examples && python 30_multi_dimensional_cp_ct.py` with the same results
- `Farm.turbine_library_path` takes a similar route, but will attempt three locations:
  - The file path as-is
  - The file path relative to the location where the FLORIS script is located
  - The file path relative to the system location that is attempting to run FLORIS (this applies primarily to testing or internal applications)
- `TurbineMultiDimensional` now has an input for a turbine library path so that the `power_thrust_data_file` can attempted to be found at either the location or originally provided or a path relative to where FLORIS is being run.

This PR also addresses some docstring ambiguity as it relates to the above implementation.

## Related issue
<!--
-->
From #604, a better solution is needed for handling user's configurations where they are, and this is often as relative paths, including in our examples, which is what this PR is solving.

This PR should close #737 as it resolves the relative path definition of the multidimensional Cp-Ct curve, and completes one of the remaining tasks in #733.

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
-->
- `floris.type_dec.convert_to_path`: A three-pronged search for the path is performed, and the adds a validation step, so nonexistent file paths are found earlier.
- `floris.simulation.farm.Farm`:
  - arguments have been added to the docstring.
  - `internal_turbine_library_path` is added to provide a namespace for the module's `__default_library_path`
  - `turbine_library_path`: is now either matching the internal or mapped to 1 of 2 file path locations (see above).
- `floris.tools.FlorisInterface`: enables relative file paths to in the configuration definition, and updates the internal mapping, if that is the case.
- `floris/simulation.turbine_multi_dim.TurbineMultiDimensional`:
  - Arguments have been added to the docstring to provide clarity
  - `turbine_library_path` has been added as an argument, which is passed from the `Farm` class on initialization, to indicate where the `power_thrust_data_file` will be located. 
  - `power_thrust_data_file` should no longer point directly to where it is located, but should be in relation to the FLORIS turbine library, or in a user-provided turbine library. This change will promote adherence to consistent data library usage.


## Additional supporting information
<!--
Add any other context about the problem here.
-->
How to effectively manage relative file definitions in YAML has been a lingering issue since the introduction of the turbine library, and this enhancement should work towards a more rigorous Turbine Library by providing some necessary patches to unconsidered use cases.

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->
All tests pass, and all CI tests pass as a result, demonstrating that this successfully addresses #737, while leaving room to build a more robust turbine library per #604.

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
