### PR TITLE
[BUGFIX] Correct condition when yaw_angles passed to TurboPark model (version 3)

### DIFF
--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -965,7 +965,7 @@ def turbopark_solver(
 
         # Model calculations
         # NOTE: exponential
-        if not np.all(farm.yaw_angles_sorted):
+        if np.any(farm.yaw_angles_sorted):
             model_manager.deflection_model.logger.warning(
                 "WARNING: Deflection with the TurbOPark model has not been fully validated."
                 "This is an initial implementation, and we advise you use at your own risk"


### PR DESCRIPTION
Equivalent bugfix to #808 for FLORIS v3. See #808 for details

The example code to run is slightly different (due to the change from 5d to 4d arrays in v4, #764):
```
import numpy as np
from floris.tools import FlorisInterface

fi = FlorisInterface("inputs/turbopark.yaml")
print(1)
fi.calculate_wake() # Raises warning
print(2)
fi.calculate_wake(yaw_angles=None) # Raises warning
print(3)
fi.calculate_wake(yaw_angles=np.zeros((1,1,3))) # Raises warning
print(4)
fi.calculate_wake(yaw_angles=np.array([[[20, 10, 0]]])) # Raises warning (due to 0)
print(5)
fi.calculate_wake(yaw_angles=np.array(([[[20, 20, 20]]]))) # No warning raised
```

Expected behavior, and what this PR implements, is that 1), 2), and 3) do not raise a warning, while 4) and 5) do.
