### PR TITLE
Validate and test wind direction and wind speed

### DIFF
--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -79,8 +79,30 @@ class FlowField(BaseClass):
 
     @wind_directions.validator
     def wind_directions_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:
+        # Check that the array is 1-dimensional
+        if self.wind_directions.ndim != 1:
+            raise ValueError(
+                "wind_directions must have 1-dimension"
+            )
+
         """Using the validator method to keep the `n_findex` attribute up to date."""
         self.n_findex = value.size
+
+    @wind_speeds.validator
+    def wind_speeds_validator(self, instance: attrs.Attribute, value: NDArrayFloat) -> None:
+
+        # Check that the array is 1-dimensional
+        if self.wind_speeds.ndim != 1:
+            raise ValueError(
+                "wind_directions must have 1-dimension"
+            )
+
+        """Confirm wind speeds and wind directions have the same lenght"""
+        if len(self.wind_directions) != len(self.wind_speeds):
+            raise ValueError(
+                f"wind_directions (length = {len(self.wind_directions)}) and "
+                f"wind_speeds (length = {len(self.wind_speeds)}) must have the same length"
+            )
 
     @heterogenous_inflow_config.validator
     def heterogenous_config_validator(self, instance: attrs.Attribute, value: dict | None) -> None:

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -94,7 +94,7 @@ class FlowField(BaseClass):
         # Check that the array is 1-dimensional
         if self.wind_speeds.ndim != 1:
             raise ValueError(
-                "wind_directions must have 1-dimension"
+                "wind_speeds must have 1-dimension"
             )
 
         """Confirm wind speeds and wind directions have the same lenght"""

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -71,6 +71,12 @@ class FlowField(BaseClass):
         self, instance: attrs.Attribute, value: NDArrayFloat
     ) -> None:
 
+        # Check that the array is 1-dimensional
+        if value.ndim != 1:
+            raise ValueError(
+                "wind_directions must have 1-dimension"
+            )
+
         # Check the turbulence intensity is either length 1 or n_findex
         if len(value) != 1 and len(value) != self.n_findex:
             raise ValueError("turbulence_intensities should either be length 1 or n_findex")

--- a/tests/floris_interface_test.py
+++ b/tests/floris_interface_test.py
@@ -22,9 +22,6 @@ def test_reinitialize():
     with pytest.raises(ValueError):
         fi.reinitialize(layout_x=[0,1000,2000,3000], layout_y=[0, 0, 0])
 
-    # Initialize to 4 turbines
-    fi.reinitialize(layout_x=[0,1000,2000,3000], layout_y=[0, 0, 0, 0])
-
     # Test that passing in wind speeds and wind directions of different lenght raises an error
     with pytest.raises(ValueError):
         fi.reinitialize(wind_directions=[0,180],wind_speeds=[8,8,8, 8, 8])

--- a/tests/floris_interface_test.py
+++ b/tests/floris_interface_test.py
@@ -15,21 +15,6 @@ def test_read_yaml():
     assert isinstance(fi, FlorisInterface)
 
 
