### PR TITLE
Require TI must be length n_findex in core code

### DIFF
--- a/examples/01_opening_floris_computing_power.py
+++ b/examples/01_opening_floris_computing_power.py
@@ -42,9 +42,13 @@ print("\n========================= Single Wind Direction and Multiple Wind Speed
 
 wind_speeds = np.array([8.0, 9.0, 10.0])
 wind_directions = np.array([270.0, 270.0, 270.0])
+turbulence_intensities = np.array([0.06, 0.06, 0.06])
 
 # 3 wind directions/ speeds
-fi.set(wind_speeds=wind_speeds, wind_directions=wind_directions, yaw_angles=np.zeros([3, 2]))
+fi.set(wind_speeds=wind_speeds,
+        wind_directions=wind_directions,
+          turbulence_intensities=turbulence_intensities,
+          yaw_angles=np.zeros([3, 2]))
 fi.run()
 turbine_powers = fi.get_turbine_powers() / 1000.0
 print("The turbine power matrix should be of dimensions 3 findex X 2 Turbines")
@@ -58,8 +62,12 @@ print("\n========================= Multiple Wind Directions and Multiple Wind Sp
 
 wind_speeds = np.tile([8.0, 9.0, 10.0], 3)
 wind_directions = np.repeat([260.0, 270.0, 280.0], 3)
+turbulence_intensities = np.tile([0.06, 0.06, 0.06], 3)
 
-fi.set(wind_directions=wind_directions, wind_speeds=wind_speeds, yaw_angles=np.zeros([9, 2]))
+fi.set(wind_directions=wind_directions,
+       wind_speeds=wind_speeds,
+         turbulence_intensities=turbulence_intensities,
+       yaw_angles=np.zeros([9, 2]))
 fi.run()
 turbine_powers = fi.get_turbine_powers() / 1000.0
 print("The turbine power matrix should be of dimensions 9 WD/WS X 2 Turbines")

--- a/examples/01_opening_floris_computing_power.py
+++ b/examples/01_opening_floris_computing_power.py
@@ -45,10 +45,12 @@ wind_directions = np.array([270.0, 270.0, 270.0])
 turbulence_intensities = np.array([0.06, 0.06, 0.06])
 
 # 3 wind directions/ speeds
-fi.set(wind_speeds=wind_speeds,
-        wind_directions=wind_directions,
-          turbulence_intensities=turbulence_intensities,
-          yaw_angles=np.zeros([3, 2]))
+fi.set(
+    wind_speeds=wind_speeds,
+    wind_directions=wind_directions,
+    turbulence_intensities=turbulence_intensities,
+    yaw_angles=np.zeros([3, 2])
+)
 fi.run()
 turbine_powers = fi.get_turbine_powers() / 1000.0
 print("The turbine power matrix should be of dimensions 3 findex X 2 Turbines")
@@ -64,10 +66,12 @@ wind_speeds = np.tile([8.0, 9.0, 10.0], 3)
 wind_directions = np.repeat([260.0, 270.0, 280.0], 3)
 turbulence_intensities = np.tile([0.06, 0.06, 0.06], 3)
 
-fi.set(wind_directions=wind_directions,
-       wind_speeds=wind_speeds,
-         turbulence_intensities=turbulence_intensities,
-       yaw_angles=np.zeros([9, 2]))
+fi.set(
+    wind_directions=wind_directions,
+    wind_speeds=wind_speeds,
+    turbulence_intensities=turbulence_intensities,
+    yaw_angles=np.zeros([9, 2])
+)
 fi.run()
 turbine_powers = fi.get_turbine_powers() / 1000.0
 print("The turbine power matrix should be of dimensions 9 WD/WS X 2 Turbines")

--- a/examples/04_sweep_wind_directions.py
+++ b/examples/04_sweep_wind_directions.py
@@ -27,7 +27,8 @@ fi.set(layout_x=layout_x, layout_y=layout_y)
 # Sweep wind speeds but keep wind direction fixed
 wd_array = np.arange(250,291,1.)
 ws_array = 8.0 * np.ones_like(wd_array)
-fi.set(wind_directions=wd_array, wind_speeds=ws_array)
+ti_array = 0.06 * np.ones_like(wd_array)
+fi.set(wind_directions=wd_array, wind_speeds=ws_array, turbulence_intensities=ti_array)
 
 # Define a matrix of yaw angles to be all 0
 # Note that yaw angles is now specified as a matrix whose dimensions are

--- a/examples/05_sweep_wind_speeds.py
+++ b/examples/05_sweep_wind_speeds.py
@@ -27,7 +27,8 @@ fi.set(layout_x=layout_x, layout_y=layout_y)
 # Sweep wind speeds but keep wind direction fixed
 ws_array = np.arange(5,25,0.5)
 wd_array = 270.0 * np.ones_like(ws_array)
-fi.set(wind_directions=wd_array,wind_speeds=ws_array)
+ti_array = 0.06 * np.ones_like(ws_array)
+fi.set(wind_directions=wd_array,wind_speeds=ws_array, turbulence_intensities=ti_array)
 
 # Define a matrix of yaw angles to be all 0
 # Note that yaw angles is now specified as a matrix whose dimensions are

--- a/examples/06_sweep_wind_conditions.py
+++ b/examples/06_sweep_wind_conditions.py
@@ -44,9 +44,12 @@ wind_speeds_grid, wind_directions_grid = np.meshgrid(
 # Flatten the grids back to 1D arrays
 ws_array = wind_speeds_grid.flatten()
 wd_array = wind_directions_grid.flatten()
+turbulence_intensities = 0.06 * np.ones_like(wd_array)
 
 # Now reinitialize FLORIS
-fi.set(wind_speeds=ws_array, wind_directions=wd_array)
+fi.set(wind_speeds=ws_array,
+       wind_directions=wd_array,
+       turbulence_intensities=turbulence_intensities)
 
 # Define a matrix of yaw angles to be all 0
 # Note that yaw angles is now specified as a matrix whose dimensions are

--- a/examples/06_sweep_wind_conditions.py
+++ b/examples/06_sweep_wind_conditions.py
@@ -47,9 +47,11 @@ wd_array = wind_directions_grid.flatten()
 turbulence_intensities = 0.06 * np.ones_like(wd_array)
 
 # Now reinitialize FLORIS
-fi.set(wind_speeds=ws_array,
-       wind_directions=wd_array,
-       turbulence_intensities=turbulence_intensities)
+fi.set(
+    wind_speeds=ws_array,
+    wind_directions=wd_array,
+    turbulence_intensities=turbulence_intensities
+)
 
 # Define a matrix of yaw angles to be all 0
 # Note that yaw angles is now specified as a matrix whose dimensions are

--- a/examples/07_calc_aep_from_rose.py
+++ b/examples/07_calc_aep_from_rose.py
@@ -28,6 +28,7 @@ wd_grid, ws_grid = np.meshgrid(
 )
 wind_directions = wd_grid.flatten()
 wind_speeds = ws_grid.flatten()
+turbulence_intensities = np.ones_like(wind_directions) * 0.06
 
 # Format the frequency array into the conventional FLORIS v3 format, which is
 # an np.array with shape (n_wind_directions, n_wind_speeds). To avoid having
@@ -52,6 +53,7 @@ fi.set(
     layout_y=[0.0, 0.0, 0.0],
     wind_directions=wind_directions,
     wind_speeds=wind_speeds,
+    turbulence_intensities=turbulence_intensities,
 )
 
 # Compute the AEP using the default settings

--- a/examples/09_compare_farm_power_with_neighbor.py
+++ b/examples/09_compare_farm_power_with_neighbor.py
@@ -30,9 +30,11 @@ fi.set(layout_x=layout_x, layout_y=layout_y)
 wd_array = np.arange(0,360,4.)
 ws_array = 8.0 * np.ones_like(wd_array)
 turbulence_intensities = 0.06 * np.ones_like(wd_array)
-fi.set(wind_directions=wd_array,
-       wind_speeds=ws_array,
-       turbulence_intensities=turbulence_intensities)
+fi.set(
+    wind_directions=wd_array,
+    wind_speeds=ws_array,
+    turbulence_intensities=turbulence_intensities
+)
 
 
 # Calculate

--- a/examples/09_compare_farm_power_with_neighbor.py
+++ b/examples/09_compare_farm_power_with_neighbor.py
@@ -29,7 +29,10 @@ fi.set(layout_x=layout_x, layout_y=layout_y)
 # Define a simple wind rose with just 1 wind speed
 wd_array = np.arange(0,360,4.)
 ws_array = 8.0 * np.ones_like(wd_array)
-fi.set(wind_directions=wd_array, wind_speeds=ws_array)
+turbulence_intensities = 0.06 * np.ones_like(wd_array)
+fi.set(wind_directions=wd_array,
+       wind_speeds=ws_array,
+       turbulence_intensities=turbulence_intensities)
 
 
 # Calculate

--- a/examples/10_opt_yaw_single_ws.py
+++ b/examples/10_opt_yaw_single_ws.py
@@ -22,12 +22,14 @@ fi = FlorisInterface("inputs/gch.yaml") # GCH model matched to the default "lega
 # Reinitialize as a 3-turbine farm with range of WDs and 1 WS
 wd_array = np.arange(0.0, 360.0, 3.0)
 ws_array = 8.0 * np.ones_like(wd_array)
+turbulence_intensities = 0.06 * np.ones_like(wd_array)
 D = 126.0 # Rotor diameter for the NREL 5 MW
 fi.set(
     layout_x=[0.0, 5 * D, 10 * D],
     layout_y=[0.0, 0.0, 0.0],
     wind_directions=wd_array,
     wind_speeds=ws_array,
+    turbulence_intensities=turbulence_intensities,
 )
 print(fi.floris.farm.rotor_diameters)
 

--- a/examples/11_opt_yaw_multiple_ws.py
+++ b/examples/11_opt_yaw_multiple_ws.py
@@ -32,6 +32,7 @@ wind_speeds_grid, wind_directions_grid = np.meshgrid(
 # Flatten the grids back to 1D arrays
 wd_array = wind_directions_grid.flatten()
 ws_array = wind_speeds_grid.flatten()
+turbulence_intensities = 0.06 * np.ones_like(wd_array)
 
 # Reinitialize as a 3-turbine farm with range of WDs and WSs
 D = 126.0 # Rotor diameter for the NREL 5 MW
@@ -40,6 +41,7 @@ fi.set(
     layout_y=[0.0, 0.0, 0.0],
     wind_directions=wd_array,
     wind_speeds=ws_array,
+    turbulence_intensities=turbulence_intensities,
 )
 
 # Initialize optimizer object and run optimization using the Serial-Refine method

--- a/examples/12_optimize_yaw.py
+++ b/examples/12_optimize_yaw.py
@@ -62,8 +62,12 @@ def calculate_aep(fi, df_windrose, column_name="farm_power"):
     # Derive the wind directions and speeds we need to evaluate in FLORIS
     wd_array = np.array(df_windrose["wd"], dtype=float)
     ws_array = np.array(df_windrose["ws"], dtype=float)
+    turbulence_intensities = 0.06 * np.ones_like(wd_array)
     yaw_angles = np.array(df_windrose[yaw_cols], dtype=float)
-    fi.set(wind_directions=wd_array, wind_speeds=ws_array, yaw_angles=yaw_angles)
+    fi.set(wind_directions=wd_array,
+           wind_speeds=ws_array,
+           turbulence_intensities=turbulence_intensities,
+           yaw_angles=yaw_angles)
 
     # Calculate FLORIS for every WD and WS combination and get the farm power
     fi.run()
@@ -109,9 +113,11 @@ if __name__ == "__main__":
     start_time = timerpc()
     wd_array = np.arange(0.0, 360.0, 5.0)
     ws_array = 8.0 * np.ones_like(wd_array)
+    turbulence_intensities = 0.06 * np.ones_like(wd_array)
     fi.set(
         wind_directions=wd_array,
         wind_speeds=ws_array,
+        turbulence_intensities=turbulence_intensities,
     )
     yaw_opt = YawOptimizationSR(
         fi=fi,

--- a/examples/12_optimize_yaw.py
+++ b/examples/12_optimize_yaw.py
@@ -64,10 +64,12 @@ def calculate_aep(fi, df_windrose, column_name="farm_power"):
     ws_array = np.array(df_windrose["ws"], dtype=float)
     turbulence_intensities = 0.06 * np.ones_like(wd_array)
     yaw_angles = np.array(df_windrose[yaw_cols], dtype=float)
-    fi.set(wind_directions=wd_array,
-           wind_speeds=ws_array,
-           turbulence_intensities=turbulence_intensities,
-           yaw_angles=yaw_angles)
+    fi.set(
+        wind_directions=wd_array,
+        wind_speeds=ws_array,
+        turbulence_intensities=turbulence_intensities,
+        yaw_angles=yaw_angles
+    )
 
     # Calculate FLORIS for every WD and WS combination and get the farm power
     fi.run()

--- a/examples/12_optimize_yaw_in_parallel.py
+++ b/examples/12_optimize_yaw_in_parallel.py
@@ -58,11 +58,12 @@ if __name__ == "__main__":
     # Flatten the grids back to 1D arrays
     wd_array = wind_directions_grid.flatten()
     ws_array = wind_speeds_grid.flatten()
+    turbulence_intensities = 0.08 * np.ones_like(wd_array)
 
     fi_aep.set(
         wind_directions=wd_array,
         wind_speeds=ws_array,
-        turbulence_intensities=[0.08],  # Assume 8% turbulence intensity
+        turbulence_intensities=turbulence_intensities,
     )
 
     # Pour this into a parallel computing interface
@@ -111,11 +112,12 @@ if __name__ == "__main__":
     # Flatten the grids back to 1D arrays
     wd_array_opt = wind_directions_grid.flatten()
     ws_array_opt = wind_speeds_grid.flatten()
+    turbulence_intensities = 0.08 * np.ones_like(wd_array_opt)
 
     fi_opt.set(
         wind_directions=wd_array_opt,
         wind_speeds=ws_array_opt,
-        turbulence_intensities=[0.08],  # Assume 8% turbulence intensity
+        turbulence_intensities=turbulence_intensities,
     )
 
     # Pour this into a parallel computing interface

--- a/examples/13_optimize_yaw_with_neighboring_farm.py
+++ b/examples/13_optimize_yaw_with_neighboring_farm.py
@@ -177,18 +177,23 @@ if __name__ == "__main__":
     # Load a dataframe containing the wind rose information
     ws_windrose, wd_windrose, freq_windrose = load_windrose()
     ws_windrose = ws_windrose + 0.001  # Deal with 0.0 m/s discrepancy
+    turbulence_intensities_windrose = 0.06 * np.ones_like(wd_windrose)
 
     # Create a FLORIS object for AEP calculations
     fi_AEP = fi.copy()
-    fi_AEP.set(wind_speeds=ws_windrose, wind_directions=wd_windrose)
+    fi_AEP.set(wind_speeds=ws_windrose,
+               wind_directions=wd_windrose,
+               turbulence_intensities=turbulence_intensities_windrose)
 
     # And create a separate FLORIS object for optimization
     fi_opt = fi.copy()
     wd_array = np.arange(0.0, 360.0, 3.0)
     ws_array = 8.0 * np.ones_like(wd_array)
+    turbulence_intensities = 0.06 * np.ones_like(wd_array)
     fi_opt.set(
         wind_directions=wd_array,
         wind_speeds=ws_array,
+        turbulence_intensities=turbulence_intensities,
     )
 
     # First, get baseline AEP, without wake steering

--- a/examples/13_optimize_yaw_with_neighboring_farm.py
+++ b/examples/13_optimize_yaw_with_neighboring_farm.py
@@ -181,9 +181,11 @@ if __name__ == "__main__":
 
     # Create a FLORIS object for AEP calculations
     fi_AEP = fi.copy()
-    fi_AEP.set(wind_speeds=ws_windrose,
-               wind_directions=wd_windrose,
-               turbulence_intensities=turbulence_intensities_windrose)
+    fi_AEP.set(
+        wind_speeds=ws_windrose,
+        wind_directions=wd_windrose,
+        turbulence_intensities=turbulence_intensities_windrose
+    )
 
     # And create a separate FLORIS object for optimization
     fi_opt = fi.copy()

--- a/examples/14_compare_yaw_optimizers.py
+++ b/examples/14_compare_yaw_optimizers.py
@@ -38,11 +38,13 @@ fi = FlorisInterface("inputs/gch.yaml") # GCH model matched to the default "lega
 D = 126.0 # Rotor diameter for the NREL 5 MW
 wd_array = np.arange(0.0, 360.0, 3.0)
 ws_array = 8.0 * np.ones_like(wd_array)
+turbulence_intensities = 0.06 * np.ones_like(wd_array)
 fi.set(
     layout_x=[0.0, 5 * D, 10 * D],
     layout_y=[0.0, 0.0, 0.0],
     wind_directions=wd_array,
     wind_speeds=ws_array,
+    turbulence_intensities=turbulence_intensities,
 )
 
 print("Performing optimizations with SciPy...")

--- a/examples/15_optimize_layout.py
+++ b/examples/15_optimize_layout.py
@@ -35,10 +35,12 @@ freq_table[:,0] = (np.abs(np.sort(np.random.randn(len(wind_directions)))))
 freq_table = freq_table / freq_table.sum()
 
 # Establish a TimeSeries object
-wind_rose = WindRose(wind_directions=wind_directions,
-                     wind_speeds=wind_speeds,
-                     freq_table=freq_table,
-                     ti_table=0.06)
+wind_rose = WindRose(
+    wind_directions=wind_directions,
+    wind_speeds=wind_speeds,
+    freq_table=freq_table,
+    ti_table=0.06
+)
 
 fi.set(wind_data=wind_rose)
 

--- a/examples/15_optimize_layout.py
+++ b/examples/15_optimize_layout.py
@@ -28,11 +28,14 @@ fi = FlorisInterface('inputs/gch.yaml')
 wind_directions = np.arange(0, 360.0, 5.0)
 np.random.seed(1)
 wind_speeds = 8.0 + np.random.randn(1) * 0.5 * np.ones_like(wind_directions)
+turbulence_intensities = 0.06 * np.ones_like(wind_directions)
 # Shape frequency distribution to match number of wind directions and wind speeds
 freq = (np.abs(np.sort(np.random.randn(len(wind_directions)))))
 freq = freq / freq.sum()
 
-fi.set(wind_directions=wind_directions, wind_speeds=wind_speeds)
+fi.set(wind_directions=wind_directions,
+       wind_speeds=wind_speeds,
+       turbulence_intensities=turbulence_intensities)
 
 # The boundaries for the turbines, specified as vertices
 boundaries = [(0.0, 0.0), (0.0, 1000.0), (1000.0, 1000.0), (1000.0, 0.0), (0.0, 0.0)]

--- a/examples/16b_heterogeneity_multiple_ws_wd.py
+++ b/examples/16b_heterogeneity_multiple_ws_wd.py
@@ -28,6 +28,7 @@ fi.set(
     wind_shear=0.0,
     wind_speeds=[8.0],
     wind_directions=[270.],
+    turbulence_intensities=[0.06],
     layout_x=[0, 0],
     layout_y=[-299., 299.],
 )
@@ -55,6 +56,7 @@ heterogenous_inflow_config = {
 fi.set(
     wind_directions=[270.0, 275.0],
     wind_speeds=[8.0, 8.0],
+    turbulence_intensities=[0.06, 0.06],
     heterogenous_inflow_config=heterogenous_inflow_config
 )
 fi.run()

--- a/examples/16c_optimize_layout_with_heterogeneity.py
+++ b/examples/16c_optimize_layout_with_heterogeneity.py
@@ -67,17 +67,19 @@ heterogenous_inflow_config_by_wd = {
 }
 
 # Establish a WindRose object
-wind_rose = WindRose(wind_directions=wind_directions,
-                     wind_speeds=wind_speeds,
-                     freq_table=freq_table,
-                     ti_table=0.06,
-                     heterogenous_inflow_config_by_wd=heterogenous_inflow_config_by_wd)
+wind_rose = WindRose(
+    wind_directions=wind_directions,
+    wind_speeds=wind_speeds,
+    freq_table=freq_table,
+    ti_table=0.06,
+    heterogenous_inflow_config_by_wd=heterogenous_inflow_config_by_wd
+)
 
 
 fi.set(
     layout_x=layout_x,
     layout_y=layout_y,
-    wind_data=wind_rose
+    wind_data=wind_rose,
 )
 
 # Setup and solve the layout optimization problem without heterogeneity

--- a/examples/16c_optimize_layout_with_heterogeneity.py
+++ b/examples/16c_optimize_layout_with_heterogeneity.py
@@ -31,6 +31,7 @@ fi = FlorisInterface('inputs/gch.yaml')
 wind_directions = [270., 90.]
 n_wds = len(wind_directions)
 wind_speeds = [8.0] * np.ones_like(wind_directions)
+turbulence_intensities = 0.06 * np.ones_like(wind_directions)
 # Shape frequency distribution to match number of wind directions and wind speeds
 freq = np.ones((len(wind_directions), len(wind_speeds)))
 freq = freq / freq.sum()
@@ -68,6 +69,7 @@ fi.set(
     layout_y=layout_y,
     wind_directions=wind_directions,
     wind_speeds=wind_speeds,
+    turbulence_intensities=turbulence_intensities,
     heterogenous_inflow_config=heterogenous_inflow_config
 )
 

--- a/examples/18_check_turbine.py
+++ b/examples/18_check_turbine.py
@@ -13,6 +13,7 @@ curve and power loss to yaw are reasonable and  reasonably smooth
 """
 ws_array = np.arange(0.1,30,0.2)
 wd_array = 270.0 * np.ones_like(ws_array)
+turbulence_intensities = 0.06 * np.ones_like(ws_array)
 yaw_angles = np.linspace(-30,30,60)
 wind_speed_to_test_yaw = 11
 
@@ -23,7 +24,9 @@ fi = FlorisInterface("inputs/gch.yaml")
 fi.set(layout_x=[0], layout_y=[0])
 
 # Apply wind directions and wind speeds
-fi.set(wind_speeds=ws_array, wind_directions=wd_array)
+fi.set(wind_speeds=ws_array,
+       wind_directions=wd_array,
+         turbulence_intensities=turbulence_intensities)
 
 # Get a list of available turbine models provided through FLORIS, and remove
 # multi-dimensional Cp/Ct turbine definitions as they require different handling
@@ -72,7 +75,9 @@ for t in turbines:
 
         # POWER CURVE
         ax = axarr[0]
-        fi.set(wind_speeds=ws_array, wind_directions=wd_array)
+        fi.set(wind_speeds=ws_array,
+               wind_directions=wd_array,
+               turbulence_intensities=turbulence_intensities)
         fi.run()
         turbine_powers = fi.get_turbine_powers().flatten() / 1e3
         if density == 1.225:
@@ -87,7 +92,9 @@ for t in turbines:
         # Power loss to yaw, try a range of yaw angles
         ax = axarr[1]
 
-        fi.set(wind_speeds=[wind_speed_to_test_yaw], wind_directions=[270.0])
+        fi.set(wind_speeds=[wind_speed_to_test_yaw],
+               wind_directions=[270.0],
+                 turbulence_intensities=[0.06])
         yaw_result = []
         for yaw in yaw_angles:
             fi.set(yaw_angles=np.array([[yaw]]))

--- a/examples/18_check_turbine.py
+++ b/examples/18_check_turbine.py
@@ -24,9 +24,11 @@ fi = FlorisInterface("inputs/gch.yaml")
 fi.set(layout_x=[0], layout_y=[0])
 
 # Apply wind directions and wind speeds
-fi.set(wind_speeds=ws_array,
-       wind_directions=wd_array,
-         turbulence_intensities=turbulence_intensities)
+fi.set(
+    wind_speeds=ws_array,
+    wind_directions=wd_array,
+    turbulence_intensities=turbulence_intensities
+)
 
 # Get a list of available turbine models provided through FLORIS, and remove
 # multi-dimensional Cp/Ct turbine definitions as they require different handling
@@ -75,9 +77,11 @@ for t in turbines:
 
         # POWER CURVE
         ax = axarr[0]
-        fi.set(wind_speeds=ws_array,
-               wind_directions=wd_array,
-               turbulence_intensities=turbulence_intensities)
+        fi.set(
+            wind_speeds=ws_array,
+            wind_directions=wd_array,
+            turbulence_intensities=turbulence_intensities
+        )
         fi.run()
         turbine_powers = fi.get_turbine_powers().flatten() / 1e3
         if density == 1.225:
@@ -92,9 +96,11 @@ for t in turbines:
         # Power loss to yaw, try a range of yaw angles
         ax = axarr[1]
 
-        fi.set(wind_speeds=[wind_speed_to_test_yaw],
-               wind_directions=[270.0],
-                 turbulence_intensities=[0.06])
+        fi.set(
+            wind_speeds=[wind_speed_to_test_yaw],
+            wind_directions=[270.0],
+            turbulence_intensities=[0.06]
+        )
         yaw_result = []
         for yaw in yaw_angles:
             fi.set(yaw_angles=np.array([[yaw]]))

--- a/examples/21_demo_time_series.py
+++ b/examples/21_demo_time_series.py
@@ -22,13 +22,14 @@ time = np.arange(0, 120, 10.) # Each time step represents a 10-minute average
 ws = np.ones_like(time) * 8.
 ws[int(len(ws) / 2):] = 9.
 wd = np.ones_like(time) * 270.
+turbulence_intensities = np.ones_like(time) * 0.06
 
 for idx in range(1, len(time)):
     wd[idx] = wd[idx - 1] + np.random.randn() * 2.
 
 
 # Now intiialize FLORIS object to this history using time_series flag
-fi.set(wind_directions=wd, wind_speeds=ws)
+fi.set(wind_directions=wd, wind_speeds=ws, turbulence_intensities=turbulence_intensities)
 
 # Collect the powers
 fi.run()

--- a/examples/24_floating_turbine_models.py
+++ b/examples/24_floating_turbine_models.py
@@ -42,9 +42,11 @@ wd_array = 270.0 * np.ones_like(ws_array)
 ti_array = 0.06 * np.ones_like(ws_array)
 fi_fixed.set(wind_speeds=ws_array,  wind_directions=wd_array, turbulence_intensities=ti_array)
 fi_floating.set(wind_speeds=ws_array, wind_directions=wd_array, turbulence_intensities=ti_array)
-fi_floating_defined_floating.set(wind_speeds=ws_array,
-                                 wind_directions=wd_array,
-                                   turbulence_intensities=ti_array)
+fi_floating_defined_floating.set(
+    wind_speeds=ws_array,
+    wind_directions=wd_array,
+    turbulence_intensities=ti_array
+)
 
 fi_fixed.run()
 fi_floating.run()

--- a/examples/24_floating_turbine_models.py
+++ b/examples/24_floating_turbine_models.py
@@ -39,9 +39,12 @@ fi_floating_defined_floating = FlorisInterface("inputs_floating/gch_floating_def
 # Calculate across wind speeds
 ws_array = np.arange(3., 25., 1.)
 wd_array = 270.0 * np.ones_like(ws_array)
-fi_fixed.set(wind_speeds=ws_array,  wind_directions=wd_array)
-fi_floating.set(wind_speeds=ws_array, wind_directions=wd_array)
-fi_floating_defined_floating.set(wind_speeds=ws_array, wind_directions=wd_array)
+ti_array = 0.06 * np.ones_like(ws_array)
+fi_fixed.set(wind_speeds=ws_array,  wind_directions=wd_array, turbulence_intensities=ti_array)
+fi_floating.set(wind_speeds=ws_array, wind_directions=wd_array, turbulence_intensities=ti_array)
+fi_floating_defined_floating.set(wind_speeds=ws_array,
+                                 wind_directions=wd_array,
+                                   turbulence_intensities=ti_array)
 
 fi_fixed.run()
 fi_floating.run()

--- a/examples/28_extract_wind_speed_at_points.py
+++ b/examples/28_extract_wind_speed_at_points.py
@@ -39,7 +39,8 @@ ax[0].scatter(fi.layout_x, fi.layout_y, color="black", label="Turbine")
 # Set the wind direction to run 360 degrees
 wd_array = np.arange(0, 360, 1)
 ws_array = 8.0 * np.ones_like(wd_array)
-fi.set(wind_directions=wd_array, wind_speeds=ws_array)
+ti_array = 0.06 * np.ones_like(wd_array)
+fi.set(wind_directions=wd_array, wind_speeds=ws_array, turbulence_intensities=ti_array)
 
 # Simulate a met mast in between the turbines
 if met_mast_option == 0:

--- a/examples/29_floating_vs_fixedbottom_farm.py
+++ b/examples/29_floating_vs_fixedbottom_farm.py
@@ -46,7 +46,8 @@ for fi in [fi_fixed, fi_floating]:
         layout_x=x,
         layout_y=y,
         wind_speeds=[10],
-        wind_directions=[270]
+        wind_directions=[270],
+        turbulence_intensities=[0.06],
     )
     fi.run()
 
@@ -121,6 +122,7 @@ for fi in [fi_fixed, fi_floating]:
     fi.set(
         wind_directions=wd_grid.flatten(),
         wind_speeds= ws_grid.flatten(),
+        turbulence_intensities=0.06 * np.ones_like(wd_grid.flatten())
     )
 
 # Compute the AEP

--- a/examples/30_multi_dimensional_cp_ct.py
+++ b/examples/30_multi_dimensional_cp_ct.py
@@ -50,7 +50,7 @@ fi.set(layout_x=[0., 500.], layout_y=[0., 0.])
 print('\n========================= Single Wind Direction and Wind Speed =========================')
 
 # Get the turbine powers assuming 1 wind speed and 1 wind direction
-fi.set(wind_directions=[270.0], wind_speeds=[8.0])
+fi.set(wind_directions=[270.0], wind_speeds=[8.0], turbulence_intensities=[0.06])
 
 # Set the yaw angles to 0
 yaw_angles = np.zeros([1, 2]) # 1 wind direction and wind speed, 2 turbines
@@ -70,9 +70,13 @@ print('\n========================= Single Wind Direction and Multiple Wind Speed
 
 wind_speeds = np.array([8.0, 9.0, 10.0])
 wind_directions = np.array([270.0, 270.0, 270.0])
+turbulence_intensities = np.array([0.06, 0.06, 0.06])
 
 yaw_angles = np.zeros([3, 2])  # 3 wind directions/ speeds, 2 turbines
-fi.set(wind_speeds=wind_speeds, wind_directions=wind_directions, yaw_angles=yaw_angles)
+fi.set(wind_speeds=wind_speeds,
+       wind_directions=wind_directions,
+        turbulence_intensities=turbulence_intensities,
+         yaw_angles=yaw_angles)
 fi.run()
 turbine_powers = fi.get_turbine_powers() / 1000.0
 print("The turbine power matrix should be of dimensions 3 findex X 2 Turbines")
@@ -84,9 +88,13 @@ print('\n========================= Multiple Wind Directions and Multiple Wind Sp
 
 wind_speeds = np.tile([8.0, 9.0, 10.0], 3)
 wind_directions = np.repeat([260.0, 270.0, 280.0], 3)
+turbulence_intensities = 0.06 * np.ones_like(wind_speeds)
 
 yaw_angles = np.zeros([9, 2])  # 9 wind directions/ speeds, 2 turbines
-fi.set(wind_directions=wind_directions, wind_speeds=wind_speeds, yaw_angles=yaw_angles)
+fi.set(wind_directions=wind_directions,
+       wind_speeds=wind_speeds,
+        turbulence_intensities=turbulence_intensities,
+         yaw_angles=yaw_angles)
 fi.run()
 turbine_powers = fi.get_turbine_powers()/1000.
 print("The turbine power matrix should be of dimensions 9 WD/WS X 2 Turbines")

--- a/examples/30_multi_dimensional_cp_ct.py
+++ b/examples/30_multi_dimensional_cp_ct.py
@@ -73,10 +73,12 @@ wind_directions = np.array([270.0, 270.0, 270.0])
 turbulence_intensities = np.array([0.06, 0.06, 0.06])
 
 yaw_angles = np.zeros([3, 2])  # 3 wind directions/ speeds, 2 turbines
-fi.set(wind_speeds=wind_speeds,
-       wind_directions=wind_directions,
-        turbulence_intensities=turbulence_intensities,
-         yaw_angles=yaw_angles)
+fi.set(
+    wind_speeds=wind_speeds,
+    wind_directions=wind_directions,
+    turbulence_intensities=turbulence_intensities,
+    yaw_angles=yaw_angles
+)
 fi.run()
 turbine_powers = fi.get_turbine_powers() / 1000.0
 print("The turbine power matrix should be of dimensions 3 findex X 2 Turbines")
@@ -91,10 +93,12 @@ wind_directions = np.repeat([260.0, 270.0, 280.0], 3)
 turbulence_intensities = 0.06 * np.ones_like(wind_speeds)
 
 yaw_angles = np.zeros([9, 2])  # 9 wind directions/ speeds, 2 turbines
-fi.set(wind_directions=wind_directions,
-       wind_speeds=wind_speeds,
-        turbulence_intensities=turbulence_intensities,
-         yaw_angles=yaw_angles)
+fi.set(
+    wind_directions=wind_directions,
+    wind_speeds=wind_speeds,
+    turbulence_intensities=turbulence_intensities,
+    yaw_angles=yaw_angles
+)
 fi.run()
 turbine_powers = fi.get_turbine_powers()/1000.
 print("The turbine power matrix should be of dimensions 9 WD/WS X 2 Turbines")

--- a/examples/31_multi_dimensional_cp_ct_2Hs.py
+++ b/examples/31_multi_dimensional_cp_ct_2Hs.py
@@ -35,12 +35,16 @@ fi_hs_1.set(layout_x=[0., 500., 1000.], layout_y=[0., 0., 0.])
 wind_speeds = np.arange(5, 20, 1.0)
 wind_directions = 270.0 * np.ones_like(wind_speeds)
 turbulence_intensities = 0.06 * np.ones_like(wind_speeds)
-fi.set(wind_directions=wind_directions,
-       wind_speeds=wind_speeds,
-       turbulence_intensities=turbulence_intensities)
-fi_hs_1.set(wind_directions=wind_directions,
-            wind_speeds=wind_speeds,
-            turbulence_intensities=turbulence_intensities)
+fi.set(
+    wind_directions=wind_directions,
+    wind_speeds=wind_speeds,
+    turbulence_intensities=turbulence_intensities
+)
+fi_hs_1.set(
+    wind_directions=wind_directions,
+    wind_speeds=wind_speeds,
+    turbulence_intensities=turbulence_intensities
+)
 
 # Calculate wakes with baseline yaw
 fi.run()

--- a/examples/31_multi_dimensional_cp_ct_2Hs.py
+++ b/examples/31_multi_dimensional_cp_ct_2Hs.py
@@ -34,8 +34,13 @@ fi_hs_1.set(layout_x=[0., 500., 1000.], layout_y=[0., 0., 0.])
 # Use a sweep of wind speeds
 wind_speeds = np.arange(5, 20, 1.0)
 wind_directions = 270.0 * np.ones_like(wind_speeds)
-fi.set(wind_directions=wind_directions, wind_speeds=wind_speeds)
-fi_hs_1.set(wind_directions=wind_directions, wind_speeds=wind_speeds)
+turbulence_intensities = 0.06 * np.ones_like(wind_speeds)
+fi.set(wind_directions=wind_directions,
+       wind_speeds=wind_speeds,
+       turbulence_intensities=turbulence_intensities)
+fi_hs_1.set(wind_directions=wind_directions,
+            wind_speeds=wind_speeds,
+            turbulence_intensities=turbulence_intensities)
 
 # Calculate wakes with baseline yaw
 fi.run()

--- a/examples/33_specify_turbine_power_curve.py
+++ b/examples/33_specify_turbine_power_curve.py
@@ -42,12 +42,14 @@ turbine_dict = build_cosine_loss_turbine_dict(
 fi = FlorisInterface("inputs/gch.yaml")
 wind_speeds = np.linspace(1, 15, 100)
 wind_directions = 270 * np.ones_like(wind_speeds)
+turbulence_intensities = 0.06 * np.ones_like(wind_speeds)
 # Replace the turbine(s) in the FLORIS model with the created one
 fi.set(
     layout_x=[0],
     layout_y=[0],
     wind_directions=wind_directions,
     wind_speeds=wind_speeds,
+    turbulence_intensities=turbulence_intensities,
     turbine_type=[turbine_dict]
 )
 fi.run()

--- a/examples/36_generate_ti.py
+++ b/examples/36_generate_ti.py
@@ -19,9 +19,10 @@ and TimeSeries classes
 # Generate a random time series of wind speeds, wind directions and turbulence intensities
 wind_directions = np.array([250, 260, 270])
 wind_speeds = np.array([5, 6, 7, 8, 9, 10])
+ti_table = 0.06
 
 # Declare a WindRose object
-wind_rose = WindRose(wind_directions=wind_directions, wind_speeds=wind_speeds)
+wind_rose = WindRose(wind_directions=wind_directions, wind_speeds=wind_speeds, ti_table=ti_table)
 
 
 # Define a custom function where TI = 1 / wind_speed
@@ -51,7 +52,10 @@ ax.set_title(f"Turbulence Intensity defined by Iref = {Iref:0.2}")
 N = 100
 wind_directions = 270 * np.ones(N)
 wind_speeds = np.linspace(5, 15, N)
-time_series = TimeSeries(wind_directions=wind_directions, wind_speeds=wind_speeds)
+turbulence_intensities =  0.06 * np.ones(N)
+time_series = TimeSeries(wind_directions=wind_directions,
+                         wind_speeds=wind_speeds,
+                         turbulence_intensities=turbulence_intensities)
 time_series.assign_ti_using_IEC_method(Iref=Iref)
 
 fig, axarr = plt.subplots(2, 1, sharex=True, figsize=(7, 8))

--- a/examples/36_generate_ti.py
+++ b/examples/36_generate_ti.py
@@ -53,9 +53,11 @@ N = 100
 wind_directions = 270 * np.ones(N)
 wind_speeds = np.linspace(5, 15, N)
 turbulence_intensities =  0.06 * np.ones(N)
-time_series = TimeSeries(wind_directions=wind_directions,
-                         wind_speeds=wind_speeds,
-                         turbulence_intensities=turbulence_intensities)
+time_series = TimeSeries(
+    wind_directions=wind_directions,
+    wind_speeds=wind_speeds,
+    turbulence_intensities=turbulence_intensities
+)
 time_series.assign_ti_using_IEC_method(Iref=Iref)
 
 fig, axarr = plt.subplots(2, 1, sharex=True, figsize=(7, 8))

--- a/examples/40_test_derating.py
+++ b/examples/40_test_derating.py
@@ -26,9 +26,11 @@ fi.set(layout_x=[0, 1000.0], layout_y=[0.0, 0.0], turbine_type=[turbine_type])
 
 # Set the wind directions and speeds to be constant over n_findex = N time steps
 N = 50
-fi.set(wind_directions=270 * np.ones(N),
-        wind_speeds=10.0 * np.ones(N),
-        turbulence_intensities=0.06 * np.ones(N))
+fi.set(
+    wind_directions=270 * np.ones(N),
+    wind_speeds=10.0 * np.ones(N),
+    turbulence_intensities=0.06 * np.ones(N)
+)
 fi.run()
 turbine_powers_orig = fi.get_turbine_powers()
 

--- a/examples/40_test_derating.py
+++ b/examples/40_test_derating.py
@@ -26,7 +26,9 @@ fi.set(layout_x=[0, 1000.0], layout_y=[0.0, 0.0], turbine_type=[turbine_type])
 
 # Set the wind directions and speeds to be constant over n_findex = N time steps
 N = 50
-fi.set(wind_directions=270 * np.ones(N), wind_speeds=10.0 * np.ones(N))
+fi.set(wind_directions=270 * np.ones(N),
+        wind_speeds=10.0 * np.ones(N),
+        turbulence_intensities=0.06 * np.ones(N))
 fi.run()
 turbine_powers_orig = fi.get_turbine_powers()
 
@@ -96,6 +98,7 @@ power_setpoints = np.array([
 fi.set(
     wind_directions=270 * np.ones(len(yaw_angles)),
     wind_speeds=10.0 * np.ones(len(yaw_angles)),
+    turbulence_intensities=0.06 * np.ones(len(yaw_angles)),
     turbine_type=[turbine_type]*2,
     yaw_angles=yaw_angles,
     power_setpoints=power_setpoints,

--- a/examples/41_test_disable_turbines.py
+++ b/examples/41_test_disable_turbines.py
@@ -33,6 +33,7 @@ layout = np.array([[0.0, 0.0], [500.0, 0.0], [1000.0, 0.0]])
 # (n_findex = 2)
 wind_directions = np.array([270.0, 270.0])
 wind_speeds = np.array([8.0, 8.0])
+turbulence_intensities = np.array([0.06, 0.06])
 
 # Shut down the first 2 turbines for the second findex
 # 2 findex x 3 turbines
@@ -47,6 +48,7 @@ fi.set(
     layout_y=layout[:, 1],
     wind_directions=wind_directions,
     wind_speeds=wind_speeds,
+    turbulence_intensities=turbulence_intensities,
     disable_turbines=disable_turbines,
 )
 

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -64,9 +64,9 @@ class FlowField(BaseClass):
                 "turbulence_intensities must have 1-dimension"
             )
 
-        # Check the turbulence intensity is either length 1 or n_findex
-        if len(value) != 1 and len(value) != self.n_findex:
-            raise ValueError("turbulence_intensities should either be length 1 or n_findex")
+        # Check the turbulence intensity is lenght n_findex
+        if len(value) != self.n_findex:
+            raise ValueError("turbulence_intensities must be length n_findex")
 
 
 
@@ -134,10 +134,6 @@ class FlowField(BaseClass):
         if self.heterogenous_inflow_config is not None:
             self.generate_heterogeneous_wind_map()
 
-        # If turbulence_intensity is length 1, then convert it to a uniform array of
-        # length n_findex
-        if len(self.turbulence_intensities) == 1:
-            self.turbulence_intensities = self.turbulence_intensities[0] * np.ones(self.n_findex)
 
     def initialize_velocity_field(self, grid: Grid) -> None:
 

--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -64,7 +64,7 @@ class FlowField(BaseClass):
                 "turbulence_intensities must have 1-dimension"
             )
 
-        # Check the turbulence intensity is lenght n_findex
+        # Check the turbulence intensity is length n_findex
         if len(value) != self.n_findex:
             raise ValueError("turbulence_intensities must be length n_findex")
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -267,15 +267,18 @@ class FlorisInterface(LoggingManager):
                 (wind_directions is not None)
                 or (wind_speeds is not None)
                 or (turbulence_intensities is not None)
+                or (heterogenous_inflow_config is not None)
             ):
                 raise ValueError(
                     "If wind_data is passed to reinitialize, then do not pass wind_directions, "
-                    "wind_speeds or turbulence_intensities as this is redundant"
+                    "wind_speeds, turbulence_intensities or "
+                    "heterogenous_inflow_config as this is redundant"
                 )
             (
                 wind_directions,
                 wind_speeds,
                 turbulence_intensities,
+                heterogenous_inflow_config,
             ) = wind_data.unpack_for_reinitialize()
 
         ## FlowField

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -296,27 +296,6 @@ class FlorisInterface(LoggingManager):
         if heterogenous_inflow_config is not None:
             flow_field_dict["heterogenous_inflow_config"] = heterogenous_inflow_config
 
-        # Handle a special case where:
-        #   wind_speeds | wind_directions are not None
-        #   turbulence_intensities is None
-        #   len(turbulence intensity) != len(wind_directions)
-        #   turbulence_intensities is uniform
-        # In this case, automatically resize turbulence intensity
-        # This is the case where user is assuming same TI across all findex
-        if (
-            (wind_speeds is not None or wind_directions is not None)
-            and turbulence_intensities is None
-            and (
-                len(flow_field_dict["turbulence_intensities"])
-                != len(flow_field_dict["wind_directions"])
-            )
-            and len(np.unique(flow_field_dict["turbulence_intensities"])) == 1
-        ):
-            flow_field_dict["turbulence_intensities"] = (
-                flow_field_dict["turbulence_intensities"][0]
-                * np.ones_like(flow_field_dict["wind_directions"])
-            )
-
         ## Farm
         if layout_x is not None:
             farm_dict["layout_x"] = layout_x
@@ -1000,6 +979,9 @@ class FlorisInterface(LoggingManager):
         # the the farm_power variable as an empty array.
         wind_speeds = np.array(self.floris.flow_field.wind_speeds, copy=True)
         wind_directions = np.array(self.floris.flow_field.wind_directions, copy=True)
+        turbulence_intensities = np.array(
+            self.floris.flow_field.turbulence_intensities, copy=True
+        )
         farm_power = np.zeros(self.floris.flow_field.n_findex)
 
         # Determine which wind speeds we must evaluate
@@ -1011,9 +993,11 @@ class FlorisInterface(LoggingManager):
         if np.any(conditions_to_evaluate):
             wind_speeds_subset = wind_speeds[conditions_to_evaluate]
             wind_directions_subset = wind_directions[conditions_to_evaluate]
+            turbulence_intensities_subset = turbulence_intensities[conditions_to_evaluate]
             self.set(
                 wind_speeds=wind_speeds_subset,
                 wind_directions=wind_directions_subset,
+                turbulence_intensities=turbulence_intensities_subset,
             )
             if no_wake:
                 self.run_no_wake()
@@ -1027,7 +1011,9 @@ class FlorisInterface(LoggingManager):
         aep = np.sum(np.multiply(freq, farm_power) * 365 * 24)
 
         # Reset the FLORIS object to the full wind speed array
-        self.set(wind_speeds=wind_speeds, wind_directions=wind_directions)
+        self.set(wind_speeds=wind_speeds,
+                 wind_directions=wind_directions,
+                 turbulence_intensities=turbulence_intensities)
 
         return aep
 

--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -1014,9 +1014,11 @@ class FlorisInterface(LoggingManager):
         aep = np.sum(np.multiply(freq, farm_power) * 365 * 24)
 
         # Reset the FLORIS object to the full wind speed array
-        self.set(wind_speeds=wind_speeds,
-                 wind_directions=wind_directions,
-                 turbulence_intensities=turbulence_intensities)
+        self.set(
+            wind_speeds=wind_speeds,
+            wind_directions=wind_directions,
+            turbulence_intensities=turbulence_intensities
+        )
 
         return aep
 

--- a/floris/tools/wind_data.py
+++ b/floris/tools/wind_data.py
@@ -910,7 +910,7 @@ class TimeSeries(WindDataBase):
     turbulence intensity can be assigned as an array of values or a single value.
     At least one of wind_directions, wind_speeds, or turbulence_intensities must
     be an array.  If arrays are provided, they must be the same length as the
-    other arrays or the single values.  If signle values are provided, then an
+    other arrays or the single values.  If single values are provided, then an
     array of the same length as the other arrays will be created with the single
     value.
 

--- a/floris/tools/wind_data.py
+++ b/floris/tools/wind_data.py
@@ -33,8 +33,8 @@ class WindDataBase:
         (
             wind_directions_unpack,
             wind_speeds_unpack,
-            _,
             ti_table_unpack,
+            _,
             _,
         ) = self.unpack()
 
@@ -46,8 +46,8 @@ class WindDataBase:
         (
             _,
             _,
-            freq_table_unpack,
             _,
+            freq_table_unpack,
             _,
         ) = self.unpack()
 
@@ -207,8 +207,8 @@ class WindRose(WindDataBase):
         return (
             wind_directions_unpack,
             wind_speeds_unpack,
-            freq_table_unpack,
             ti_table_unpack,
+            freq_table_unpack,
             value_table_unpack,
         )
 
@@ -539,8 +539,8 @@ class WindTIRose(WindDataBase):
         return (
             wind_directions_unpack,
             wind_speeds_unpack,
-            freq_table_unpack,
             turbulence_intensities_unpack,
+            freq_table_unpack,
             value_table_unpack,
         )
 
@@ -830,8 +830,8 @@ class TimeSeries(WindDataBase):
         return (
             self.wind_directions,
             self.wind_speeds,
-            uniform_frequency,
             self.turbulence_intensities,
+            uniform_frequency,
             self.values,
         )
 

--- a/floris/tools/wind_data.py
+++ b/floris/tools/wind_data.py
@@ -966,8 +966,9 @@ class TimeSeries(WindDataBase):
                     "wind_directions and wind_speeds must be the same length if provided as arrays"
                 )
 
-        if isinstance(wind_directions, np.ndarray) and isinstance(
-            turbulence_intensities, np.ndarray
+        if (
+            isinstance(wind_directions, np.ndarray)
+            and isinstance(turbulence_intensities, np.ndarray)
         ):
             if len(wind_directions) != len(turbulence_intensities):
                 raise ValueError(

--- a/floris/tools/wind_data.py
+++ b/floris/tools/wind_data.py
@@ -96,8 +96,8 @@ class WindDataBase:
             heterogenous_inflow_config (dict): A dictionary containing the following keys:
                 * 'speed_multipliers': A 2D NumPy array (size n_findex x num_points)
                       of speed multipliers.
-                * 'x': A 1D NumPy array (size n_findex) of x-coordinates (meters).
-                * 'y': A 1D NumPy array (size n_findex) of y-coordinates (meters).
+                * 'x': A 1D NumPy array (size num_points) of x-coordinates (meters).
+                * 'y': A 1D NumPy array (size num_points) of y-coordinates (meters).
         """
         if heterogenous_inflow_config is not None:
             if not isinstance(heterogenous_inflow_config, dict):
@@ -194,7 +194,8 @@ class WindRose(WindDataBase):
             each bin to compute the total value of the energy produced
         compute_zero_freq_occurrence: Flag indicating whether to compute zero
             frequency occurrences (bool, optional).  Defaults to False.
-        heterogenous_inflow_config_by_wd (dict): A dictionary containing the following keys:
+        heterogenous_inflow_config_by_wd (dict, optional): A dictionary containing the following
+            keys. Defaults to None.
             * 'speed_multipliers': A 2D NumPy array (size num_wd x num_points)
                     of speed multipliers.
             * 'wind_directions': A 1D NumPy array (size num_wd) of wind directions (degrees).
@@ -564,7 +565,8 @@ class WindTIRose(WindDataBase):
             to compute the total value of the energy produced.
         compute_zero_freq_occurrence: Flag indicating whether to compute zero
             frequency occurrences (bool, optional).  Defaults to False.
-        heterogenous_inflow_config_by_wd (dict): A dictionary containing the following keys:
+        heterogenous_inflow_config_by_wd (dict, optional): A dictionary containing the following
+            keys. Defaults to None.
             * 'speed_multipliers': A 2D NumPy array (size num_wd x num_points)
                     of speed multipliers.
             * 'wind_directions': A 1D NumPy array (size num_wd) of wind directions (degrees).
@@ -921,17 +923,19 @@ class TimeSeries(WindDataBase):
             a single value or an array of values.
         values (NDArrayFloat, optional): Values associated with each wind
             direction, wind speed, and turbulence intensity. Defaults to None.
-        heterogenous_inflow_config_by_wd (dict): A dictionary containing the following keys:
+        heterogenous_inflow_config_by_wd (dict, optional): A dictionary containing the following
+            keys. Defaults to None.
             * 'speed_multipliers': A 2D NumPy array (size num_wd x num_points)
                     of speed multipliers.
             * 'wind_directions': A 1D NumPy array (size num_wd) of wind directions (degrees).
             * 'x': A 1D NumPy array (size num_points) of x-coordinates (meters).
             * 'y': A 1D NumPy array (size num_points) of y-coordinates (meters).
-        heterogenous_inflow_config (dict): A dictionary containing the following keys:
+        heterogenous_inflow_config (dict, optional): A dictionary containing the following keys.
+            Defaults to None.
             * 'speed_multipliers': A 2D NumPy array (size n_findex x num_points)
                     of speed multipliers.
-            * 'x': A 1D NumPy array (size n_findex) of x-coordinates (meters).
-            * 'y': A 1D NumPy array (size n_findex) of y-coordinates (meters).
+            * 'x': A 1D NumPy array (size num_points) of x-coordinates (meters).
+            * 'y': A 1D NumPy array (size num_points) of y-coordinates (meters).
     """
 
     def __init__(

--- a/floris/tools/wind_data.py
+++ b/floris/tools/wind_data.py
@@ -60,7 +60,7 @@ class WindDataBase:
 
         return freq_table_unpack
 
-    def check_heterogenous_inflow_config_by_wd(heterogenous_inflow_config_by_wd):
+    def check_heterogenous_inflow_config_by_wd(self, heterogenous_inflow_config_by_wd):
         """
         Check that the heterogenous_inflow_config_by_wd dictionary is properly formatted
 
@@ -87,7 +87,7 @@ class WindDataBase:
             if "y" not in heterogenous_inflow_config_by_wd:
                 raise ValueError("heterogenous_inflow_config_by_wd must contain a key 'y'")
 
-    def check_heterogenous_inflow_config(heterogenous_inflow_config):
+    def check_heterogenous_inflow_config(self, heterogenous_inflow_config):
         """
         Check that the heterogenous_inflow_config dictionary is properly formatted
 

--- a/floris/tools/wind_data.py
+++ b/floris/tools/wind_data.py
@@ -66,10 +66,11 @@ class WindDataBase:
 
         Args:
             heterogenous_inflow_config_by_wd (dict): A dictionary containing the following keys:
-                * 'speed_multipliers': A 2D NumPy array (size mxn) of speed multipliers.
-                * 'wind_directions': A 1D NumPy array (size m) of wind directions (degrees).
-                * 'x': A 1D NumPy array (size m) of x-coordinates (meters).
-                * 'y': A 1D NumPy array (size m) of y-coordinates (meters).
+                * 'speed_multipliers': A 2D NumPy array (size num_wd x num_points)
+                     of speed multipliers.
+                * 'wind_directions': A 1D NumPy array (size num_wd) of wind directions (degrees).
+                * 'x': A 1D NumPy array (size num_points) of x-coordinates (meters).
+                * 'y': A 1D NumPy array (size num_points) of y-coordinates (meters).
         """
         if heterogenous_inflow_config_by_wd is not None:
             if not isinstance(heterogenous_inflow_config_by_wd, dict):
@@ -93,9 +94,10 @@ class WindDataBase:
 
         Args:
             heterogenous_inflow_config (dict): A dictionary containing the following keys:
-                * 'speed_multipliers': A 2D NumPy array (size mxn) of speed multipliers.
-                * 'x': A 1D NumPy array (size m) of x-coordinates (meters).
-                * 'y': A 1D NumPy array (size m) of y-coordinates (meters).
+                * 'speed_multipliers': A 2D NumPy array (size n_findex x num_points)
+                      of speed multipliers.
+                * 'x': A 1D NumPy array (size n_findex) of x-coordinates (meters).
+                * 'y': A 1D NumPy array (size n_findex) of y-coordinates (meters).
         """
         if heterogenous_inflow_config is not None:
             if not isinstance(heterogenous_inflow_config, dict):
@@ -114,12 +116,12 @@ class WindDataBase:
         Processes heterogenous inflow configuration data to generate a speed multiplier array
         aligned with the wind directions. Accounts for the cyclical nature of wind directions.
         Args:
-            heterogenous_inflow_config_by_wd (dict): A dictionary containing the
-                following keys:
-                * 'speed_multipliers': A 2D NumPy array (size mxn) of speed multipliers.
-                * 'wind_directions': A 1D NumPy array (size m) of wind directions (degrees).
-                * 'x': A 1D NumPy array (size m) of x-coordinates (meters).
-                * 'y': A 1D NumPy array (size m) of y-coordinates (meters).
+            heterogenous_inflow_config_by_wd (dict): A dictionary containing the following keys:
+                * 'speed_multipliers': A 2D NumPy array (size num_wd x num_points)
+                     of speed multipliers.
+                * 'wind_directions': A 1D NumPy array (size num_wd) of wind directions (degrees).
+                * 'x': A 1D NumPy array (size num_points) of x-coordinates (meters).
+                * 'y': A 1D NumPy array (size num_points) of y-coordinates (meters).
 
             wind_directions (np.array): Wind directions to map onto
         Returns:
@@ -192,12 +194,12 @@ class WindRose(WindDataBase):
             each bin to compute the total value of the energy produced
         compute_zero_freq_occurrence: Flag indicating whether to compute zero
             frequency occurrences (bool, optional).  Defaults to False.
-        heterogenous_inflow_config_by_wd (dict, optional): A dictionary
-            containing the following keys:
-            * 'speed_multipliers': A 2D NumPy array (size mxn) of speed multipliers.
-            * 'wind_directions': A 1D NumPy array (size m) of wind directions (degrees).
-            * 'x': A 1D NumPy array (size m) of x-coordinates (meters).
-            * 'y': A 1D NumPy array (size m) of y-coordinates (meters).
+        heterogenous_inflow_config_by_wd (dict): A dictionary containing the following keys:
+            * 'speed_multipliers': A 2D NumPy array (size num_wd x num_points)
+                    of speed multipliers.
+            * 'wind_directions': A 1D NumPy array (size num_wd) of wind directions (degrees).
+            * 'x': A 1D NumPy array (size num_points) of x-coordinates (meters).
+            * 'y': A 1D NumPy array (size num_points) of y-coordinates (meters).
 
     """
 
@@ -562,12 +564,12 @@ class WindTIRose(WindDataBase):
             to compute the total value of the energy produced.
         compute_zero_freq_occurrence: Flag indicating whether to compute zero
             frequency occurrences (bool, optional).  Defaults to False.
-        heterogenous_inflow_config_by_wd (dict, optional): A dictionary containing
-             the following keys:
-            * 'speed_multipliers': A 2D NumPy array (size mxn) of speed multipliers.
-            * 'wind_directions': A 1D NumPy array (size m) of wind directions (degrees).
-            * 'x': A 1D NumPy array (size m) of x-coordinates (meters).
-            * 'y': A 1D NumPy array (size m) of y-coordinates (meters).
+        heterogenous_inflow_config_by_wd (dict): A dictionary containing the following keys:
+            * 'speed_multipliers': A 2D NumPy array (size num_wd x num_points)
+                    of speed multipliers.
+            * 'wind_directions': A 1D NumPy array (size num_wd) of wind directions (degrees).
+            * 'x': A 1D NumPy array (size num_points) of x-coordinates (meters).
+            * 'y': A 1D NumPy array (size num_points) of y-coordinates (meters).
 
     """
 
@@ -911,16 +913,25 @@ class TimeSeries(WindDataBase):
     value.
 
     Args:
-        wind_direction (float, NDArrayFloat): Wind direction. Can be a single
+        wind_directions (float, NDArrayFloat): Wind direction. Can be a single
             value or an array of values.
-        wind_speed (float, NDArrayFloat): Wind speed. Can be a single value or
+        wind_speeds (float, NDArrayFloat): Wind speed. Can be a single value or
             an array of values.
-        turbulence_intensity (float, NDArrayFloat): Turbulence intensity. Can be
+        turbulence_intensities (float, NDArrayFloat): Turbulence intensity. Can be
             a single value or an array of values.
         values (NDArrayFloat, optional): Values associated with each wind
             direction, wind speed, and turbulence intensity. Defaults to None.
-
-
+        heterogenous_inflow_config_by_wd (dict): A dictionary containing the following keys:
+            * 'speed_multipliers': A 2D NumPy array (size num_wd x num_points)
+                    of speed multipliers.
+            * 'wind_directions': A 1D NumPy array (size num_wd) of wind directions (degrees).
+            * 'x': A 1D NumPy array (size num_points) of x-coordinates (meters).
+            * 'y': A 1D NumPy array (size num_points) of y-coordinates (meters).
+        heterogenous_inflow_config (dict): A dictionary containing the following keys:
+            * 'speed_multipliers': A 2D NumPy array (size n_findex x num_points)
+                    of speed multipliers.
+            * 'x': A 1D NumPy array (size n_findex) of x-coordinates (meters).
+            * 'y': A 1D NumPy array (size n_findex) of y-coordinates (meters).
     """
 
     def __init__(

--- a/profiling/quality_metrics.py
+++ b/profiling/quality_metrics.py
@@ -16,6 +16,7 @@ wd_grid, ws_grid = np.meshgrid(
 )
 WIND_DIRECTIONS = wd_grid.flatten()
 WIND_SPEEDS = ws_grid.flatten()
+TURBULENCE_INTENSITIES = np.ones_like(WIND_DIRECTIONS) * 0.1
 N_FINDEX = len(WIND_DIRECTIONS)
 
 N_TURBINES = 3
@@ -116,6 +117,7 @@ if __name__=="__main__":
     sample_inputs.floris["farm"]["layout_y"] = Y_COORDS
     sample_inputs.floris["flow_field"]["wind_directions"] = WIND_DIRECTIONS
     sample_inputs.floris["flow_field"]["wind_speeds"] = WIND_SPEEDS
+    sample_inputs.floris["flow_field"]["turbulence_intensities"] = TURBULENCE_INTENSITIES
 
     print()
     print("### Memory profiling")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,24 @@ WIND_SPEEDS = [
     10.0,
     11.0,
 ]
+TURBULENCE_INTENSITIES = [
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+]
 
 # FINDEX is the length of the number of conditions, so it can be
 # len(WIND_DIRECTIONS) or len(WIND_SPEEDS
@@ -407,7 +425,7 @@ class SampleInputs:
         self.flow_field = {
             "wind_speeds": WIND_SPEEDS,
             "wind_directions": WIND_DIRECTIONS,
-            "turbulence_intensities": [0.1],
+            "turbulence_intensities": TURBULENCE_INTENSITIES,
             "wind_shear": 0.12,
             "wind_veer": 0.0,
             "air_density": 1.225,

--- a/tests/floris_interface_integration_test.py
+++ b/tests/floris_interface_integration_test.py
@@ -62,15 +62,16 @@ def test_set_run():
     fi.run()
     assert fi.floris.farm.yaw_angles == yaw_angles
 
-    # Verify making changes to the layout, wind speed, and wind direction  and
-    # turbulence intensity both before and after
-    # running the calculation
+    # Verify making changes to the layout, wind speed, wind direction  and
+    # turbulence intensity both before and after running the calculation
     fi.reset_operation()
-    fi.set(layout_x=[0, 0],
-            layout_y=[0, 1000],
-            wind_speeds=[8, 8],
-            wind_directions=[270, 270],
-            turbulence_intensities=[0.06, 0.06])
+    fi.set(
+        layout_x=[0, 0],
+        layout_y=[0, 1000],
+        wind_speeds=[8, 8],
+        wind_directions=[270, 270],
+        turbulence_intensities=[0.06, 0.06]
+    )
     assert np.array_equal(fi.floris.farm.layout_x, np.array([0, 0]))
     assert np.array_equal(fi.floris.farm.layout_y, np.array([0, 1000]))
     assert np.array_equal(fi.floris.flow_field.wind_speeds, np.array([8, 8]))
@@ -435,12 +436,7 @@ def test_set_ti():
     with pytest.raises(ValueError):
         fi.set(
             wind_speeds=[8.0, 8.0, 8.0, 8.0],
-            wind_directions=[
-                240.0,
-                250.0,
-                260.0,
-                270.0,
-            ],
+            wind_directions=[240.0, 250.0, 260.0, 270.0],
         )
 
 

--- a/tests/floris_interface_integration_test.py
+++ b/tests/floris_interface_integration_test.py
@@ -341,6 +341,7 @@ def test_get_farm_aep_with_conditions():
 
     wind_speeds = np.array([5.0, 8.0, 8.0, 8.0, 20.0])
     wind_directions = np.array([270.0, 270.0, 270.0, 270.0, 270.0])
+    turbulence_intensities = np.array([0.06, 0.06, 0.06, 0.06, 0.06])
     n_findex = len(wind_directions)
 
     layout_x = np.array([0, 0])
@@ -350,6 +351,7 @@ def test_get_farm_aep_with_conditions():
     fi.set(
         wind_speeds=wind_speeds,
         wind_directions=wind_directions,
+        turbulence_intensities=turbulence_intensities,
         layout_x=layout_x,
         layout_y=layout_y,
     )
@@ -388,45 +390,26 @@ def test_set_ti():
         turbulence_intensities=[0.1, 0.1, 0.1],
     )
 
-    # Now confirm can change wind speeds and directions shape without changing
-    # turbulence intensity since this is allowed when the turbulence intensities are uniform
-    # raises n_findex to 4
-    fi.set(
-        wind_speeds=[8.0, 8.0, 8.0, 8.0],
-        wind_directions=[
-            240.0,
-            250.0,
-            260.0,
-            270.0,
-        ],
-    )
+    # Confirm can change turbulence intensities if not changing the lenght of the array
+    fi.set(turbulence_intensities=[0.12, 0.12, 0.12])
 
-    # Confirm turbulence_intensities now length 4 with single unique value
-    np.testing.assert_allclose(fi.floris.flow_field.turbulence_intensities, [0.1, 0.1, 0.1, 0.1])
-
-    # Now should be able to change turbulence intensity to changing, so long as length 4
-    fi.set(turbulence_intensities=[0.08, 0.09, 0.1, 0.11])
-
-    # However the wrong length should raise an error
-    with pytest.raises(ValueError):
-        fi.set(turbulence_intensities=[0.08, 0.09, 0.1])
-
-    # Also, now that TI is not a single unique value, it can not be left default when changing
-    # shape of wind speeds and directions
+    # Confirm that changes wind speeds and directions without change turbulence intensities
+    # raises an error
     with pytest.raises(ValueError):
         fi.set(
-            wind_speeds=[8.0, 8.0, 8.0, 8.0, 8.0],
+            wind_speeds=[8.0, 8.0, 8.0, 8.0],
             wind_directions=[
                 240.0,
                 250.0,
                 260.0,
                 270.0,
-                280.0,
             ],
         )
 
-    # Test that applying a 1D array of length 1 is allowed for ti
-    fi.set(turbulence_intensities=[0.12])
+
+    # Changing the length of TI alone is not allowed
+    with pytest.raises(ValueError):
+        fi.set(turbulence_intensities=[0.12])
 
     # Test that applying a float however raises an error
     with pytest.raises(TypeError):

--- a/tests/floris_interface_integration_test.py
+++ b/tests/floris_interface_integration_test.py
@@ -428,10 +428,10 @@ def test_set_ti():
         turbulence_intensities=[0.1, 0.1, 0.1],
     )
 
-    # Confirm can change turbulence intensities if not changing the lenght of the array
+    # Confirm can change turbulence intensities if not changing the length of the array
     fi.set(turbulence_intensities=[0.12, 0.12, 0.12])
 
-    # Confirm that changes wind speeds and directions without change turbulence intensities
+    # Confirm that changes to wind speeds and directions without changing turbulence intensities
     # raises an error
     with pytest.raises(ValueError):
         fi.set(

--- a/tests/floris_interface_integration_test.py
+++ b/tests/floris_interface_integration_test.py
@@ -37,10 +37,15 @@ def test_set_run():
     fi.run()
     assert fi.floris.farm.yaw_angles == yaw_angles
 
-    # Verify making changes to the layout, wind speed, and wind direction both before and after
+    # Verify making changes to the layout, wind speed, and wind direction  and
+    # turbulence intensity both before and after
     # running the calculation
     fi.reset_operation()
-    fi.set(layout_x=[0, 0], layout_y=[0, 1000], wind_speeds=[8, 8], wind_directions=[270, 270])
+    fi.set(layout_x=[0, 0],
+            layout_y=[0, 1000],
+            wind_speeds=[8, 8],
+            wind_directions=[270, 270],
+            turbulence_intensities=[0.06, 0.06])
     assert np.array_equal(fi.floris.farm.layout_x, np.array([0, 0]))
     assert np.array_equal(fi.floris.farm.layout_y, np.array([0, 1000]))
     assert np.array_equal(fi.floris.flow_field.wind_speeds, np.array([8, 8]))
@@ -146,6 +151,7 @@ def test_get_turbine_powers():
 
     wind_speeds = np.array([8.0, 8.0, 8.0])
     wind_directions = np.array([270.0, 270.0, 270.0])
+    turbulence_intensities = np.array([0.06, 0.06, 0.06])
     n_findex = len(wind_directions)
 
     layout_x = np.array([0, 0])
@@ -155,6 +161,7 @@ def test_get_turbine_powers():
     fi.set(
         wind_speeds=wind_speeds,
         wind_directions=wind_directions,
+        turbulence_intensities=turbulence_intensities,
         layout_x=layout_x,
         layout_y=layout_y,
     )
@@ -172,6 +179,7 @@ def test_get_farm_power():
 
     wind_speeds = np.array([8.0, 8.0, 8.0])
     wind_directions = np.array([270.0, 270.0, 270.0])
+    turbulence_intensities = np.array([0.06, 0.06, 0.06])
     n_findex = len(wind_directions)
 
     layout_x = np.array([0, 0])
@@ -181,6 +189,7 @@ def test_get_farm_power():
     fi.set(
         wind_speeds=wind_speeds,
         wind_directions=wind_directions,
+        turbulence_intensities=turbulence_intensities,
         layout_x=layout_x,
         layout_y=layout_y,
     )
@@ -234,6 +243,7 @@ def test_disable_turbines():
     fi.set(
         wind_speeds=np.array([8.,8.,]),
         wind_directions=np.array([270.,270.]),
+        turbulence_intensities=np.array([0.06,0.06]),
         layout_x = [0,1000,2000],
         layout_y=[0,0,0]
     )
@@ -308,6 +318,7 @@ def test_get_farm_aep():
 
     wind_speeds = np.array([8.0, 8.0, 8.0])
     wind_directions = np.array([270.0, 270.0, 270.0])
+    turbulence_intensities = np.array([0.06, 0.06, 0.06])
     n_findex = len(wind_directions)
 
     layout_x = np.array([0, 0])
@@ -317,6 +328,7 @@ def test_get_farm_aep():
     fi.set(
         wind_speeds=wind_speeds,
         wind_directions=wind_directions,
+        turbulence_intensities=turbulence_intensities,
         layout_x=layout_x,
         layout_y=layout_y,
     )

--- a/tests/reg_tests/cumulative_curl_regression_test.py
+++ b/tests/reg_tests/cumulative_curl_regression_test.py
@@ -318,6 +318,7 @@ def test_regression_rotation(sample_inputs_fixture):
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1, 0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()
@@ -688,6 +689,7 @@ def test_full_flow_solver(sample_inputs_fixture):
     }
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.solve_for_viz()

--- a/tests/reg_tests/empirical_gauss_regression_test.py
+++ b/tests/reg_tests/empirical_gauss_regression_test.py
@@ -293,6 +293,7 @@ def test_regression_rotation(sample_inputs_fixture):
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1, 0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()
@@ -658,6 +659,7 @@ def test_full_flow_solver(sample_inputs_fixture):
     }
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.solve_for_viz()

--- a/tests/reg_tests/gauss_regression_test.py
+++ b/tests/reg_tests/gauss_regression_test.py
@@ -410,6 +410,8 @@ def test_regression_rotation(sample_inputs_fixture):
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1, 0.1]
+
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()
@@ -946,6 +948,7 @@ def test_full_flow_solver(sample_inputs_fixture):
     }
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.solve_for_viz()

--- a/tests/reg_tests/jensen_jimenez_regression_test.py
+++ b/tests/reg_tests/jensen_jimenez_regression_test.py
@@ -260,6 +260,7 @@ def test_regression_rotation(sample_inputs_fixture):
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1, 0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()
@@ -464,6 +465,7 @@ def test_full_flow_solver(sample_inputs_fixture):
     }
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.solve_for_viz()

--- a/tests/reg_tests/none_regression_test.py
+++ b/tests/reg_tests/none_regression_test.py
@@ -261,6 +261,7 @@ def test_regression_rotation(sample_inputs_fixture):
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1, 0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()
@@ -389,6 +390,7 @@ def test_full_flow_solver(sample_inputs_fixture):
     }
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.solve_for_viz()

--- a/tests/reg_tests/turbopark_regression_test.py
+++ b/tests/reg_tests/turbopark_regression_test.py
@@ -221,6 +221,7 @@ def test_regression_rotation(sample_inputs_fixture):
     ]
     sample_inputs_fixture.floris["flow_field"]["wind_directions"] = [270.0, 360.0]
     sample_inputs_fixture.floris["flow_field"]["wind_speeds"] = [8.0, 8.0]
