### PR TITLE
Enhancement: Add a Dimension Validator for 5-D and 3-D Array Structures

### DIFF
--- a/floris/simulation/base.py
+++ b/floris/simulation/base.py
@@ -33,7 +33,7 @@ from attrs import (
 )
 
 from floris.logging_manager import LoggingManager
-from floris.type_dec import FromDictMixin
+from floris.type_dec import FromDictMixin, ValidateMixin
 
 
 class State(Enum):
@@ -43,7 +43,7 @@ class State(Enum):
 
 
 @define
-class BaseClass(FromDictMixin):
+class BaseClass(FromDictMixin, ValidateMixin):
     """
     BaseClass object class. This class does the logging and MixIn class inheritance.
     """

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -33,6 +33,7 @@ from floris.simulation import (
 )
 from floris.simulation.turbine import compute_tilt_angles_for_floating_turbines
 from floris.type_dec import (
+    array_3D_field,
     convert_to_path,
     floris_array_converter,
     iter_validator,
@@ -79,6 +80,9 @@ class Farm(BaseClass):
         default=default_turbine_library_path, converter=convert_to_path
     )
 
+    n_wind_directions: int = field(init=False)
+    n_wind_speeds: int = field(init=False)
+
     turbine_definitions: list = field(init=False, validator=iter_validator(list, dict))
 
     turbine_fCts: Dict[str, interp1d] | List[interp1d] = field(init=False, factory=list)
@@ -86,43 +90,43 @@ class Farm(BaseClass):
 
     turbine_fTilts: list = field(init=False, factory=list)
 
-    yaw_angles: NDArrayFloat = field(init=False)
-    yaw_angles_sorted: NDArrayFloat = field(init=False)
+    yaw_angles: NDArrayFloat = array_3D_field
+    yaw_angles_sorted: NDArrayFloat = array_3D_field
 
-    tilt_angles: NDArrayFloat = field(init=False)
-    tilt_angles_sorted: NDArrayFloat = field(init=False)
+    tilt_angles: NDArrayFloat = array_3D_field
+    tilt_angles_sorted: NDArrayFloat = array_3D_field
 
-    hub_heights: NDArrayFloat = field(init=False)
-    hub_heights_sorted: NDArrayFloat = field(init=False, factory=list)
+    hub_heights: NDArrayFloat = array_3D_field
+    hub_heights_sorted: NDArrayFloat = array_3D_field
 
     turbine_map: List[Turbine | TurbineMultiDimensional] = field(init=False, factory=list)
 
-    turbine_type_map: NDArrayObject = field(init=False, factory=list)
-    turbine_type_map_sorted: NDArrayObject = field(init=False, factory=list)
+    turbine_type_map: NDArrayObject = array_3D_field
+    turbine_type_map_sorted: NDArrayObject = array_3D_field
 
     turbine_power_interps: Dict[str, interp1d] | List[interp1d] = field(init=False, factory=list)
-    turbine_power_interps_sorted: NDArrayFloat = field(init=False, factory=list)
+    turbine_power_interps_sorted: NDArrayFloat = array_3D_field
 
-    rotor_diameters: NDArrayFloat = field(init=False, factory=list)
-    rotor_diameters_sorted: NDArrayFloat = field(init=False, factory=list)
+    rotor_diameters: NDArrayFloat = array_3D_field
+    rotor_diameters_sorted: NDArrayFloat = array_3D_field
 
-    TSRs: NDArrayFloat = field(init=False, factory=list)
-    TSRs_sorted: NDArrayFloat = field(init=False, factory=list)
+    TSRs: NDArrayFloat = array_3D_field
+    TSRs_sorted: NDArrayFloat = array_3D_field
 
-    pPs: NDArrayFloat = field(init=False, factory=list)
-    pPs_sorted: NDArrayFloat = field(init=False, factory=list)
+    pPs: NDArrayFloat = array_3D_field
+    pPs_sorted: NDArrayFloat = array_3D_field
 
-    pTs: NDArrayFloat = field(init=False, factory=list)
-    pTs_sorted: NDArrayFloat = field(init=False, factory=list)
+    pTs: NDArrayFloat = array_3D_field
+    pTs_sorted: NDArrayFloat = array_3D_field
 