-def test_reinitialize():
-    fi = FlorisInterface(configuration=YAML_INPUT)
-
-    # Test that passing in layouts of different lengths raises an error
-    with pytest.raises(ValueError):
-        fi.reinitialize(layout_x=[0,1000,2000,3000], layout_y=[0, 0, 0])
-
-    # Test that passing in wind speeds and wind directions of different lenght raises an error
-    with pytest.raises(ValueError):
-        fi.reinitialize(wind_directions=[0,180],wind_speeds=[8, 8, 8, 8, 8])
-
-    # Test that passing in two many dimensions of wind direction raises an error
-    with pytest.raises(ValueError):
-        fi.reinitialize(wind_directions=np.ones((5,2)),wind_speeds=[8, 8, 8, 8, 8])
-
 
 def test_calculate_wake():
     """

--- a/tests/floris_interface_test.py
+++ b/tests/floris_interface_test.py
@@ -24,11 +24,11 @@ def test_reinitialize():
 
     # Test that passing in wind speeds and wind directions of different lenght raises an error
     with pytest.raises(ValueError):
-        fi.reinitialize(wind_directions=[0,180],wind_speeds=[8,8,8, 8, 8])
+        fi.reinitialize(wind_directions=[0,180],wind_speeds=[8, 8, 8, 8, 8])
 
     # Test that passing in two many dimensions of wind direction raises an error
     with pytest.raises(ValueError):
-        fi.reinitialize(wind_directions=np.ones((5,2)),wind_speeds=[8,8,8, 8, 8])
+        fi.reinitialize(wind_directions=np.ones((5,2)),wind_speeds=[8, 8, 8, 8, 8])
 
 
 def test_calculate_wake():

--- a/tests/floris_interface_test.py
+++ b/tests/floris_interface_test.py
@@ -29,7 +29,7 @@ def test_reinitialize():
     with pytest.raises(ValueError):
         fi.reinitialize(wind_directions=[0,180],wind_speeds=[8,8,8, 8, 8])
 
-    # Test that passing in different dimension of wind speed and direction raises an error
+    # Test that passing in two many dimensions of wind direction raises an error
     with pytest.raises(ValueError):
         fi.reinitialize(wind_directions=np.ones((5,2)),wind_speeds=[8,8,8, 8, 8])
 

--- a/tests/floris_interface_test.py
+++ b/tests/floris_interface_test.py
@@ -15,6 +15,25 @@ def test_read_yaml():
     assert isinstance(fi, FlorisInterface)
 
 
+def test_reinitialize():
+    fi = FlorisInterface(configuration=YAML_INPUT)
+
+    # Test that passing in layouts of different lengths raises an error
+    with pytest.raises(ValueError):
+        fi.reinitialize(layout_x=[0,1000,2000,3000], layout_y=[0, 0, 0])
+
+    # Initialize to 4 turbines
+    fi.reinitialize(layout_x=[0,1000,2000,3000], layout_y=[0, 0, 0, 0])
+
+    # Test that passing in wind speeds and wind directions of different lenght raises an error
+    with pytest.raises(ValueError):
+        fi.reinitialize(wind_directions=[0,180],wind_speeds=[8,8,8, 8, 8])
+
+    # Test that passing in different dimension of wind speed and direction raises an error
+    with pytest.raises(ValueError):
+        fi.reinitialize(wind_directions=np.ones((5,2)),wind_speeds=[8,8,8, 8, 8])
+
+
 def test_calculate_wake():
     """
     In FLORIS v3.2, running calculate_wake twice incorrectly set the yaw angles when the first time

--- a/tests/flow_field_unit_test.py
+++ b/tests/flow_field_unit_test.py
@@ -12,8 +12,8 @@
 
 # See https://floris.readthedocs.io for documentation
 
-
 import numpy as np
+import pytest
 
 from floris.simulation import FlowField, TurbineGrid
 from tests.conftest import N_FINDEX, N_TURBINES