+    sample_inputs_fixture.floris["flow_field"]["turbulence_intensities"] = [0.1, 0.1]
 
     floris = Floris.from_dict(sample_inputs_fixture.floris)
     floris.initialize_domain()

--- a/tests/reg_tests/yaw_optimization_regression_test.py
+++ b/tests/reg_tests/yaw_optimization_regression_test.py
@@ -83,12 +83,15 @@ def test_serial_refine(sample_inputs_fixture):
     fi = FlorisInterface(sample_inputs_fixture.floris)
     wd_array = np.arange(0.0, 360.0, 90.0)
     ws_array = 8.0 * np.ones_like(wd_array)
+    ti_array = 0.1 * np.ones_like(wd_array)
+
     D = 126.0 # Rotor diameter for the NREL 5 MW
     fi.set(
         layout_x=[0.0, 5 * D, 10 * D],
         layout_y=[0.0, 0.0, 0.0],
         wind_directions=wd_array,
         wind_speeds=ws_array,
+        turbulence_intensities=ti_array,
     )
 
     yaw_opt = YawOptimizationSR(fi)
@@ -113,12 +116,14 @@ def test_geometric_yaw(sample_inputs_fixture):
     fi = FlorisInterface(sample_inputs_fixture.floris)
     wd_array = np.arange(0.0, 360.0, 90.0)
     ws_array = 8.0 * np.ones_like(wd_array)
