### PR TITLE
Add TI as input for calculate plane functions

### DIFF
--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -491,6 +491,7 @@ class FlorisInterface(LoggingManager):
         y_bounds=None,
         wd=None,
         ws=None,
+        ti=None,
         yaw_angles=None,
         power_setpoints=None,
         disable_turbines=None,
@@ -512,6 +513,7 @@ class FlorisInterface(LoggingManager):
                 Defaults to None.
             wd (float, optional): Wind direction. Defaults to None.
             ws (float, optional): Wind speed. Defaults to None.
+            ti (float, optional): Turbulence intensity. Defaults to None.
             yaw_angles (NDArrayFloat, optional): Turbine yaw angles. Defaults
                 to None.
             power_setpoints (NDArrayFloat, optional):
@@ -528,7 +530,9 @@ class FlorisInterface(LoggingManager):
             wd = self.floris.flow_field.wind_directions
         if ws is None:
             ws = self.floris.flow_field.wind_speeds
-        self.check_wind_condition_for_viz(wd=wd, ws=ws)
+        if ti is None:
+            ti = self.floris.flow_field.turbulence_intensities
+        self.check_wind_condition_for_viz(wd=wd, ws=ws, ti=ti)
 
         # Store the current state for reinitialization
         floris_dict = self.floris.as_dict()
