### PR TITLE
[BUGFIX] Raise warning if turbine_type passed without updating reference_wind_height

### DIFF
--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -298,6 +298,13 @@ class FlorisInterface(LoggingManager):
         if layout_y is not None:
             farm_dict["layout_y"] = layout_y
         if turbine_type is not None:
+            if reference_wind_height is None:
+                self.logger.warning(
+                    "turbine_type has been changed without specifying a new "
+                    +"reference_wind_height. reference_wind_height remains {0:.2f} m.".format(
+                        flow_field_dict["reference_wind_height"]
+                    )
+                )
             farm_dict["turbine_type"] = turbine_type
         if turbine_library_path is not None:
             farm_dict["turbine_library_path"] = turbine_library_path


### PR DESCRIPTION
Addresses #806 by raising a warning if `FlorisInterface.reinitialize()` is called with `turbine_type` specified and `reference_wind_height` unspecified. 

The following code
```
from floris.tools import FlorisInterface

# Initialization uses NREL 5MW model with 90m hub height
fi = FlorisInterface("inputs/gch.yaml")
print(fi.floris.flow_field.reference_wind_height)

# Changing the turbine type without specifying reference_wind_height
fi.reinitialize(turbine_type=["iea_15mw"]*len(fi.layout_x))
print(fi.floris.flow_field.reference_wind_height)

# Changing the turbine type and specifying reference_wind_height
fi.reinitialize(turbine_type=["iea_15mw"]*len(fi.layout_x), reference_wind_height=150.2)
print(fi.floris.flow_field.reference_wind_height)
```

now raises the following warning for the line `fi.reinitialize(turbine_type=["iea_15mw"]*len(fi.layout_x))`:

```
floris.tools.floris_interface.FlorisInterface WARNING turbine_type has been changed without specifying a new reference_wind_height. reference_wind_height remains 90.00 m.
```

This "bug" is not specified to v4, and a similar change could be made for v3. However, since it is simply raising a warning, that may not be necessary.