+    ti_array = 0.1 * np.ones_like(wd_array)
     D = 126.0 # Rotor diameter for the NREL 5 MW
     fi.set(
         layout_x=[0.0, 5 * D, 10 * D],
         layout_y=[0.0, 0.0, 0.0],
         wind_directions=wd_array,
         wind_speeds=ws_array,
+        turbulence_intensities=ti_array,
     )
     fi.run()
     baseline_farm_power = fi.get_farm_power().squeeze()
@@ -161,12 +166,14 @@ def test_scipy_yaw_opt(sample_inputs_fixture):
     fi = FlorisInterface(sample_inputs_fixture.floris)
     wd_array = np.arange(0.0, 360.0, 90.0)
     ws_array = 8.0 * np.ones_like(wd_array)
+    ti_array = 0.1 * np.ones_like(wd_array)
     D = 126.0 # Rotor diameter for the NREL 5 MW
     fi.set(
         layout_x=[0.0, 5 * D, 10 * D],
         layout_y=[0.0, 0.0, 0.0],
         wind_directions=wd_array,
         wind_speeds=ws_array,
+        turbulence_intensities=ti_array,
     )
 
     yaw_opt = YawOptimizationScipy(fi, opt_options=opt_options)

--- a/tests/wind_data_integration_test.py
+++ b/tests/wind_data_integration_test.py
@@ -121,8 +121,8 @@ def test_wind_rose_unpack():
     (
         wind_directions_unpack,
         wind_speeds_unpack,
-        freq_table_unpack,
         ti_table_unpack,
+        freq_table_unpack,
         value_table_unpack,
     ) = wind_rose.unpack()
 