@@ -58,6 +58,62 @@ def test_asdict(flow_field_fixture: FlowField, turbine_grid_fixture: TurbineGrid
     dict2 = new_ff.as_dict()
 
     assert dict1 == dict2
+
+def test_len_ws_equals_len_wd(flow_field_fixture: FlowField, turbine_grid_fixture: TurbineGrid):
+
+    flow_field_fixture.initialize_velocity_field(turbine_grid_fixture)
+    dict1 = flow_field_fixture.as_dict()
+
+    # Test that having the 3 equal in lenght raises no error
+    dict1['wind_directions'] = np.array([180, 180])
+    dict1['wind_speeds'] = np.array([5., 6.])
+    dict1['turbulence_intensities'] = np.array([175., 175.])
+
+    FlowField.from_dict(dict1)
+
+    # Set the wind speeds as a different length of wind directions and turbulence_intensities
+    # And confirm error raised
+    dict1['wind_directions'] = np.array([180, 180])
+    dict1['wind_speeds'] = np.array([5., 6., 7.])
+    dict1['turbulence_intensities'] = np.array([175., 175.])
+
+    with pytest.raises(ValueError):
+        FlowField.from_dict(dict1)
+
+    # Set the wind directions as a different length of wind speeds and turbulence_intensities
+    dict1['wind_directions'] = np.array([180, 180, 180.])
+    # And confirm error raised
+    dict1['wind_speeds'] = np.array([5., 6.])
+    dict1['turbulence_intensities'] = np.array([175., 175.])
+
+    with pytest.raises(ValueError):
+        FlowField.from_dict(dict1)
+
+def test_dim_ws_wd_ti(flow_field_fixture: FlowField, turbine_grid_fixture: TurbineGrid):
+
+    flow_field_fixture.initialize_velocity_field(turbine_grid_fixture)
+    dict1 = flow_field_fixture.as_dict()
+
+    # Test that having an extra dimension in wind_directions raises an error
+    with pytest.raises(ValueError):
+        dict1['wind_directions'] = np.array([[180, 180]])
+        dict1['wind_speeds'] = np.array([5., 6.])
+        dict1['turbulence_intensities'] = np.array([175., 175.])
+        FlowField.from_dict(dict1)
+
+    # Test that having an extra dimension in wind_speeds raises an error
+    with pytest.raises(ValueError):
+        dict1['wind_directions'] = np.array([180, 180])
+        dict1['wind_speeds'] = np.array([[5., 6.]])
+        dict1['turbulence_intensities'] = np.array([175., 175.])
+        FlowField.from_dict(dict1)
+
+    # Test that having an extra dimension in turbulence_intensities raises an error
+    with pytest.raises(ValueError):
+        dict1['wind_directions'] = np.array([180, 180])
+        dict1['wind_speeds'] = np.array([5., 6.])
+        dict1['turbulence_intensities'] = np.array([[175., 175.]])
+        FlowField.from_dict(dict1)
 
 
 def test_turbulence_intensities_to_n_findex(flow_field_fixture, turbine_grid_fixture):

--- a/tests/reg_tests/cumulative_curl_regression_test.py
+++ b/tests/reg_tests/cumulative_curl_regression_test.py
@@ -281,7 +281,7 @@ def test_regression_rotation(sample_inputs_fixture):
         5 * TURBINE_DIAMETER
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
-    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()

--- a/tests/reg_tests/empirical_gauss_regression_test.py
+++ b/tests/reg_tests/empirical_gauss_regression_test.py
@@ -255,7 +255,7 @@ def test_regression_rotation(sample_inputs_fixture):
         5 * TURBINE_DIAMETER
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
-    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()

--- a/tests/reg_tests/gauss_regression_test.py
+++ b/tests/reg_tests/gauss_regression_test.py
@@ -372,7 +372,7 @@ def test_regression_rotation(sample_inputs_fixture):
         5 * TURBINE_DIAMETER
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
-    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()

--- a/tests/reg_tests/jensen_jimenez_regression_test.py
+++ b/tests/reg_tests/jensen_jimenez_regression_test.py
@@ -223,7 +223,7 @@ def test_regression_rotation(sample_inputs_fixture):
         5 * TURBINE_DIAMETER
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
-    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()

--- a/tests/reg_tests/none_regression_test.py
+++ b/tests/reg_tests/none_regression_test.py
@@ -224,7 +224,7 @@ def test_regression_rotation(sample_inputs_fixture):
         5 * TURBINE_DIAMETER
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
-    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()

--- a/tests/reg_tests/turbopark_regression_test.py
+++ b/tests/reg_tests/turbopark_regression_test.py
@@ -226,7 +226,7 @@ def test_regression_rotation(sample_inputs_fixture):
         5 * TURBINE_DIAMETER
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
-    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()


### PR DESCRIPTION
# Validate and test wind direction and wind speed

In the development of #783, @misi9170 noticed that running this code:

```
fi.reinitialize(
    wind_directions=270 * np.ones_like(yaw_angles),
    wind_speeds=10.0 * np.ones_like(yaw_angles),
    turbine_type=[turbine_type]*2
)
```

Which has the wrong number of dimensions for wind speed and direction, produces an error related to turbulence intensity.  Experimenting with the code I found that, contrary to expectations, passing in wind directions and wind speeds of different length does not produce an error, instead f_index = len(wind_directions), which is confusing.  Then also, having extra dimensions in wd/ws does not immediately error, explaining the complicated errors later.

This pull request attempts to clarify the issue by:

1) Adding to the wind_direction validator a test that it is 1D
2) Add a wind_speed validator to test that it is 1D and the same length as wind_direction
(Note TI already had a validator/test comparing lengths)

These changes are made in flow_field.py so they will catch the same errors in reinitialize as above, but also different lengths of values in an input yaml

Finally:

3) Adds test to confirm that making these errors in reinitialize raises value errors.
4) Fixing regression test that didn't conform to this standard

## Impacted areas of the software
flow_field.py
tests/

