### PR TITLE
Fix issue with mutable default attributes

### DIFF
--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -81,10 +81,10 @@ class Farm(BaseClass):
 
     turbine_definitions: list = field(init=False, validator=iter_validator(list, dict))
 
-    turbine_fCts: Dict[str, interp1d] | List[interp1d] = field(init=False, default=[])
-    turbine_fCts_sorted: NDArrayFloat = field(init=False, default=[])
+    turbine_fCts: Dict[str, interp1d] | List[interp1d] = field(init=False, factory=list)
+    turbine_fCts_sorted: NDArrayFloat = field(init=False, factory=list)
 
-    turbine_fTilts: list = field(init=False, default=[])
+    turbine_fTilts: list = field(init=False, factory=list)
 
     yaw_angles: NDArrayFloat = field(init=False)
     yaw_angles_sorted: NDArrayFloat = field(init=False)
@@ -93,36 +93,36 @@ class Farm(BaseClass):
     tilt_angles_sorted: NDArrayFloat = field(init=False)
 
     hub_heights: NDArrayFloat = field(init=False)
-    hub_heights_sorted: NDArrayFloat = field(init=False, default=[])
+    hub_heights_sorted: NDArrayFloat = field(init=False, factory=list)
 
-    turbine_map: List[Turbine | TurbineMultiDimensional] = field(init=False, default=[])
+    turbine_map: List[Turbine | TurbineMultiDimensional] = field(init=False, factory=list)
 
-    turbine_type_map: NDArrayObject = field(init=False, default=[])
-    turbine_type_map_sorted: NDArrayObject = field(init=False, default=[])
+    turbine_type_map: NDArrayObject = field(init=False, factory=list)
+    turbine_type_map_sorted: NDArrayObject = field(init=False, factory=list)
 
-    turbine_power_interps: Dict[str, interp1d] | List[interp1d] = field(init=False, default=[])
-    turbine_power_interps_sorted: NDArrayFloat = field(init=False, default=[])
+    turbine_power_interps: Dict[str, interp1d] | List[interp1d] = field(init=False, factory=list)
+    turbine_power_interps_sorted: NDArrayFloat = field(init=False, factory=list)
 
-    rotor_diameters: NDArrayFloat = field(init=False, default=[])
-    rotor_diameters_sorted: NDArrayFloat = field(init=False, default=[])
+    rotor_diameters: NDArrayFloat = field(init=False, factory=list)
+    rotor_diameters_sorted: NDArrayFloat = field(init=False, factory=list)
 
-    TSRs: NDArrayFloat = field(init=False, default=[])
-    TSRs_sorted: NDArrayFloat = field(init=False, default=[])
+    TSRs: NDArrayFloat = field(init=False, factory=list)
+    TSRs_sorted: NDArrayFloat = field(init=False, factory=list)
 
-    pPs: NDArrayFloat = field(init=False, default=[])
-    pPs_sorted: NDArrayFloat = field(init=False, default=[])
+    pPs: NDArrayFloat = field(init=False, factory=list)
+    pPs_sorted: NDArrayFloat = field(init=False, factory=list)
 
-    pTs: NDArrayFloat = field(init=False, default=[])
-    pTs_sorted: NDArrayFloat = field(init=False, default=[])
+    pTs: NDArrayFloat = field(init=False, factory=list)
+    pTs_sorted: NDArrayFloat = field(init=False, factory=list)
 
-    ref_density_cp_cts: NDArrayFloat = field(init=False, default=[])
-    ref_density_cp_cts_sorted: NDArrayFloat = field(init=False, default=[])
+    ref_density_cp_cts: NDArrayFloat = field(init=False, factory=list)
+    ref_density_cp_cts_sorted: NDArrayFloat = field(init=False, factory=list)
 
-    ref_tilt_cp_cts: NDArrayFloat = field(init=False, default=[])
-    ref_tilt_cp_cts_sorted: NDArrayFloat = field(init=False, default=[])
+    ref_tilt_cp_cts: NDArrayFloat = field(init=False, factory=list)
+    ref_tilt_cp_cts_sorted: NDArrayFloat = field(init=False, factory=list)
 