@@ -543,6 +547,7 @@ class FlorisInterface(LoggingManager):
         self.set(
             wind_directions=wd,
             wind_speeds=ws,
+            turbulence_intensities=ti,
             solver_settings=solver_settings,
             yaw_angles=yaw_angles,
             power_setpoints=power_setpoints,
@@ -585,6 +590,7 @@ class FlorisInterface(LoggingManager):
         z_bounds=None,
         wd=None,
         ws=None,
+        ti=None,
         yaw_angles=None,
         power_setpoints=None,
         disable_turbines=None,
@@ -614,7 +620,9 @@ class FlorisInterface(LoggingManager):
             wd = self.floris.flow_field.wind_directions
         if ws is None:
             ws = self.floris.flow_field.wind_speeds
-        self.check_wind_condition_for_viz(wd=wd, ws=ws)
+        if ti is None:
+            ti = self.floris.flow_field.turbulence_intensities
+        self.check_wind_condition_for_viz(wd=wd, ws=ws, ti=ti)
 
         # Store the current state for reinitialization
         floris_dict = self.floris.as_dict()
@@ -630,6 +638,7 @@ class FlorisInterface(LoggingManager):
         self.set(
             wind_directions=wd,
             wind_speeds=ws,
+            turbulence_intensities=ti,
             solver_settings=solver_settings,
             yaw_angles=yaw_angles,
             power_setpoints=power_setpoints,
@@ -667,6 +676,7 @@ class FlorisInterface(LoggingManager):
         z_bounds=None,
         wd=None,
         ws=None,
+        ti=None,
         yaw_angles=None,
         power_setpoints=None,
         disable_turbines=None,
@@ -690,6 +700,7 @@ class FlorisInterface(LoggingManager):
                 Defaults to None.
             wd (float, optional): Wind direction. Defaults to None.
             ws (float, optional): Wind speed. Defaults to None.
+            ti (float, optional): Turbulence intensity. Defaults to None.
             yaw_angles (NDArrayFloat, optional): Turbine yaw angles. Defaults
                 to None.
             power_setpoints (NDArrayFloat, optional):
@@ -708,7 +719,9 @@ class FlorisInterface(LoggingManager):
             wd = self.floris.flow_field.wind_directions
         if ws is None:
             ws = self.floris.flow_field.wind_speeds
-        self.check_wind_condition_for_viz(wd=wd, ws=ws)
+        if ti is None:
+            ti = self.floris.flow_field.turbulence_intensities
+        self.check_wind_condition_for_viz(wd=wd, ws=ws, ti=ti)
 
         # Store the current state for reinitialization
         floris_dict = self.floris.as_dict()
@@ -724,6 +737,7 @@ class FlorisInterface(LoggingManager):
         self.set(
             wind_directions=wd,
             wind_speeds=ws,
+            turbulence_intensities=ti,
             solver_settings=solver_settings,
             yaw_angles=yaw_angles,
             power_setpoints=power_setpoints,
@@ -752,7 +766,7 @@ class FlorisInterface(LoggingManager):
 
         return y_plane
 
-    def check_wind_condition_for_viz(self, wd=None, ws=None):
+    def check_wind_condition_for_viz(self, wd=None, ws=None, ti=None):
         if len(wd) > 1 or len(wd) < 1:
             raise ValueError(
                 "Wind direction input must be of length 1 for visualization. "
@@ -763,6 +777,12 @@ class FlorisInterface(LoggingManager):
             raise ValueError(
                 "Wind speed input must be of length 1 for visualization. "
                 f"Current length is {len(ws)}."
+            )
+
+        if len(ti) != 1:
+            raise ValueError(
+                "Turbulence intensity input must be of length 1 for visualization. "
+                f"Current length is {len(ti)}."
             )
 
     def get_turbine_powers(self) -> NDArrayFloat:

--- a/floris/tools/flow_visualization.py
+++ b/floris/tools/flow_visualization.py
@@ -479,6 +479,7 @@ def calculate_horizontal_plane_with_turbines(
     y_bounds=None,
     wd=None,
     ws=None,
+    ti=None,
     yaw_angles=None,
     power_setpoints=None,
     disable_turbines=None,
@@ -505,6 +506,7 @@ def calculate_horizontal_plane_with_turbines(
             y_bounds (tuple, optional): Limits of output array (in m). Defaults to None.
             wd (float, optional): Wind direction setting. Defaults to None.
             ws (float, optional): Wind speed setting. Defaults to None.
+            ti (float, optional): Turbulence intensity. Defaults to None.
             yaw_angles (np.ndarray, optional): Yaw angles settings. Defaults to None.
             power_setpoints (np.ndarray, optional): Power setpoints settings. Defaults to None.
             disable_turbines (np.ndarray, optional): Disable turbines settings. Defaults to None.
@@ -521,7 +523,9 @@ def calculate_horizontal_plane_with_turbines(
             wd = fi.floris.flow_field.wind_directions
         if ws is None:
             ws = fi.floris.flow_field.wind_speeds
-        fi.check_wind_condition_for_viz(wd=wd, ws=ws)
+        if ti is None:
+            ti = fi.floris.flow_field.turbulence_intensities
+        fi.check_wind_condition_for_viz(wd=wd, ws=ws, ti=ti)
 
         # Set the ws and wd
         fi.set(

--- a/tests/floris_interface_integration_test.py
+++ b/tests/floris_interface_integration_test.py
@@ -447,3 +447,48 @@ def test_set_ti():
     # Test that applying a float however raises an error
     with pytest.raises(TypeError):
         fi.set(turbulence_intensities=0.12)
+
+def test_calculate_planes():
+    fi = FlorisInterface(configuration=YAML_INPUT)
+
+    # The calculate_plane functions should run directly with the inputs as given
+    fi.calculate_horizontal_plane(90.0)
+    fi.calculate_y_plane(0.0)
+    fi.calculate_cross_plane(500.0)
+
+    # They should also support setting new wind conditions, but they all have to set at once
+    wind_speeds = [8.0, 8.0, 8.0]
+    wind_directions = [270.0, 270.0, 270.0]
+    turbulence_intensities = [0.1, 0.1, 0.1]
+    fi.calculate_horizontal_plane(
+        90.0,
+        ws=[wind_speeds[0]],
+        wd=[wind_directions[0]],
+        ti=[turbulence_intensities[0]]
+    )
+    fi.calculate_y_plane(
+        0.0,
+        ws=[wind_speeds[0]],
+        wd=[wind_directions[0]],
+        ti=[turbulence_intensities[0]]
+    )
+    fi.calculate_cross_plane(
+        500.0,
+        ws=[wind_speeds[0]],
+        wd=[wind_directions[0]],
+        ti=[turbulence_intensities[0]]
+    )
+
+    # If Floris is configured with multiple wind conditions prior to this, then all of the
+    # components must be changed together.
+    fi.set(
+        wind_speeds=wind_speeds,
+        wind_directions=wind_directions,
+        turbulence_intensities=turbulence_intensities
+    )
+    with pytest.raises(ValueError):
+        fi.calculate_horizontal_plane(90.0, ws=[wind_speeds[0]], wd=[wind_directions[0]])
+    with pytest.raises(ValueError):
+        fi.calculate_y_plane(0.0, ws=[wind_speeds[0]], wd=[wind_directions[0]])
+    with pytest.raises(ValueError):
+        fi.calculate_cross_plane(500.0, ws=[wind_speeds[0]], wd=[wind_directions[0]])


### PR DESCRIPTION
# Allow to set TI alongside wind direction and wind speed for calculate plane functions
In #831, it was required that turbulence intensity inputs be the same length as wind direction and wind speed inputs. However, the `FlorisInterface.calculate_XX_plane` functions were not updated to accept TI alongside wd and ws. If the `FlorisInterface` object is configured with multiple wind conditions and then passed to `FlorisInterface.calculate_horizontal_plane`, it will always error:

```python
fi = FlorisInterface("inputs/gch.yaml")
wind_directions = np.array([270, 280, 290])
wind_speeds = np.array([8, 8, 8])
turbulence_intensities = np.array([0.1, 0.1, 0.1])
fi.set(wind_directions=wind_directions, wind_speeds=wind_speeds, turbulence_intensities=turbulence_intensities)
horizontal_plane = fi.calculate_horizontal_plane(wd=[wind_directions[0]], ws=[wind_speeds[0]])

# Error:
# Traceback (most recent call last):
#   File "/Users/rmudafor/Development/floris/examples/02_visualizations.py", line 16, in <module>
#     horizontal_plane = fi.calculate_horizontal_plane(
#                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "/Users/rmudafor/Development/floris/floris/tools/floris_interface.py", line 543, in calculate_horizontal_plane
#     self.set(
#   File "/Users/rmudafor/Development/floris/floris/tools/floris_interface.py", line 170, in set
#     self._reinitialize(
#   File "/Users/rmudafor/Development/floris/floris/tools/floris_interface.py", line 319, in _reinitialize
#     self.floris = Floris.from_dict(floris_dict)
#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "/Users/rmudafor/Development/floris/floris/type_dec.py", line 226, in from_dict
#     return cls(**kwargs)
#            ^^^^^^^^^^^^^
#   File "<attrs generated init floris.simulation.floris.Floris>", line 9, in __init__
#   File "/Users/rmudafor/Development/floris/floris/type_dec.py", line 226, in from_dict
#     return cls(**kwargs)
#            ^^^^^^^^^^^^^
#   File "<attrs generated init floris.simulation.flow_field.FlowField>", line 32, in __init__
#   File "/Users/rmudafor/Development/floris/floris/simulation/flow_field.py", line 69, in turbulence_intensities_validator
#     raise ValueError("turbulence_intensities must be length n_findex")
# ValueError: turbulence_intensities must be length n_findex
```

This pull request resolves this issue by adding turbulence intensity as an input to these functions.
