### PR TITLE
Use compatible-release specifier for dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,20 +29,20 @@ REQUIRES_PYTHON = ">=3.8.0"
 # What packages are required for this module to be executed?
 REQUIRED = [
     # simulation
-    "attrs",
-    "pyyaml",
-    "numexpr",
-    "numpy>=1.20",
-    "scipy>=1.1",
+    "attrs~=23.1",
+    "pyyaml~=6.0",
+    "numexpr~=2.8",
+    "numpy~=1.20",
+    "scipy~=1.1",
 
     # tools
-    "matplotlib>=3",
-    "pandas",
-    "shapely",
+    "matplotlib~=3.8",
+    "pandas~=2.1",
+    "shapely~=2.0",
 
     # utilities
-    "coloredlogs>=10.0",
-    "flatten_dict",
+    "coloredlogs~=10.0",
+    "flatten_dict~0.4",
 ]
 
 # What packages are optional?

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ REQUIRED = [
 
     # utilities
     "coloredlogs~=10.0",
-    "flatten_dict~0.4",
+    "flatten_dict~=0.4",
 ]
 
 # What packages are optional?

--- a/setup.py
+++ b/setup.py
@@ -29,20 +29,20 @@ REQUIRES_PYTHON = ">=3.8.0"
 # What packages are required for this module to be executed?
 REQUIRED = [
     # simulation
-    "attrs~=23.1",
+    "attrs",
     "pyyaml~=6.0",
-    "numexpr~=2.8",
+    "numexpr~=2.0",
     "numpy~=1.20",
     "scipy~=1.1",
 
     # tools
-    "matplotlib~=3.8",
-    "pandas~=2.1",
+    "matplotlib~=3.0",
+    "pandas~=2.0",
     "shapely~=2.0",
 
     # utilities
     "coloredlogs~=10.0",
-    "flatten_dict~=0.4",
+    "flatten_dict~=0.0",
 ]
 
 # What packages are optional?


### PR DESCRIPTION
# Use compatible release specifiers for dependency versions

This pull request adds version specifications for the dependencies with the [compatible release specifier](https://packaging.python.org/en/latest/specifications/version-specifiers/#compatible-release). The change uses the latest release of each dependent version of the requirement without incrementing a major version which in [semantic versioning](https://semver.org) could include breaking changes.

From the docs:
> For a given release identifier V.N, the compatible release clause is approximately equivalent to the pair of comparison clauses:
    >= V.N, == V.*

Some examples from the docs:

```
~= 2.2                     # <- this line is approximately equivalent
>= 2.2, == 2.*         # <- to this line

~= 1.4.5                   # <- this line is approximately equivalent
>= 1.4.5, == 1.4.*.    # <- to this line
```

More concretely, if we say `numpy~=1.20`, it means that FLORIS requires Numpy to be at least v1.20 and any other larger v1 is valid but not v2.

## Related issue
Closes #745 

## Impacted areas of the software
setup.py and the dependencies chosen during installation

@kflemin 