-    correct_cp_ct_for_tilt: NDArrayFloat = field(init=False, default=[])
-    correct_cp_ct_for_tilt_sorted: NDArrayFloat = field(init=False, default=[])
+    correct_cp_ct_for_tilt: NDArrayFloat = field(init=False, factory=list)
+    correct_cp_ct_for_tilt_sorted: NDArrayFloat = field(init=False, factory=list)
 
     internal_turbine_library: Path = field(init=False, default=default_turbine_library_path)
 

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -48,21 +48,23 @@ class FlowField(BaseClass):
     n_wind_speeds: int = field(init=False)
     n_wind_directions: int = field(init=False)
 
-    u_initial_sorted: NDArrayFloat = field(init=False, default=np.array([]))
-    v_initial_sorted: NDArrayFloat = field(init=False, default=np.array([]))
-    w_initial_sorted: NDArrayFloat = field(init=False, default=np.array([]))
-    u_sorted: NDArrayFloat = field(init=False, default=np.array([]))
-    v_sorted: NDArrayFloat = field(init=False, default=np.array([]))
-    w_sorted: NDArrayFloat = field(init=False, default=np.array([]))
-    u: NDArrayFloat = field(init=False, default=np.array([]))
-    v: NDArrayFloat = field(init=False, default=np.array([]))
-    w: NDArrayFloat = field(init=False, default=np.array([]))
+    u_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    v_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    w_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    u_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    v_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    w_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    u: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    v: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    w: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
     het_map: list = field(init=False, default=None)
-    dudz_initial_sorted: NDArrayFloat = field(init=False, default=np.array([]))
+    dudz_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
 
-    turbulence_intensity_field: NDArrayFloat = field(init=False, default=np.array([]))
-    turbulence_intensity_field_sorted: NDArrayFloat = field(init=False, default=np.array([]))
-    turbulence_intensity_field_sorted_avg: NDArrayFloat = field(init=False, default=np.array([]))
+    turbulence_intensity_field: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    turbulence_intensity_field_sorted: NDArrayFloat = field(init=False,
+                                                            factory=lambda: np.array([]))
+    turbulence_intensity_field_sorted_avg: NDArrayFloat = field(init=False,
+                                                                factory=lambda: np.array([]))
 
     @wind_speeds.validator
     def wind_speeds_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -61,10 +61,12 @@ class FlowField(BaseClass):
     dudz_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
 
     turbulence_intensity_field: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    turbulence_intensity_field_sorted: NDArrayFloat = field(init=False,
-                                                            factory=lambda: np.array([]))
-    turbulence_intensity_field_sorted_avg: NDArrayFloat = field(init=False,
-                                                                factory=lambda: np.array([]))
+    turbulence_intensity_field_sorted: NDArrayFloat = field(
+        init=False, factory=lambda: np.array([])
+    )
+    turbulence_intensity_field_sorted_avg: NDArrayFloat = field(
+        init=False, factory=lambda: np.array([])
+    )
 
     @wind_speeds.validator
     def wind_speeds_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:

