### PR TITLE
[BUGFIX] Remove secondary effects from TurboPark model

### DIFF
--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -969,20 +969,8 @@ def turbopark_solver(
 
 
         if model_manager.enable_secondary_steering:
-            added_yaw = wake_added_yaw(
-                u_i,
-                v_i,
-                flow_field.u_initial_sorted,
-                grid.y_sorted[:, i:i+1] - y_i,
-                grid.z_sorted[:, i:i+1],
-                rotor_diameter_i,
-                hub_height_i,
-                ct_i,
-                TSR_i,
-                axial_induction_i,
-                flow_field.wind_shear,
-            )
-            effective_yaw_i += added_yaw
+            raise NotImplementedError(
+                "Secondary steering not available for this model.")
 
         # Model calculations
         # NOTE: exponential
@@ -1031,33 +1019,12 @@ def turbopark_solver(
                 deflection_field[:, ii:ii+1, :, :] = deflection_field_ii[:, i:i+1, :, :]
 
         if model_manager.enable_transverse_velocities:
-            v_wake, w_wake = calculate_transverse_velocity(
-                u_i,
-                flow_field.u_initial_sorted,
-                flow_field.dudz_initial_sorted,
-                grid.x_sorted - x_i,
-                grid.y_sorted - y_i,
-                grid.z_sorted,
-                rotor_diameter_i,
-                hub_height_i,
-                yaw_angle_i,
-                ct_i,
-                TSR_i,
-                axial_induction_i,
-                flow_field.wind_shear,
-            )
+            raise NotImplementedError(
+                "Transverse velocities not used in this model.")
 
         if model_manager.enable_yaw_added_recovery:
-            I_mixing = yaw_added_turbulence_mixing(
-                u_i,
-                turbulence_intensity_i,
-                v_i,
-                flow_field.w_sorted[:, :, i:i+1],
-                v_wake[:, :, i:i+1],
-                w_wake[:, :, i:i+1],
-            )
-            gch_gain = 2
-            turbine_turbulence_intensity[:, :, i:i+1] = turbulence_intensity_i + gch_gain * I_mixing
+            raise NotImplementedError(
+                "Yaw added recovery not used in this model.")
 
         # NOTE: exponential
         velocity_deficit = model_manager.velocity_model.function(

--- a/floris/simulation/solver.py
+++ b/floris/simulation/solver.py
@@ -904,9 +904,6 @@ def turbopark_solver(
         z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3))
         z_i = z_i[:, :, None, None]
 
-        u_i = flow_field.u_sorted[:, :, i:i+1]
-        v_i = flow_field.v_sorted[:, :, i:i+1]
-
         Cts = thrust_coefficient(
             velocities=flow_field.u_sorted,
             air_density=flow_field.air_density,
@@ -958,11 +955,8 @@ def turbopark_solver(
         # Since we are filtering for the i'th turbine in the axial induction function,
         # get the first index here (0:1)
         axial_induction_i = axial_induction_i[:, 0:1, None, None]
-        turbulence_intensity_i = turbine_turbulence_intensity[:, i:i+1]
         yaw_angle_i = farm.yaw_angles_sorted[:, i:i+1, None, None]
-        hub_height_i = farm.hub_heights_sorted[:, i:i+1, None, None]
         rotor_diameter_i = farm.rotor_diameters_sorted[:, i:i+1, None, None]
-        TSR_i = farm.TSRs_sorted[:, i:i+1, None, None]
 
         effective_yaw_i = np.zeros_like(yaw_angle_i)
         effective_yaw_i += yaw_angle_i


### PR DESCRIPTION
During the transition to 4d structures (#764), the secondary effects (for wake steering) in the TurboPark model were not converted (as these are not tested and not in the examples). Speaking to @bayc and @paulf81, the secondary effects were never validated, and we decided it's best to remove the capabilities and instead raise `NotImplementedError`s. 

To recreate the issue, take the following steps:
1. Change the `enable_secondary_steering`, `enable_yaw_added_recovery`, and `enable_transverse_velocities` to `true` in examples/inputs/turbopark.yaml.
2. Run (from the examples/ directory)
```
from floris.tools import FlorisInterface
fi = FlorisInterface("inputs/turbopark.yaml")
fi.calculate_wake()
```

On the v4 branch, this raises an error that appears to be to do with dimensions. This PR changes this to raise `NotImplementedError`s.

