### PR TITLE
[BUGFIX] Coordinates getter on Farm class

### DIFF
--- a/floris/simulation/farm.py
+++ b/floris/simulation/farm.py
@@ -503,7 +503,11 @@ class Farm(BaseClass):
     @property
     def coordinates(self):
         return np.array([
-            np.array([x, y, z]) for x, y, z in zip(self.layout_x, self.layout_y, self.hub_heights)
+            np.array([x, y, z]) for x, y, z in zip(
+                self.layout_x,
+                self.layout_y,
+                self.hub_heights if len(self.hub_heights.shape) == 1 else self.hub_heights[0,0]
+            )
         ])
 
     @property


### PR DESCRIPTION
Addresses issue raised in #833 that getter `Farm.coordinates` fails when `hub_heights` has been expanded to dimensions (`n_wind_directions` x `n_wind_speeds` x `n_turbines`) (from its original shape of `n_turbines`).

After considering the two possible fixes mentioned in #833, I've decided to go with the latter, because it affects less of the code. When investigating the former option (which removes the broadcasting of `hub_heights` to be 3-dimensional in the first place), I found that I could remove the broadcast of both `hub_heights` and `rotor_diameters` and still pass tests, but removing the broadcast of `turbine_type_map` causes failures. For consistency and minimal invasiveness, I've gone with a higher-level patch here. 