--- a/floris/simulation/turbine.py
+++ b/floris/simulation/turbine.py
@@ -472,9 +472,9 @@ class PowerThrustTable(FromDictMixin):
         ValueError: Raised if the power, thrust, and wind_speed are not all 1-d array-like shapes.
         ValueError: Raised if power, thrust, and wind_speed don't have the same number of values.
     """
-    power: NDArrayFloat = field(default=[], converter=floris_array_converter)
-    thrust: NDArrayFloat = field(default=[], converter=floris_array_converter)
-    wind_speed: NDArrayFloat = field(default=[], converter=floris_array_converter)
+    power: NDArrayFloat = field(factory=list, converter=floris_array_converter)
+    thrust: NDArrayFloat = field(factory=list, converter=floris_array_converter)
+    wind_speed: NDArrayFloat = field(factory=list, converter=floris_array_converter)
 
     def __attrs_post_init__(self) -> None:
         # Validate the power, thrust, and wind speed inputs.

--- a/floris/simulation/wake.py
+++ b/floris/simulation/wake.py
@@ -91,7 +91,7 @@ class WakeModelManager(BaseClass):
 
     wake_deflection_parameters: dict = field(converter=dict)
     wake_turbulence_parameters: dict = field(converter=dict)
-    wake_velocity_parameters: dict = field(converter=dict, default={})
+    wake_velocity_parameters: dict = field(converter=dict, factory=dict)
 
     combination_model: BaseModel = field(init=False)
     deflection_model: BaseModel = field(init=False)

--- a/floris/simulation/wake_velocity/empirical_gauss.py
+++ b/floris/simulation/wake_velocity/empirical_gauss.py
@@ -65,8 +65,8 @@ class EmpiricalGaussVelocityDeficit(BaseModel):
             :style: unsrt
             :filter: docname in docnames
     """
-    wake_expansion_rates: list = field(default=[0.023, 0.008])
-    breakpoints_D: list = field(default=[10])
+    wake_expansion_rates: list = field(factory=lambda: [0.023, 0.008])
+    breakpoints_D: list = field(factory=lambda: [10])
     sigma_0_D: float = field(default=0.28)
     smoothing_length_D: float = field(default=2.0)
     mixing_gain_velocity: float = field(default=2.0)

--- a/tests/type_dec_unit_test.py
+++ b/tests/type_dec_unit_test.py
@@ -39,11 +39,11 @@ class AttrsDemoClass(FromDictMixin):
         self.non_initd = 1.1
 
     liststr: List[str] = field(
-        default=["qwerty", "asdf"],
+        factory=lambda:["qwerty", "asdf"],
         validator=iter_validator(list, str)
     )
     array: np.ndarray = field(
-        default=[1.0, 2.0],
+        factory=lambda:[1.0, 2.0],
         converter=floris_array_converter,
         # validator=iter_validator(np.ndarray, floris_float_type)
     )

--- a/tests/type_dec_unit_test.py
+++ b/tests/type_dec_unit_test.py
@@ -63,8 +63,8 @@ def test_FromDictMixin_defaults():
     defaults = {a.name: a.default for a in AttrsDemoClass.__attrs_attrs__ if a.default}
     assert cls.y == defaults["y"]
     assert cls.z == defaults["z"]
-    np.testing.assert_array_equal(cls.liststr, defaults["liststr"])
-    np.testing.assert_array_equal(cls.array, defaults["array"])
+    np.testing.assert_array_equal(cls.liststr, defaults["liststr"].factory())
+    np.testing.assert_array_equal(cls.array, defaults["array"].factory())
 
     # Test that defaults can be overwritten
     inputs = {"w": 0, "x": 1, "y": 4.5}


### PR DESCRIPTION
# Fix issue with mutable default attributes

This pull request address the fact that if you use a list, dict, array or other mutable object as a default parameter in attrs (or more generally in function defaults), all instances of the declared object will point to the same list/dict/array, possibly generating confusing bugs.  See Issue #758 for more detail on the problem and proposed solution.

The approach used in this pull request was determined in Issue #758 and is also identified as the correct solution in the attrs documentation (https://www.attrs.org/en/stable/api-attr.html#attr.ib) (can see also a quick explanation here: https://refex.readthedocs.io/en/latest/guide/fixers/attrib_default.html), specifically to use a factory to generate a new list/dict/array, rather declaring a single instance.  The resulting changes all take the form of converting:

```
power: NDArrayFloat = field(default=[], converter=floris_array_converter)
```

to:

```
power: NDArrayFloat = field(factory=list, converter=floris_array_converter)
```
For empty lists, while using a lambda for empty numpy arrays:

```
w_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
```

## Related issue
Closes #758

## Impacted areas of the software
farm.py
turbine.py
flow_field.py
wake.py
empirical_gauss.py



## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->