-    ref_density_cp_cts: NDArrayFloat = field(init=False, factory=list)
-    ref_density_cp_cts_sorted: NDArrayFloat = field(init=False, factory=list)
+    ref_density_cp_cts: NDArrayFloat = array_3D_field
+    ref_density_cp_cts_sorted: NDArrayFloat = array_3D_field
 
-    ref_tilt_cp_cts: NDArrayFloat = field(init=False, factory=list)
-    ref_tilt_cp_cts_sorted: NDArrayFloat = field(init=False, factory=list)
+    ref_tilt_cp_cts: NDArrayFloat = array_3D_field
+    ref_tilt_cp_cts_sorted: NDArrayFloat = array_3D_field
 
-    correct_cp_ct_for_tilt: NDArrayFloat = field(init=False, factory=list)
-    correct_cp_ct_for_tilt_sorted: NDArrayFloat = field(init=False, factory=list)
+    correct_cp_ct_for_tilt: NDArrayFloat = array_3D_field
+    correct_cp_ct_for_tilt_sorted: NDArrayFloat = array_3D_field
 
     internal_turbine_library: Path = field(init=False, default=default_turbine_library_path)
 
@@ -405,6 +409,9 @@ class Farm(BaseClass):
         )
 
     def set_yaw_angles(self, n_wind_directions: int, n_wind_speeds: int):
+        self.n_wind_directions = n_wind_directions
+        self.n_wind_speeds = n_wind_speeds
+
         # TODO Is this just for initializing yaw angles to zero?
         self.yaw_angles = np.zeros((n_wind_directions, n_wind_speeds, self.n_turbines))
         self.yaw_angles_sorted = np.zeros((n_wind_directions, n_wind_speeds, self.n_turbines))

--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -86,7 +86,7 @@ class Farm(BaseClass):
     turbine_definitions: list = field(init=False, validator=iter_validator(list, dict))
 
     turbine_fCts: Dict[str, interp1d] | List[interp1d] = field(init=False, factory=list)