@@ -130,6 +130,7 @@ def test_wind_rose_unpack():
     # we expect only the (270 deg, 6 m/s) and (280 deg, 7 m/s) rows
     np.testing.assert_allclose(wind_directions_unpack, [270, 280])
     np.testing.assert_allclose(wind_speeds_unpack, [6, 7])
+    np.testing.assert_allclose(ti_table_unpack, [0.06, 0.06])
     np.testing.assert_allclose(freq_table_unpack, [0.5, 0.5])
 
     # In this case n_findex is the length of the wind combinations that are
@@ -144,8 +145,8 @@ def test_wind_rose_unpack():
     (
         wind_directions_unpack,
         wind_speeds_unpack,
-        freq_table_unpack,
         ti_table_unpack,
+        freq_table_unpack,
         value_table_unpack,
     ) = wind_rose.unpack()
 
@@ -174,6 +175,7 @@ def test_unpack_for_reinitialize():
     # (270 deg, 6 m/s) and (280 deg, 7 m/s) rows
     np.testing.assert_allclose(wind_directions_unpack, [270, 280])
     np.testing.assert_allclose(wind_speeds_unpack, [6, 7])
+    np.testing.assert_allclose(ti_table_unpack, [0.06, 0.06])
 
 
 def test_wind_rose_resample():
