### PR TITLE
Raise informative errors if v3 input files passed in

### DIFF
--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -347,6 +347,7 @@ class Floris(BaseClass):
             Floris: The class object instance.
         """
         input_dict = load_yaml(Path(input_file_path).resolve())
+        check_input_file_for_v3_keys(input_dict)
         return Floris.from_dict(input_dict)
 
     def to_file(self, output_file_path: str) -> None:
@@ -362,3 +363,34 @@ class Floris(BaseClass):
                 sort_keys=False,
                 default_flow_style=False
             )
+
+def check_input_file_for_v3_keys(input_dict) -> None:
+    """
+    Checks if any FLORIS v3 keys are present in the input file and raises special errors if
+    the extra keys belong to a v3 definition of the input_dct.
+    and raises special errors if the extra arguments belong to a v3 definition of the class.
+
+    Args:
+        input_dict (dict): The input dictionary to be checked for v3 keys.
+    """
+    v3_deprecation_msg = (
+        "See https://nrel.github.io/floris/upgrade_guides/v3_to_v4.html for more information."
+    )
+    if "turbulence_intensity" in input_dict["flow_field"]:
+        raise AttributeError(
+            "turbulency_intensity has been updated to turbulence_intensities in FLORIS v4. "
+            + v3_deprecation_msg
+        )
+    elif not hasattr(input_dict["flow_field"]["turbulence_intensities"], "__len__"):
+        raise AttributeError(
+            "turbulence_intensities must be a list of floats in FLORIS v4. "
+            + v3_deprecation_msg
+        )
+
+    if input_dict["wake"]["model_strings"]["velocity_model"] == "multidim_cp_ct":
+        raise AttributeError(
+            "Dedicated 'multidim_cp_ct' velocity model has been removed in FLORIS v4 in favor of "
+            + "supporting all available wake models. To recover previous operation, set velocity_model "
+            + "to gauss. "
+            + v3_deprecation_msg
+        )


### PR DESCRIPTION
Addresses #791 

Checklist:
- [X] Raise informative errors if v3 floris input yaml used
- [ ] Raise informative errors if v3 turbine yaml used
- [ ] Provide converter for v3 floris input yaml
- [X] Provide conveter for v3 turbine yaml (see floris/tools/convert_turbine_v3_to_v4.py, introduced in #765)
