### PR TITLE
Fix path dependency in `convert_to_path` test

### DIFF
--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -85,7 +85,7 @@ def iter_validator(iter_type, item_types: Union[Any, Tuple[Any]]) -> Callable:
     return validator
 
 def convert_to_path(fn: str | Path) -> Path:
-    """Converts an input string or pathlib.Path object to a fully resolved ``pathlib.Path``
+    """Converts an input string or ``pathlib.Path`` object to a fully resolved ``pathlib.Path``
     object.
 
     Args:
@@ -113,11 +113,11 @@ def convert_to_path(fn: str | Path) -> Path:
         absolute_fn = fn.resolve()
         relative_fn_script = (base_fn_script / fn).resolve()
         relative_fn_sys = (base_fn_sys / fn).resolve()
-        if absolute_fn.is_dir():
+        if absolute_fn.exists():
             return absolute_fn
-        if relative_fn_script.is_dir():
+        if relative_fn_script.exists():
             return relative_fn_script
-        if relative_fn_sys.is_dir():
+        if relative_fn_sys.exists():
             return relative_fn_sys
         raise FileExistsError(
             f"{fn} could not be found as either a\n"

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -85,8 +85,12 @@ def iter_validator(iter_type, item_types: Union[Any, Tuple[Any]]) -> Callable:
     return validator
 
 def convert_to_path(fn: str | Path) -> Path:
-    """Converts an input string or ``pathlib.Path`` object to a fully resolved ``pathlib.Path``
-    object.
+    """
+    Converts an input string or ``pathlib.Path`` object to a fully resolved ``pathlib.Path``
+    object. If the input is a string, it is converted to a pathlib.Path object.
+    The function then checks if the path exists as an absolute path, a relative path from
+    the script, or a relative path from the system location. If the path does not exist in
+    any of these locations, a FileExistsError is raised.
 
     Args:
         fn (str | Path): The user input file path or file name.

--- a/tests/type_dec_unit_test.py
+++ b/tests/type_dec_unit_test.py
@@ -151,6 +151,11 @@ def test_convert_to_path():
     test_abs_path = convert_to_path(abs_path)
     assert test_abs_path == expected_path
 
+    # Test a file
+    file_input = Path(__file__)
+    test_file = convert_to_path(file_input)
+    assert test_file == file_input
+
     # Test that a non-existent folder fails, now that the conversion has a multi-pronged search
     str_input = str(Path(__file__).parent / "tests")
     with pytest.raises(FileExistsError):

--- a/tests/type_dec_unit_test.py
+++ b/tests/type_dec_unit_test.py
@@ -143,10 +143,10 @@ def test_convert_to_path():
     # Test that both of those inputs are the same
     assert test_str_input == test_path_input
 
-    # Test that a non-existent folder also works even though it's a valid data type
-    str_input = "tests"
-    test_str_input = convert_to_path(str_input)
-    assert isinstance(test_str_input, Path)
+    # Test that a non-existent folder fails, now that the conversion has a multi-pronged search
+    str_input = str(Path(__file__).parent / "tests")
+    with pytest.raises(FileExistsError):
+        convert_to_path(str_input)
 
     # Test that invalid data types fail
     with pytest.raises(TypeError):

--- a/tests/type_dec_unit_test.py
+++ b/tests/type_dec_unit_test.py
@@ -157,7 +157,7 @@ def test_convert_to_path():
     assert test_file == file_input
 
     # Test that a non-existent folder fails, now that the conversion has a multi-pronged search
-    str_input = str(Path(__file__).parent / "tests")
+    str_input = str(Path(__file__).parent / "bad_path")
     with pytest.raises(FileExistsError):
         convert_to_path(str_input)
 

--- a/tests/type_dec_unit_test.py
+++ b/tests/type_dec_unit_test.py
@@ -130,18 +130,26 @@ def test_attrs_array_converter():
 
 
 def test_convert_to_path():
-    # Test that a string works
     str_input = "../tests"
+    expected_path = (Path(__file__).parent / str_input).resolve()
+
+    # Test that a string works
     test_str_input = convert_to_path(str_input)
-    assert isinstance(test_str_input, Path)
+    assert test_str_input == expected_path
 
     # Test that a pathlib.Path works
-    path_input = Path("../tests")
+    path_input = Path(str_input)
     test_path_input = convert_to_path(path_input)
-    assert isinstance(test_path_input, Path)
+    assert test_path_input == expected_path
 
     # Test that both of those inputs are the same
+    # NOTE These first three asserts tests the relative path search
     assert test_str_input == test_path_input
+
+    # Test absolute path
+    abs_path = expected_path
+    test_abs_path = convert_to_path(abs_path)
+    assert test_abs_path == expected_path
 
     # Test that a non-existent folder fails, now that the conversion has a multi-pronged search
     str_input = str(Path(__file__).parent / "tests")


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Fix Minor Test Issue in `convert_to_path`
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This PR addresses an error that's raised in `type_dec_unit_test.py:test_convert_to_path` when run from within the "tests" folder, as opposed to from the "floris" directory. As a result of #739, `convert_to_path` attempts to validate three separate path relationships to return a path that exists, or fails, so the updated unit test now reflects that usage, and checks for a `FileExistsError` in `floris/tests/tests/` regardless of where `pytest` is invoked.

## Related issue
<!--
If one exists, link to a related GitHub Issue.
-->
N/A

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
-->
- `type_dec_unit_test.py:test_convert_to_path`: Updated the third subtest to reflect the updated logic of `convert_to_path`

## Additional supporting information
<!--
Add any other context about the problem here.
-->
N/A

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->
All tests pass, regardless of where pytest is run from.

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