@@ -347,8 +349,8 @@ def test_wind_ti_rose_unpack():
     (
         wind_directions_unpack,
         wind_speeds_unpack,
-        freq_table_unpack,
         turbulence_intensities_unpack,
+        freq_table_unpack,
         value_table_unpack,
     ) = wind_rose.unpack()
 
@@ -376,8 +378,8 @@ def test_wind_ti_rose_unpack():
     (
         wind_directions_unpack,
         wind_speeds_unpack,
-        freq_table_unpack,
         turbulence_intensities_unpack,
+        freq_table_unpack,
         value_table_unpack,
     ) = wind_rose.unpack()
 

--- a/tests/wind_data_integration_test.py
+++ b/tests/wind_data_integration_test.py
@@ -53,9 +53,11 @@ def test_time_series_instantiation():
     # Test the passing in a 1D array of turbulence intensities which is longer than the
     # wind directions and wind speeds raises an error
     with pytest.raises(ValueError):
-        TimeSeries(wind_directions,
-                   wind_speeds,
-                   turbulence_intensities=np.array([0.06, 0.07, 0.08, 0.09]))
+        TimeSeries(
+            wind_directions,
+            wind_speeds,
+            turbulence_intensities=np.array([0.06, 0.07, 0.08, 0.09])
+        )
 
 
 def test_wind_rose_init():