-    turbine_fCts_sorted: NDArrayFloat = field(init=False, factory=list)
+    turbine_fCts_sorted: NDArrayFloat = array_3D_field
 
     turbine_fTilts: list = field(init=False, factory=list)
 

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -29,11 +29,13 @@ from floris.simulation import (
 from floris.type_dec import (
     floris_array_converter,
     NDArrayFloat,
+    validate_3DArray_shape,
+    ValidateMixin,
 )
 
 
 @define
-class FlowField(BaseClass):
+class FlowField(BaseClass, ValidateMixin):
     wind_speeds: NDArrayFloat = field(converter=floris_array_converter)
     wind_directions: NDArrayFloat = field(converter=floris_array_converter)
     wind_veer: float = field(converter=float)

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -30,12 +30,11 @@ from floris.type_dec import (
     array_5D_field,
     floris_array_converter,
     NDArrayFloat,
-    ValidateMixin,
 )
 
 
 @define
-class FlowField(BaseClass, ValidateMixin):
+class FlowField(BaseClass):
     wind_speeds: NDArrayFloat = field(converter=floris_array_converter)
     wind_directions: NDArrayFloat = field(converter=floris_array_converter)
     wind_veer: float = field(converter=float)
@@ -47,8 +46,8 @@ class FlowField(BaseClass, ValidateMixin):
     heterogenous_inflow_config: dict = field(default=None)
     multidim_conditions: dict = field(default=None)
 
-    n_wind_speeds: int = field(init=False)
     n_wind_directions: int = field(init=False)
+    n_wind_speeds: int = field(init=False)
     n_turbines: int = field(init=False)
     grid_resolution: int = field(init=False)
 

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -28,6 +28,7 @@ from floris.simulation import (
 )
 from floris.type_dec import (
     array_5D_field,
+    array_mixed_dim_field,
     floris_array_converter,
     NDArrayFloat,
 )
@@ -61,15 +62,11 @@ class FlowField(BaseClass):
     v: NDArrayFloat = array_5D_field
     w: NDArrayFloat = array_5D_field
     het_map: list = field(init=False, default=None)
-    dudz_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    dudz_initial_sorted: NDArrayFloat = array_5D_field
 
-    turbulence_intensity_field: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    turbulence_intensity_field_sorted: NDArrayFloat = field(
-        init=False, factory=lambda: np.array([])
-    )
-    turbulence_intensity_field_sorted_avg: NDArrayFloat = field(
-        init=False, factory=lambda: np.array([])
-    )
+    turbulence_intensity_field: NDArrayFloat = array_mixed_dim_field
+    turbulence_intensity_field_sorted: NDArrayFloat = array_5D_field
+    turbulence_intensity_field_sorted_avg: NDArrayFloat = array_mixed_dim_field
 
     @wind_speeds.validator
     def wind_speeds_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -27,9 +27,9 @@ from floris.simulation import (
     Grid,
 )
 from floris.type_dec import (
+    array_5D_field,
     floris_array_converter,
     NDArrayFloat,
-    validate_3DArray_shape,
     ValidateMixin,
 )
 
@@ -49,16 +49,18 @@ class FlowField(BaseClass, ValidateMixin):
 
     n_wind_speeds: int = field(init=False)
     n_wind_directions: int = field(init=False)
+    n_turbines: int = field(init=False)
+    grid_resolution: int = field(init=False)
 
-    u_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    v_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    w_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    u_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    v_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    w_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    u: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    v: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
-    w: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
+    u_initial_sorted: NDArrayFloat = array_5D_field
+    v_initial_sorted: NDArrayFloat = array_5D_field
+    w_initial_sorted: NDArrayFloat = array_5D_field
+    u_sorted: NDArrayFloat = array_5D_field
+    v_sorted: NDArrayFloat = array_5D_field
+    w_sorted: NDArrayFloat = array_5D_field
+    u: NDArrayFloat = array_5D_field
+    v: NDArrayFloat = array_5D_field
+    w: NDArrayFloat = array_5D_field
     het_map: list = field(init=False, default=None)
     dudz_initial_sorted: NDArrayFloat = field(init=False, factory=lambda: np.array([]))
 
@@ -133,6 +135,9 @@ class FlowField(BaseClass, ValidateMixin):
         # determined by this line. Since the right-most dimension on grid.z is storing the values
         # for height, using it here to apply the shear law makes that dimension store the vertical
         # wind profile.
+        self.n_turbines = grid.n_turbines
+        self.grid_resolution = grid.grid_resolution
+
         wind_profile_plane = (grid.z_sorted / self.reference_wind_height) ** self.wind_shear
         dwind_profile_plane = (
             self.wind_shear

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -30,7 +30,6 @@ from floris.type_dec import (
     NDArrayInt,
     validate_3DArray_shape,
     validate_5DArray_shape,
-    ValidateMixin,
 )
 from floris.utilities import (
     reverse_rotate_coordinates_rel_west,
@@ -39,7 +38,7 @@ from floris.utilities import (
 
 
 @define
-class Grid(ABC, BaseClass, ValidateMixin):
+class Grid(ABC, BaseClass):
     """
     Grid should establish domain bounds based on given criteria,
     and develop three arrays to contain components of the grid
@@ -77,9 +76,9 @@ class Grid(ABC, BaseClass, ValidateMixin):
     time_series: bool = field()
     grid_resolution: int | Iterable = field()
 
-    n_turbines: int = field(init=False)
-    n_wind_speeds: int = field(init=False)
     n_wind_directions: int = field(init=False)
+    n_wind_speeds: int = field(init=False)
+    n_turbines: int = field(init=False)
     x_sorted: NDArrayFloat = field(init=False, validator=validate_5DArray_shape)
     y_sorted: NDArrayFloat = field(init=False, validator=validate_5DArray_shape)
     z_sorted: NDArrayFloat = field(init=False, validator=validate_5DArray_shape)

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -699,10 +699,10 @@ class PointsGrid(Grid):
     points_x: NDArrayFloat = field(converter=floris_array_converter)
     points_y: NDArrayFloat = field(converter=floris_array_converter)
     points_z: NDArrayFloat = field(converter=floris_array_converter)
-    x_center_of_rotation: float | None = field(
+    x_center_of_rotation: floris_float_type  | None = field(
         default=None, validator=attrs.validators.instance_of(floris_float_type)
     )
-    y_center_of_rotation: float | None = field(
+    y_center_of_rotation: floris_float_type | None = field(
         default=None, validator=attrs.validators.instance_of(floris_float_type)
     )
 

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -28,6 +28,7 @@ from floris.type_dec import (
     floris_float_type,
     NDArrayFloat,
     NDArrayInt,
+    validate_3DArray_shape,
     validate_5DArray_shape,
     ValidateMixin,
 )
@@ -153,11 +154,11 @@ class TurbineGrid(Grid):
             creates a 3x3 grid within the rotor swept area.
     """
     # TODO: describe these and the differences between `sorted_indices` and `sorted_coord_indices`
-    sorted_indices: NDArrayInt = field(init=False)
-    sorted_coord_indices: NDArrayInt = field(init=False)
-    unsorted_indices: NDArrayInt = field(init=False)
-    x_center_of_rotation: NDArrayFloat = field(init=False)
-    y_center_of_rotation: NDArrayFloat = field(init=False)
+    sorted_indices: NDArrayInt = field(init=False, validator=validate_5DArray_shape)
+    sorted_coord_indices: NDArrayInt = field(init=False, validator=validate_3DArray_shape)
+    unsorted_indices: NDArrayInt = field(init=False, validator=validate_5DArray_shape)
+    x_center_of_rotation: NDArrayFloat = field(init=False)  # TODO: this is a numpy float
+    y_center_of_rotation: NDArrayFloat = field(init=False)  # TODO: this is a numpy float
     average_method = "cubic-mean"
 
     def __attrs_post_init__(self) -> None:
@@ -313,9 +314,9 @@ class TurbineCubatureGrid(Grid):
             include in the cubature method. This value must be in the range [1, 10], and the
             corresponding cubature weights are set automatically.
     """
-    sorted_indices: NDArrayInt = field(init=False)
-    sorted_coord_indices: NDArrayInt = field(init=False)
-    unsorted_indices: NDArrayInt = field(init=False)
+    sorted_indices: NDArrayInt = field(init=False, validator=validate_5DArray_shape)
+    sorted_coord_indices: NDArrayInt = field(init=False, validator=validate_3DArray_shape)
+    unsorted_indices: NDArrayInt = field(init=False, validator=validate_5DArray_shape)
     x_center_of_rotation: NDArrayFloat = field(init=False)
     y_center_of_rotation: NDArrayFloat = field(init=False)
     average_method = "simple-cubature"
@@ -557,8 +558,8 @@ class FlowFieldPlanarGrid(Grid):
     x2_bounds: tuple = field(default=None)
     x_center_of_rotation: NDArrayFloat = field(init=False)
     y_center_of_rotation: NDArrayFloat = field(init=False)
-    sorted_indices: NDArrayInt = field(init=False)
-    unsorted_indices: NDArrayInt = field(init=False)
+    sorted_indices: NDArrayInt = field(init=False, validator=validate_3DArray_shape)
+    unsorted_indices: NDArrayInt = field(init=False, validator=validate_3DArray_shape)
 
     def __attrs_post_init__(self) -> None:
         self.set_grid()

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -28,6 +28,8 @@ from floris.type_dec import (
     floris_float_type,
     NDArrayFloat,
     NDArrayInt,
+    validate_5DArray_shape,
+    ValidateMixin,
 )
 from floris.utilities import (
     reverse_rotate_coordinates_rel_west,
@@ -36,7 +38,7 @@ from floris.utilities import (
 
 
 @define
-class Grid(ABC, BaseClass):
+class Grid(ABC, BaseClass, ValidateMixin):
     """
     Grid should establish domain bounds based on given criteria,
     and develop three arrays to contain components of the grid
@@ -77,12 +79,12 @@ class Grid(ABC, BaseClass):
     n_turbines: int = field(init=False)
     n_wind_speeds: int = field(init=False)
     n_wind_directions: int = field(init=False)
-    x_sorted: NDArrayFloat = field(init=False)
-    y_sorted: NDArrayFloat = field(init=False)
-    z_sorted: NDArrayFloat = field(init=False)
-    x_sorted_inertial_frame: NDArrayFloat = field(init=False)
-    y_sorted_inertial_frame: NDArrayFloat = field(init=False)
-    z_sorted_inertial_frame: NDArrayFloat = field(init=False)
+    x_sorted: NDArrayFloat = field(init=False, validator=validate_5DArray_shape)
+    y_sorted: NDArrayFloat = field(init=False, validator=validate_5DArray_shape)
+    z_sorted: NDArrayFloat = field(init=False, validator=validate_5DArray_shape)
+    x_sorted_inertial_frame: NDArrayFloat = field(init=False, validator=validate_5DArray_shape)
+    y_sorted_inertial_frame: NDArrayFloat = field(init=False, validator=validate_5DArray_shape)
+    z_sorted_inertial_frame: NDArrayFloat = field(init=False, validator=validate_5DArray_shape)
     cubature_weights: NDArrayFloat = field(init=False, default=None)
 
     @turbine_coordinates.validator

--- a/floris/simulation/grid.py
+++ b/floris/simulation/grid.py
@@ -157,8 +157,12 @@ class TurbineGrid(Grid):
     sorted_indices: NDArrayInt = field(init=False, validator=validate_5DArray_shape)
     sorted_coord_indices: NDArrayInt = field(init=False, validator=validate_3DArray_shape)
     unsorted_indices: NDArrayInt = field(init=False, validator=validate_5DArray_shape)
-    x_center_of_rotation: NDArrayFloat = field(init=False)  # TODO: this is a numpy float
-    y_center_of_rotation: NDArrayFloat = field(init=False)  # TODO: this is a numpy float
+    x_center_of_rotation: floris_float_type = field(
+        init=False, validator=attrs.validators.instance_of(floris_float_type)
+    )
+    y_center_of_rotation: floris_float_type = field(
+        init=False, validator=attrs.validators.instance_of(floris_float_type)
+        )
     average_method = "cubic-mean"
 
     def __attrs_post_init__(self) -> None:
@@ -317,8 +321,12 @@ class TurbineCubatureGrid(Grid):
     sorted_indices: NDArrayInt = field(init=False, validator=validate_5DArray_shape)
     sorted_coord_indices: NDArrayInt = field(init=False, validator=validate_3DArray_shape)
     unsorted_indices: NDArrayInt = field(init=False, validator=validate_5DArray_shape)
-    x_center_of_rotation: NDArrayFloat = field(init=False)
-    y_center_of_rotation: NDArrayFloat = field(init=False)
+    x_center_of_rotation: floris_float_type = field(
+        init=False, validator=attrs.validators.instance_of(floris_float_type)
+    )
+    y_center_of_rotation: floris_float_type = field(
+        init=False, validator=attrs.validators.instance_of(floris_float_type)
+    )
     average_method = "simple-cubature"
 
     def __attrs_post_init__(self) -> None:
@@ -478,8 +486,12 @@ class FlowFieldGrid(Grid):
         grid_resolution (:py:obj:`Iterable(int,)`): The number of grid points to create in each
             planar direction. Must be 3 components for resolution in the x, y, and z directions.
     """
-    x_center_of_rotation: NDArrayFloat = field(init=False)
-    y_center_of_rotation: NDArrayFloat = field(init=False)
+    x_center_of_rotation: floris_float_type = field(
+        init=False, validator=attrs.validators.instance_of(floris_float_type)
+    )
+    y_center_of_rotation: floris_float_type = field(
+        init=False, validator=attrs.validators.instance_of(floris_float_type)
+    )
 
     def __attrs_post_init__(self) -> None:
         self.set_grid()
@@ -556,8 +568,12 @@ class FlowFieldPlanarGrid(Grid):
     planar_coordinate: float = field()
     x1_bounds: tuple = field(default=None)
     x2_bounds: tuple = field(default=None)
-    x_center_of_rotation: NDArrayFloat = field(init=False)
-    y_center_of_rotation: NDArrayFloat = field(init=False)
+    x_center_of_rotation: floris_float_type = field(
+        init=False, validator=attrs.validators.instance_of(floris_float_type)
+    )
+    y_center_of_rotation: floris_float_type = field(
+        init=False, validator=attrs.validators.instance_of(floris_float_type)
+    )
     sorted_indices: NDArrayInt = field(init=False, validator=validate_3DArray_shape)
     unsorted_indices: NDArrayInt = field(init=False, validator=validate_3DArray_shape)
 
@@ -684,8 +700,12 @@ class PointsGrid(Grid):
     points_x: NDArrayFloat = field(converter=floris_array_converter)
     points_y: NDArrayFloat = field(converter=floris_array_converter)
     points_z: NDArrayFloat = field(converter=floris_array_converter)
-    x_center_of_rotation: float | None = field(default=None)
-    y_center_of_rotation: float | None = field(default=None)
+    x_center_of_rotation: float | None = field(
+        default=None, validator=attrs.validators.instance_of(floris_float_type)
+    )
+    y_center_of_rotation: float | None = field(
+        default=None, validator=attrs.validators.instance_of(floris_float_type)
+    )
 
     def __attrs_post_init__(self) -> None:
         self.set_grid()

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -28,7 +28,11 @@ from typing import (
 import attrs
 import numpy as np
 import numpy.typing as npt
-from attrs import Attribute, define
+from attrs import (
+    Attribute,
+    define,
+    field,
+)
 
 
 ### Define general data types used throughout
@@ -160,6 +164,10 @@ def validate_3DArray_shape(instance, attribute: Attribute, value: np.ndarray) ->
     if not isinstance(value, np.ndarray):
         raise TypeError(f"`{attribute.name}` is not a valid NumPy array type.")
 
+    # Don't fail on the initialized empty array
+    if value.size == 0:
+        return
+
     shape = (instance.n_wind_directions, instance.n_wind_speeds, instance.n_turbines)
     if value.shape != shape:
         # The grid sorted_coord_indices are broadcast along the wind speed dimension
@@ -187,6 +195,10 @@ def validate_5DArray_shape(instance, attribute: Attribute, value: np.ndarray) ->
     if not isinstance(value, np.ndarray):
         print(type(value))
         raise TypeError(f"`{attribute.name}` is not a valid NumPy array type.")
+
+    # Don't fail on the initialized empty array
+    if value.size == 0:
+        return
 
     grid = instance.grid_resolution
     shape = (instance.n_wind_directions, instance.n_wind_speeds, instance.n_turbines, grid, grid)
@@ -265,7 +277,10 @@ class ValidateMixin:
         attrs.validate(self)
 
 
-# Avoids constant redefinition of the same attr.ib properties for model attributes
+# Avoids constant redefinition of the same field properties for model attributes
+
+array_5D_field = field(init=False, factory=lambda: np.array([]), validator=validate_5DArray_shape)
+
 
 # from functools import partial, update_wrapper
 

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -40,7 +40,6 @@ NDArrayInt = npt.NDArray[np.int_]
 NDArrayFilter = Union[npt.NDArray[np.int_], npt.NDArray[np.bool_]]
 NDArrayObject = npt.NDArray[np.object_]
 NDArrayBool = npt.NDArray[np.bool_]
-NDArray = NDArrayFloat | NDArrayInt | NDArrayFilter | NDArrayObject | NDArrayBool
 
 
 ### Custom callables for attrs objects and functions
@@ -145,23 +144,48 @@ def convert_to_path(fn: str | Path) -> Path:
     raise TypeError(f"The passed input: {fn} could not be converted to a pathlib.Path object")
 
 
-def validate_3DArray_shape(instance, attribute: Attribute, value: NDArray) -> None:
-    if not isinstance(value, NDArray):
+def validate_3DArray_shape(instance, attribute: Attribute, value: np.ndarray) -> None:
+    """Validator that checks if the array's shape is N wind directions x N wind speeds x N turbines.
+
+    Args:
+        instance (cls): The class instance.
+        attribute (Attribute): The ``attrs.Attribute`` data.
+        value (np.ndarray): The input or updated NumPy array.
+
+    Raises:
+        TypeError: raised if :py:attr:`value` is not a NumPy array.
+        ValueError: raised if the shape of :py:attr:`value` is not
+            N wind directions x N wind speeds x N turbines.
+    """
+    if not isinstance(value, np.ndarray):
         raise TypeError(f"{attribute.name} is not a valid NumPy array type.")
 
     shape = (instance.n_wind_directions, instance.n_wind_speeds, instance.n_turbines)
     if value.shape != shape:
-        raise ValueError(f"{attribute.name} should have shape: {shape}")
+        raise ValueError(f"{attribute.name} should have shape: {shape}; not shape: {value.shape}")
 
 
-def validate_5DArray_shape(instance, attribute: Attribute, value: NDArray) -> None:
-    if not isinstance(value, NDArray):
+def validate_5DArray_shape(instance, attribute: Attribute, value: np.ndarray) -> None:
+    """Validator that checks if the array's shape is
+    N wind directions x N wind speeds x N turbines x N grid points x N grid points.
+
+    Args:
+        instance (cls): The class instance.
+        attribute (Attribute): The ``attrs.Attribute`` data.
+        value (np.ndarray): The input or updated NumPy array.
+
+    Raises:
+        TypeError: raised if :py:attr:`value` is not a NumPy array.
+        ValueError: raised if the shape of :py:attr:`value` is not
+            N wind directions x N wind speeds x N turbines x N grid points x N grid points.
+    """
+    if not isinstance(value, np.ndarray):
         raise TypeError(f"{attribute.name} is not a valid NumPy array type.")
 
     grid = instance.grid_resolution
     shape = (instance.n_wind_directions, instance.n_wind_speeds, instance.n_turbines, grid, grid)
     if value.shape != shape:
-        raise ValueError(f"{attribute.name} should have shape: {shape}")
+        raise ValueError(f"{attribute.name} should have shape: {shape}; not shape: {value.shape}")
 
 @define
 class FromDictMixin:

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -158,11 +158,16 @@ def validate_3DArray_shape(instance, attribute: Attribute, value: np.ndarray) ->
             N wind directions x N wind speeds x N turbines.
     """
     if not isinstance(value, np.ndarray):
-        raise TypeError(f"{attribute.name} is not a valid NumPy array type.")
+        raise TypeError(f"`{attribute.name}` is not a valid NumPy array type.")
 
     shape = (instance.n_wind_directions, instance.n_wind_speeds, instance.n_turbines)
     if value.shape != shape:
-        raise ValueError(f"{attribute.name} should have shape: {shape}; not shape: {value.shape}")
+        # The grid sorted_coord_indices are broadcast along the wind speed dimension
+        broadcast_shape = (instance.n_wind_directions, 1, instance.n_turbines)
+        if value.shape != broadcast_shape:
+            raise ValueError(
+                f"`{attribute.name}` should have shape: {shape}; not shape: {value.shape}"
+            )
 
 
 def validate_5DArray_shape(instance, attribute: Attribute, value: np.ndarray) -> None:
@@ -180,12 +185,13 @@ def validate_5DArray_shape(instance, attribute: Attribute, value: np.ndarray) ->
             N wind directions x N wind speeds x N turbines x N grid points x N grid points.
     """
     if not isinstance(value, np.ndarray):
-        raise TypeError(f"{attribute.name} is not a valid NumPy array type.")
+        print(type(value))
+        raise TypeError(f"`{attribute.name}` is not a valid NumPy array type.")
 
     grid = instance.grid_resolution
     shape = (instance.n_wind_directions, instance.n_wind_speeds, instance.n_turbines, grid, grid)
     if value.shape != shape:
-        raise ValueError(f"{attribute.name} should have shape: {shape}; not shape: {value.shape}")
+        raise ValueError(f"`{attribute.name}` should have shape: {shape}; not shape: {value.shape}")
 
 @define
 class FromDictMixin:

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -164,8 +164,8 @@ def validate_3DArray_shape(instance, attribute: Attribute, value: np.ndarray) ->
     if not isinstance(value, np.ndarray):
         raise TypeError(f"`{attribute.name}` is not a valid NumPy array type.")
 
-    # Don't fail on the initialized empty array
-    if value.size == 0:
+    # Don't fail on the initialized empty array or initialized 1-D array
+    if value.size == 0 or value.ndim == 1:
         return
 
     shape = (instance.n_wind_directions, instance.n_wind_speeds, instance.n_turbines)
@@ -279,6 +279,7 @@ class ValidateMixin:
 
 # Avoids constant redefinition of the same field properties for model attributes
 
+array_3D_field = field(init=False, factory=lambda: np.array([]), validator=validate_3DArray_shape)
 array_5D_field = field(init=False, factory=lambda: np.array([]), validator=validate_5DArray_shape)
 
 

--- a/tests/floris_unit_test.py
+++ b/tests/floris_unit_test.py
@@ -12,6 +12,7 @@
 # See https://floris.readthedocs.io for documentation
 
 
+from copy import deepcopy
 from pathlib import Path
 
 import yaml
@@ -49,7 +50,11 @@ def test_init():
 
 def test_asdict(turbine_grid_fixture: TurbineGrid):
 
-    floris = Floris.from_dict(DICT_INPUT)
+    grid_dict = deepcopy(DICT_INPUT)
+    grid_dict["flow_field"]["wind_speeds"] = turbine_grid_fixture.wind_speeds
+    grid_dict["flow_field"]["wind_directions"] = turbine_grid_fixture.wind_directions
+
+    floris = Floris.from_dict(grid_dict)
     floris.flow_field.initialize_velocity_field(turbine_grid_fixture)
     dict1 = floris.as_dict()
 

--- a/tests/type_dec_unit_test.py
+++ b/tests/type_dec_unit_test.py
@@ -159,16 +159,24 @@ def test_array_validators():
     # Check assignment with correct shape: 3 x 4 x 10 (x 3 x 3)
     demo.five_dimensions_provided = np.random.random((3, 4, 10, 3, 3))
     demo.three_dimensions_provided = np.random.random((3, 4, 10))
+    demo.mixed_dimensions_provided = np.random.random((3, 4, 10, 3, 3))
     demo.validate()
 
     # Check assignment with correct broadcatable shape: 3 x 4 x 10 x 1 x 1 or 3 x 1 x 10
     demo.five_dimensions_provided = np.random.random((3, 4, 10, 1, 1))
     demo.three_dimensions_provided = np.random.random((3, 1, 10))
+    demo.mixed_dimensions_provided = np.random.random((3, 1, 10))
     demo.validate()
 
     # Check for correct number of dimensions, but wrong shape
     with pytest.raises(ValueError):
         demo.five_dimensions_provided = np.random.random((3, 3, 3, 3, 3))
+
+    with pytest.raises(ValueError):
+        demo.mixed_dimensions_provided = np.random.random((4, 3, 10, 1, 1))
+
+    with pytest.raises(ValueError):
+        demo.mixed_dimensions_provided = np.random.random((4, 3, 10))
 
     with pytest.raises(ValueError):
         demo.three_dimensions_provided = np.random.random((3, 5, 10))


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Validate the Dimensions of 5-D and 3-D Arrays
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This PR adds new validation functionality for arrays that should adhere to dimensions requirements of N wind directions x N wind speeds x N turbines or N wind directions x N wind speeds x N turbines x N grid x N grid. An additional mixin class that wraps `attrs.validate(class_instance)` has been added to easily enable attrs class validators to be run at key points in a simulation.

## Related issue
<!--
If one exists, link to a related GitHub Issue.
-->
At least partially resolves #761 by using the `factory=lambda: np.array([])` paradigm to not build extensive carveouts for data that should only be valid at initialization.

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
-->
### `floris.type_dec.py`
- `validate_5DArray_shape` is an attrs validator checking the adherence to the shape being N wind directions x N wind speeds x N turbines x N grid x N grid, with the exception of empty arrays and those that can be broadcast along the grid axes.
- `validate_3DArray_shape` is an attrs validator checking the adherence to the shape being N wind directions x N wind speeds x N turbines, with the exception of empty arrays and those that can be broadcast along the wind speed axis.
- `validate_mixed_dim` runs the 5D, then 3D validation to check for the `turbulence_intensity` attributes that start as 5D, then are reduced to 3D.
- `array_3D_field` is a  custom field for defining a field with the 3D validator and lambda factory built in to reduce the number of multi-line attribute initializations.
- `array_5D_field` is a  custom field for defining a field with the 5D validator and lambda factory built into reduce the number of multi-line attribute initializations.
- `array_mixed_dim_field` is a  custom field for defining a field with the 3D/5D validator and lambda factory built into reduce the number of multi-line attribute initializations.
- `ValidateMixin` provides `self.validate()`, which is a wrapper for `attrs.validate(class_instance)` to easily run all validators in a class.

### `floris/simulation/base.py`
- `BaseClass`: now inherits `ValidateMixin`

### `floris/simulation/farm.py` and `floris/simulation/flow_field.py`
- Adopts the `array_3D_field`, `array_5D_field`, and `array_mixed_dim_field` as appropriate

### `floris/simulation/grid.py`
- Fixes some typing errors.
- Adopts the `array_3D_field` and `array_5D_field` where appropriate

### `floris/tests/floris_unit_test.py`
- Fixes a bug in creating a simulation object with incorrect wind speed and wind direction dimensions

### `floris/tests/type_dec_unit_test.py`
- Adds in a test for `ValidateMixin.validate()` and the new dimensions validators.

## Additional supporting information
<!--
Add any other context about the problem here.
-->
This largely stems from a conversation with @rafmudaf about questions of how to check if attributes are staying the same shape throughout a simulation, and adding methods to ensure the correctness of dimension sizes.

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->
Tests are passing with a slight modification to an existing test that was using incorrect dimensions.

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
