### PR TITLE
Fix the turbine.power function unit test

### DIFF
--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -228,7 +228,7 @@ def power(
 
     Args:
         ref_density_cp_cts (NDArrayFloat[wd, ws, turbines]): The reference density for each turbine
-        rotor_effective_velocities (NDArrayFloat[wd, ws, turbines, grid1, grid2]): The rotor
+        rotor_effective_velocities (NDArrayFloat[wd, ws, turbines]): The rotor
             effective velocities at a turbine.
         power_interp (NDArrayObject[wd, ws, turbines]): The power interpolation function
             for each turbine.

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -304,31 +304,26 @@ def test_ct():
 
 
 def test_power():
-
-    # Test that power is computed as expected for a single turbine
-    N_TURBINES = 1
     AIR_DENSITY = 1.225
 
+    # Test that power is computed as expected for a single turbine
+    n_turbines = 1
+    wind_speed = 10.0
     turbine_data = SampleInputs().turbine
     turbine = Turbine.from_dict(turbine_data)
-    turbine_type_map = np.array(N_TURBINES * [turbine.turbine_type])
+    turbine_type_map = np.array(n_turbines * [turbine.turbine_type])
     turbine_type_map = turbine_type_map[None, None, :]
-
-    # Use wind speed = 10.
-    wind_speed = 10.0
-
-    # Compute power using the power function
-    p = power(
+    test_power = power(
         ref_density_cp_ct=AIR_DENSITY,
         rotor_effective_velocities=wind_speed * np.ones((1, 1, 1)),
         power_interp={turbine.turbine_type: turbine.power_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
 
-    # Recompute using the original provided cp table
+    # Recompute using the provided Cp table
     truth_index = turbine_data["power_thrust_table"]["wind_speed"].index(wind_speed)
     cp_truth = turbine_data["power_thrust_table"]["power"][truth_index]
-    power_truth = (
+    baseline_power = (
         0.5
         * AIR_DENSITY
         * turbine.rotor_area
@@ -336,72 +331,63 @@ def test_power():
         * turbine.generator_efficiency
         * wind_speed ** 3
     )
-    np.testing.assert_allclose(p,power_truth )
+    assert np.allclose(baseline_power, test_power)
 
 
-    # Test that above rated wind speeds, the power should be very close to 5MW
-    # this is because the test turbine used is the NREL 5MW reference turbine
+    # At rated, the power calculated should be 5MW since the test data is the NREL 5MW turbine
     wind_speed = 18.0
-
-    p = power(
+    rated_power = power(
         ref_density_cp_ct=AIR_DENSITY,
         rotor_effective_velocities=wind_speed * np.ones((1, 1, 1)),
         power_interp={turbine.turbine_type: turbine.power_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
+    assert np.allclose(rated_power, 5e6)
 
-    np.testing.assert_allclose(p,5E6,1.0 )
 
-    # Test that near 0 wind speeds, the power should be near 0
-    wind_speed = 0.1
-
-    p = power(
+    # At wind speed = 0.0, the power should be 0 based on the provided Cp curve
+    wind_speed = 0.0
+    zero_power = power(
         ref_density_cp_ct=AIR_DENSITY,
         rotor_effective_velocities=wind_speed * np.ones((1, 1, 1)),
         power_interp={turbine.turbine_type: turbine.power_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
+    assert np.allclose(zero_power, 0.0)
 
-    np.testing.assert_allclose(p,0.0,1.0 )
 
-
-    # Test the vectorized version with multiple turbines
-    N_TURBINES = 4
+    # Test 4-turbine velocities array
+    n_turbines = 4
+    wind_speed = 10.0
     turbine_data = SampleInputs().turbine
     turbine = Turbine.from_dict(turbine_data)
-    turbine_type_map = np.array(N_TURBINES * [turbine.turbine_type])
+    turbine_type_map = np.array(n_turbines * [turbine.turbine_type])
     turbine_type_map = turbine_type_map[None, None, :]
-
-    wind_speed = 10.0
-
-    # Compute power using the power function
-    p = power(
+    test_4_power = power(
         ref_density_cp_ct=AIR_DENSITY,
-        rotor_effective_velocities=wind_speed * np.ones((1, 1, 1)),
+        rotor_effective_velocities=wind_speed * np.ones((1, 1, n_turbines)),
         power_interp={turbine.turbine_type: turbine.power_interp},
-        turbine_type_map=turbine_type_map[:,:,0]
+        turbine_type_map=turbine_type_map
     )
+    baseline_4_power = baseline_power * np.ones((1, 1, n_turbines))
+    assert np.allclose(baseline_4_power, test_4_power)
+    assert np.shape(baseline_4_power) == np.shape(test_4_power)
 
-    np.testing.assert_allclose(p,power_truth )
 
-    # Test with the grid dimension included
-    N_TURBINES = 4
+    # Same as above but with the grid expanded in the velocities array
     turbine_data = SampleInputs().turbine
     turbine = Turbine.from_dict(turbine_data)
-    turbine_type_map = np.array(N_TURBINES * [turbine.turbine_type])
+    turbine_type_map = np.array(n_turbines * [turbine.turbine_type])
     turbine_type_map = turbine_type_map[None, None, :]
-
-    wind_speed = 10.0
-
-    # Compute power using the power function
-    p = power(
+    test_grid_power = power(
         ref_density_cp_ct=AIR_DENSITY,
-        rotor_effective_velocities=wind_speed * np.ones((1, 1, 1, 3, 3)),
+        rotor_effective_velocities=wind_speed * np.ones((1, 1, n_turbines, 3, 3)),
         power_interp={turbine.turbine_type: turbine.power_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
-
-    np.testing.assert_allclose(p,power_truth )
+    baseline_grid_power = baseline_power * np.ones((1, 1, n_turbines, 3, 3))
+    assert np.allclose(baseline_grid_power, test_grid_power)
+    assert np.shape(baseline_grid_power) == np.shape(test_grid_power)
 
 
 def test_axial_induction():

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -13,7 +13,6 @@
 # See https://floris.readthedocs.io for documentation
 
 
-import attr
 import numpy as np
 import pytest
 from scipy.interpolate import interp1d
@@ -331,7 +330,7 @@ def test_power():
         * turbine.generator_efficiency
         * wind_speed ** 3
     )
-    assert np.allclose(baseline_power, test_power)
+    np.testing.assert_allclose(baseline_power, test_power)
 
 
     # At rated, the power calculated should be 5MW since the test data is the NREL 5MW turbine
@@ -342,7 +341,7 @@ def test_power():
         power_interp={turbine.turbine_type: turbine.power_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
-    assert np.allclose(rated_power, 5e6)
+    np.testing.assert_allclose(rated_power, 5e6)
 
 
     # At wind speed = 0.0, the power should be 0 based on the provided Cp curve
@@ -353,7 +352,7 @@ def test_power():
         power_interp={turbine.turbine_type: turbine.power_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
-    assert np.allclose(zero_power, 0.0)
+    np.testing.assert_allclose(zero_power, 0.0)
 
 
     # Test 4-turbine velocities array
@@ -370,7 +369,7 @@ def test_power():
         turbine_type_map=turbine_type_map
     )
     baseline_4_power = baseline_power * np.ones((1, 1, n_turbines))
-    assert np.allclose(baseline_4_power, test_4_power)
+    np.testing.assert_allclose(baseline_4_power, test_4_power)
     assert np.shape(baseline_4_power) == np.shape(test_4_power)
 
 
@@ -386,7 +385,7 @@ def test_power():
         turbine_type_map=turbine_type_map[:,:,0]
     )
     baseline_grid_power = baseline_power * np.ones((1, 1, n_turbines, 3, 3))
-    assert np.allclose(baseline_grid_power, test_grid_power)
+    np.testing.assert_allclose(baseline_grid_power, test_grid_power)
     assert np.shape(baseline_grid_power) == np.shape(test_grid_power)
 
 

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -340,6 +340,7 @@ def test_power():
 
 
     # Test that above rated wind speeds, the power should be very close to 5MW
+    # this is because the test turbine used is the NREL 5MW reference turbine
     wind_speed = 18.0
 
     p = power(
@@ -349,7 +350,7 @@ def test_power():
         turbine_type_map=turbine_type_map[:,:,0]
     )
 
-    np.testing.assert_allclose(p,5E6,10.0 )
+    np.testing.assert_allclose(p,5E6,1.0 )
 
     # Test that near 0 wind speeds, the power should be near 0
     wind_speed = 0.1
@@ -361,9 +362,46 @@ def test_power():
         turbine_type_map=turbine_type_map[:,:,0]
     )
 
-    np.testing.assert_allclose(p,0.0,10.0 )
+    np.testing.assert_allclose(p,0.0,1.0 )
 
 
+    # Test the vectorized version with multiple turbines
+    N_TURBINES = 4
+    turbine_data = SampleInputs().turbine
+    turbine = Turbine.from_dict(turbine_data)
+    turbine_type_map = np.array(N_TURBINES * [turbine.turbine_type])
+    turbine_type_map = turbine_type_map[None, None, :]
+
+    wind_speed = 10.0
+
+    # Compute power using the power function
+    p = power(
+        ref_density_cp_ct=AIR_DENSITY,
+        rotor_effective_velocities=wind_speed * np.ones((1, 1, 1)),
+        power_interp={turbine.turbine_type: turbine.power_interp},
+        turbine_type_map=turbine_type_map[:,:,0]
+    )
+
+    np.testing.assert_allclose(p,power_truth )
+
+    # Test with the grid dimension included
+    N_TURBINES = 4
+    turbine_data = SampleInputs().turbine
+    turbine = Turbine.from_dict(turbine_data)
+    turbine_type_map = np.array(N_TURBINES * [turbine.turbine_type])
+    turbine_type_map = turbine_type_map[None, None, :]
+
+    wind_speed = 10.0
+
+    # Compute power using the power function
+    p = power(
+        ref_density_cp_ct=AIR_DENSITY,
+        rotor_effective_velocities=wind_speed * np.ones((1, 1, 1, 3, 3)),
+        power_interp={turbine.turbine_type: turbine.power_interp},
+        turbine_type_map=turbine_type_map[:,:,0]
+    )
+
+    np.testing.assert_allclose(p,power_truth )
 
 
 def test_axial_induction():

--- a/tests/turbine_unit_test.py
+++ b/tests/turbine_unit_test.py
@@ -13,6 +13,7 @@
 # See https://floris.readthedocs.io for documentation
 
 
+import attr
 import numpy as np
 import pytest
 from scipy.interpolate import interp1d
@@ -330,7 +331,7 @@ def test_power():
         * turbine.generator_efficiency
         * wind_speed ** 3
     )
-    np.testing.assert_allclose(baseline_power, test_power)
+    assert np.allclose(baseline_power, test_power)
 
 
     # At rated, the power calculated should be 5MW since the test data is the NREL 5MW turbine
@@ -341,7 +342,7 @@ def test_power():
         power_interp={turbine.turbine_type: turbine.power_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
-    np.testing.assert_allclose(rated_power, 5e6)
+    assert np.allclose(rated_power, 5e6)
 
 
     # At wind speed = 0.0, the power should be 0 based on the provided Cp curve
@@ -352,7 +353,7 @@ def test_power():
         power_interp={turbine.turbine_type: turbine.power_interp},
         turbine_type_map=turbine_type_map[:,:,0]
     )
-    np.testing.assert_allclose(zero_power, 0.0)
+    assert np.allclose(zero_power, 0.0)
 
 
     # Test 4-turbine velocities array
@@ -369,7 +370,7 @@ def test_power():
         turbine_type_map=turbine_type_map
     )
     baseline_4_power = baseline_power * np.ones((1, 1, n_turbines))
-    np.testing.assert_allclose(baseline_4_power, test_4_power)
+    assert np.allclose(baseline_4_power, test_4_power)
     assert np.shape(baseline_4_power) == np.shape(test_4_power)
 
 
@@ -385,7 +386,7 @@ def test_power():
         turbine_type_map=turbine_type_map[:,:,0]
     )
     baseline_grid_power = baseline_power * np.ones((1, 1, n_turbines, 3, 3))
-    np.testing.assert_allclose(baseline_grid_power, test_grid_power)
+    assert np.allclose(baseline_grid_power, test_grid_power)
     assert np.shape(baseline_grid_power) == np.shape(test_grid_power)
 
 


### PR DESCRIPTION
# Fix the power unit test

The unit test of the power() function in turbine.py, test_power() in turbine_unit_test.py contained several errors which were masked by the fact that the tolerance value passed assert_allclose() function was very large.  This pull request fixes these issues.  Specifically:

  - Previously, the cp_interp function was passed to power, yielding a cp value multiplied by air_density.  However, this is not expected.  get_turbine_powers() in floris_interface.py passes self.floris.farm.turbine_power_interps, which are in W.  Correcting this yields a p, and a power_truth both in W
  - The "truth" calculation of p was missing the air density term
  - The new test compares the successfully with a very small, default tolerance.
  - Added to the unit test are checks that in high wind speeds the power is 5MW (since the test case is the reference 5MW turbine) and at near 0 wind speeds, power should be close to 0
  - Both the test_function, and the doc-string for power implied that rotor_effective_velocities should be 5D (including the last 2 dimensions for grid).  However, since these are rotor-averaged quantities they should be only 3D, and this pull request fixes that in the test, and in the doc-string of power() (it was not necessary to change the code)
 - Finally, a block of commented out code in turbine_unit_test.py was deleted

## Impacted areas of the software
turbine.py
turbine_unit_test.py
