### PR TITLE
[BUGFIX] Correct condition when yaw_angles passed to TurboPark model

### DIFF
--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -986,7 +986,7 @@ def turbopark_solver(
 
         # Model calculations
         # NOTE: exponential
-        if not np.all(farm.yaw_angles_sorted):
+        if np.any(farm.yaw_angles_sorted):
             model_manager.deflection_model.logger.warning(
                 "WARNING: Deflection with the TurbOPark model has not been fully validated. "
                 "This is an initial implementation, and we advise you use at your own risk "
@@ -1195,9 +1195,6 @@ def empirical_gauss_solver(
         z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3))
         z_i = z_i[:, :, None, None]
 
-        flow_field.u_sorted[:, i:i+1]
-        flow_field.v_sorted[:, i:i+1]
-
         ct_i = thrust_coefficient(
             velocities=flow_field.u_sorted,
             air_density=flow_field.air_density,
@@ -1399,9 +1396,6 @@ def full_flow_empirical_gauss_solver(
         y_i = y_i[:, :, None, None]
         z_i = np.mean(turbine_grid.z_sorted[:, i:i+1], axis=(2,3))
         z_i = z_i[:, :, None, None]
-
-        turbine_grid_flow_field.u_sorted[:, i:i+1]
-        turbine_grid_flow_field.v_sorted[:, i:i+1]
 
         ct_i = thrust_coefficient(
             velocities=turbine_grid_flow_field.u_sorted,


### PR DESCRIPTION
When the TurboPark model was implemented, code was added to raise a warning if the user specified nonzero `yaw_angles`, because the deflection model has not been validated to work within TurboPark. However, it seems that there is a bug in that implementation, which in fact raises the error IF any of the `yaw_angles` ARE zero. This pull request changes the `if not np.all(farm.yaw_angles_sorted):` condition to `if np.any(farm.yaw_angles_sorted):`, which I believe recovers the intended operation.

Note that the condition is not only to raise a warning; it is also a flag on whether to run the deflection models. This means that, in the current implementation, _if none of the `yaw_angles` are zero, the deflection model does not run_, which is clearly not the expected behavior. However, this is not tested in the tests; only a mix of zero and nonzero yaw angles is tests, which runs the deflection model _due to the presence of zeros, rather than the presence of nonzero values_.

## Steps to recreate
To recreate the issue, run the following code (on the v4 branch, or the develop branch, or the main branch---this issue is not specified to v4):
```
import numpy as np
from floris.tools import FlorisInterface

fi = FlorisInterface("inputs/turbopark.yaml")
print(1)
fi.calculate_wake() # Raises warning
print(2)
fi.calculate_wake(yaw_angles=None) # Raises warning
print(3)
fi.calculate_wake(yaw_angles=np.zeros((1,3))) # Raises warning
print(4)
fi.calculate_wake(yaw_angles=np.array([[20, 10, 0]])) # Raises warning (due to 0)
print(5)
fi.calculate_wake(yaw_angles=np.array(([[20, 20, 20]]))) # No warning raised
```

## Expected behavior
Contrary to what the above code produces, I would expect 1), 2), and 3) to raise no warnings (as all zero `yaw_angles` are passed) and 4) and 5) to raise a warning (as nonzero yaw angles will mean the deflection model is run, which has not been validated). The change in this PR generates the expected behavior.

## Additional supporting information
As noted above, this bug is not specific to v4. I'm happy to submit a separate PR with a bugfix for v3 also, if desired.

I've also taken the opportunity to remove a couple of unused lines from the `emprical_gauss_solver()`. This is incidental.

## Test results, if applicable
No change to test results. Tests pass as deflection is only tested with a mix of zero and non-zero values, which results in running the deflection model in both cases.