@@ -68,8 +70,10 @@ def test_wind_rose_init():
 
     # Pass ti_table in as a single float and confirm it is broadcast to the correct shape
     wind_rose = WindRose(wind_directions, wind_speeds, ti_table=0.06)
-    np.testing.assert_allclose(wind_rose.ti_table,
-                               np.array([[0.06, 0.06], [0.06, 0.06], [0.06, 0.06]]))
+    np.testing.assert_allclose(
+        wind_rose.ti_table,
+        np.array([[0.06, 0.06], [0.06, 0.06], [0.06, 0.06]])
+    )
 
     # Pass ti_table in as a 2D array and confirm it is used as is
     ti_table = np.array([[0.06, 0.06], [0.06, 0.06], [0.06, 0.06]])
@@ -78,9 +82,11 @@ def test_wind_rose_init():
 
     # Confirm passing in a ti_table that is 1D raises an error
     with pytest.raises(ValueError):
-        WindRose(wind_directions,
-                 wind_speeds,
-                 ti_table=np.array([0.06, 0.06, 0.06, 0.06, 0.06, 0.06]))
+        WindRose(
+            wind_directions,
+            wind_speeds,
+            ti_table=np.array([0.06, 0.06, 0.06, 0.06, 0.06, 0.06])
+        )
 
     # Confirm passing in a ti_table that is wrong dimensions raises an error
     with pytest.raises(ValueError):
