### PR TITLE
Add support for multiple turbine types in calculate_horizontal_plane_with_turbines()

### DIFF
--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -697,8 +697,8 @@ def calculate_horizontal_plane_with_turbines(
                 layout_x_test[-1] = x
                 layout_y_test[-1] = y
                 fi.reinitialize(
-                    layout_x=layout_x_test, 
-                    layout_y=layout_y_test, 
+                    layout_x=layout_x_test,
+                    layout_y=layout_y_test,
                     turbine_type=turbine_types_test
                 )
                 fi.calculate_wake(yaw_angles=yaw_angles)

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -663,7 +663,14 @@ def calculate_horizontal_plane_with_turbines(
         # Declare a new layout array with an extra turbine
         layout_x_test = np.append(layout_x,[0])
         layout_y_test = np.append(layout_y,[0])
-        turbine_types_test = np.append(turbine_types, 'nrel_5MW').tolist()
+
+        # Declare turbine types with an extra turbine in
+        # case of special one type useage
+        if len(layout_x) > 1 and len(turbine_types) == 1:
+            # Convert to list length len(layout_x) + 1
+            turbine_types_test = [turbine_types[0] for i in range(len(layout_x))] + ['nrel_5MW']
+        else:
+            turbine_types_test = np.append(turbine_types, 'nrel_5MW').tolist()
         yaw_angles = np.append(yaw_angles, np.zeros([len(wd), len(ws), 1]), axis=2)
 
         # Get a grid of points test test

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -657,11 +657,13 @@ def calculate_horizontal_plane_with_turbines(
         # Grab the turbine layout
         layout_x = copy.deepcopy(fi.layout_x)
         layout_y = copy.deepcopy(fi.layout_y)
+        turbine_types = copy.deepcopy(fi.floris.farm.turbine_type)
         D = fi.floris.farm.rotor_diameters_sorted[0, 0, 0]
 
         # Declare a new layout array with an extra turbine
         layout_x_test = np.append(layout_x,[0])
         layout_y_test = np.append(layout_y,[0])
+        turbine_types_test = np.append(turbine_types, 'nrel_5MW').tolist()
         yaw_angles = np.append(yaw_angles, np.zeros([len(wd), len(ws), 1]), axis=2)
 
         # Get a grid of points test test
@@ -694,7 +696,7 @@ def calculate_horizontal_plane_with_turbines(
                 # Place the test turbine at this location and calculate wake
                 layout_x_test[-1] = x
                 layout_y_test[-1] = y
-                fi.reinitialize(layout_x = layout_x_test, layout_y = layout_y_test)
+                fi.reinitialize(layout_x = layout_x_test, layout_y = layout_y_test, turbine_type = turbine_types_test)
                 fi.calculate_wake(yaw_angles=yaw_angles)
 
                 # Get the velocity of that test turbines central point

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -696,7 +696,11 @@ def calculate_horizontal_plane_with_turbines(
                 # Place the test turbine at this location and calculate wake
                 layout_x_test[-1] = x
                 layout_y_test[-1] = y
-                fi.reinitialize(layout_x = layout_x_test, layout_y = layout_y_test, turbine_type = turbine_types_test)
+                fi.reinitialize(
+                    layout_x=layout_x_test, 
+                    layout_y=layout_y_test, 
+                    turbine_type=turbine_types_test
+                )
                 fi.calculate_wake(yaw_angles=yaw_angles)
 
                 # Get the velocity of that test turbines central point


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Add support for multiple turbine types in calculate_horizontal_plane_with_turbines()
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
Function now copies turbine type list from input FlorisInterface and appends a `nrel_5MW` to ensure correct number of turbines in `fi.reinitialize()` calls.

## Related issue
<!--
-->
No related open issues.

## Impacted areas of the software
<!--
-->
floris.tools.visualization.py

## Additional supporting information
<!--
Add any other context about the problem here.
-->
Small modification to prevent `turbine_type must have the same number of entries as layout_x/layout_y or have a single turbine_type value` error when generating a CutPlane using `calculate_horizontal_plane_with_turbines()` with multiple turbine definitions. Previously the test turbine was left undefined leading to a potential mismatch between the layout arguments and number of turbines if `turbine_type` was specified in earlier reinitializations.

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