@@ -125,7 +131,6 @@ def test_wind_rose_unpack():
         freq_table_unpack,
         value_table_unpack,
         heterogenous_inflow_config,
-
     ) = wind_rose.unpack()
 
     # Given the above frequency table with zeros for a few elements,
@@ -477,28 +482,40 @@ def test_time_series_to_wind_ti_rose():
 def test_get_speed_multipliers_by_wd():
 
     heterogenous_inflow_config_by_wd = {
-        'speed_multipliers': np.array([[1.0, 1.1, 1.2],
-                                       [1.1, 1.1, 1.1],
-                                       [1.3, 1.4, 1.5],]),
+        'speed_multipliers': np.array(
+            [
+                [1.0, 1.1, 1.2],
+                [1.1, 1.1, 1.1],
+                [1.3, 1.4, 1.5],
+            ]
+        ),
         'wind_directions': np.array([0, 90, 270])
     }
 
     # Check for correctness
     wind_directions = np.array([240, 80,15])
-    expected_output = np.array([[1.3, 1.4, 1.5],
-                                [1.1, 1.1, 1.1],
-                                [1.0, 1.1, 1.2]])
+    expected_output = np.array(
+        [
+            [1.3, 1.4, 1.5],
+            [1.1, 1.1, 1.1],
+            [1.0, 1.1, 1.2]
+        ]
+    )
     wind_data = WindDataBase()
-    result = wind_data.get_speed_multipliers_by_wd(heterogenous_inflow_config_by_wd,
-                                                   wind_directions)
+    result = wind_data.get_speed_multipliers_by_wd(
+        heterogenous_inflow_config_by_wd,
+        wind_directions
+    )
     assert np.allclose(result, expected_output)
 
     # Confirm wrapping behavior
     wind_directions = np.array([350, 10])
     expected_output = np.array([[1.0, 1.1, 1.2],
                                 [1.0, 1.1, 1.2]])
-    result = wind_data.get_speed_multipliers_by_wd(heterogenous_inflow_config_by_wd,
-                                                   wind_directions)
+    result = wind_data.get_speed_multipliers_by_wd(
+        heterogenous_inflow_config_by_wd,
+        wind_directions
+    )
     assert np.allclose(result, expected_output)
 
     # Confirm can expand the result to match wind directions
@@ -515,9 +532,13 @@ def test_gen_heterogenous_inflow_config():
     turbulence_intensities = 0.06
 
     heterogenous_inflow_config_by_wd = {
-        'speed_multipliers': np.array([[0.9, 0.9],
-                                       [1.0, 1.0],
-                                       [1.1, 1.2],]),
+        'speed_multipliers': np.array(
+            [
+                [0.9, 0.9],
+                [1.0, 1.0],
+                [1.1, 1.2],
+            ]
+        ),
         'wind_directions' : np.array([250, 260, 270]),
         'x' : np.array([0, 1000]),
         'y' : np.array([0, 0]),
@@ -532,10 +553,14 @@ def test_gen_heterogenous_inflow_config():
 
     (_, _, _, _, _, heterogenous_inflow_config) = time_series.unpack()
 
-    expected_result = np.array([[1.0, 1.0],
-                               [1.0, 1.0],
-                               [1.0, 1.0],
-                                 [1.0, 1.0],
-                                 [1.1, 1.2]])
+    expected_result = np.array(
+        [
+            [1.0, 1.0],
+            [1.0, 1.0],
+            [1.0, 1.0],
+            [1.0, 1.0],
+            [1.1, 1.2]
+        ]
+    )
     np.testing.assert_allclose(heterogenous_inflow_config['speed_multipliers'], expected_result)
     np.testing.assert_allclose(heterogenous_inflow_config['x'],heterogenous_inflow_config_by_wd['x'])

--- a/tests/wind_data_integration_test.py
+++ b/tests/wind_data_integration_test.py
@@ -124,6 +124,8 @@ def test_wind_rose_unpack():
         ti_table_unpack,
         freq_table_unpack,
         value_table_unpack,
+        heterogenous_inflow_config,
+
     ) = wind_rose.unpack()
 
     # Given the above frequency table with zeros for a few elements,
@@ -148,6 +150,7 @@ def test_wind_rose_unpack():
         ti_table_unpack,
         freq_table_unpack,
         value_table_unpack,
+        heterogenous_inflow_config,
     ) = wind_rose.unpack()
 
     # Expect now to compute all combinations
@@ -169,6 +172,7 @@ def test_unpack_for_reinitialize():
         wind_directions_unpack,
         wind_speeds_unpack,
         ti_table_unpack,
+        heterogenous_inflow_config,
     ) = wind_rose.unpack_for_reinitialize()
 
     # Given the above frequency table, would only expect the
@@ -352,6 +356,7 @@ def test_wind_ti_rose_unpack():
         turbulence_intensities_unpack,
         freq_table_unpack,
         value_table_unpack,
+        heterogenous_inflow_config,
     ) = wind_rose.unpack()
 
     # Given the above frequency table with zeros for a few elements,
@@ -381,6 +386,7 @@ def test_wind_ti_rose_unpack():
         turbulence_intensities_unpack,
         freq_table_unpack,
         value_table_unpack,
+        heterogenous_inflow_config,
     ) = wind_rose.unpack()
 
     # Expect now to compute all combinations
@@ -412,6 +418,7 @@ def test_wind_ti_rose_unpack_for_reinitialize():
         wind_directions_unpack,
         wind_speeds_unpack,
         turbulence_intensities_unpack,
+        heterogenous_inflow_config,
     ) = wind_rose.unpack_for_reinitialize()
 
     # Given the above frequency table with zeros for a few elements,


### PR DESCRIPTION
# Require TI must be n_findex in core code

After some discussions we agreed that a consistent to handle a few issues would be for the "core" code to require the turbulence intensities must be n_findex.  This avoids ambiguities and cases where the code might perform unexpectedly.  However, to simplify things for the user, the wind_data objects, WindRose, WindTIRose and TimeSeries will each now include methods for broadcasting a provided float value to match the given dimensions.

Further, the approach proposed in PR #821, where heterogeneity can be described with respect to wd, in addition along findex, will be adapted in this pull request to be methods of the respective WindData objects.  This enables that FlorisInterface can go back to requiring het_map to be have 0th dimension n_findex long, simplifying that code.

Steps in this draft then:

- [x] In flowfield: require that turbulence_intensities be length n_findex
- [x] In FlorisInterface: remove helper code to catch unchanged TI and set automatically
- [x] Update impacted tests to adjust to these changed requirements
- [x] Ensure all examples are working with new stricter rules
- [x] Enable broadcasting in the wind data objects
- [x] Add tests of broadcasting
- [x] Reorganize unpack function to TI appears before freq, consistent with inputs
- [x] Implement heterogeneity via wind direction in the wind data objects
- [x] Add tests of new heterogeneity functionality
- [x] Close #814 
- [ ] ~~Update the first example around these new rules~~

## Related issue
PR #821 
