### PR TITLE
Allow to fix yaw to nominal wind direction

### DIFF
--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -11,7 +11,7 @@ from floris.type_dec import (
     NDArrayBool,
     NDArrayFloat,
 )
-from floris.utilities import wrap_360
+from floris.utilities import wrap_180
 from floris.wind_data import WindDataBase
 
 
@@ -610,9 +610,11 @@ class UncertainFlorisModel(LoggingManager):
             # If fix_yaw_to_nominal_direction is True, set the yaw angle to relative
             # to the nominal wind direction
             if fix_yaw_to_nominal_direction:
-                output_array[start_idx:end_idx, 3 : 3 + n_turbines] = (
-                    output_array[start_idx:end_idx, 3 : 3 + n_turbines] - wd_sample_points[i]
-                ) % 360
+
+                # Wrap between -180 and 180
+                output_array[start_idx:end_idx, 3 : 3 + n_turbines] = wrap_180(
+                    output_array[start_idx:end_idx, 3 : 3 + n_turbines] + wd_sample_points[i]
+                )
 
         return output_array
 

--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -20,7 +20,14 @@ class UncertainFlorisModel(LoggingManager):
     An interface for handling uncertainty in wind farm simulations.
 
     This class contains a FlorisModel object and adds functionality to handle
-    uncertainty in wind direction.
+    uncertainty in wind direction.  It is designed to be used similarly to FlorisModel.
+    In the model, the turbine powers are computed for a set of expanded wind conditions,
+    given by wd_sample_points, and then the powers are computed as a gaussian blend
+    of these expanded conditions.
+
+    To reduce computational costs, the wind directions, wind speeds, turbulence intensities,
+    yaw angles, and power setpoints are rounded to specified resolutions.  Only unique
+    conditions from within the expanded set of conditions are run.
 
     Args:
         configuration (:py:obj:`dict`): The Floris configuration dictionary or YAML file.
@@ -43,10 +50,10 @@ class UncertainFlorisModel(LoggingManager):
         wd_sample_points (list[float], optional): The sample points for wind direction.
             If not provided, defaults to [-2 * wd_std, -1 * wd_std, 0, wd_std, 2 * wd_std].
         fix_yaw_to_nominal_direction (bool, optional): Fix the yaw angle to the nominal
-            direction?   When False,
-            the yaw angle is the same across the sampled wind directions.  When True, the yaw
-            angle is fixed to the nominal wind direction and so of offset by the negative of
-            wind direction offset. Defaults to False.
+            direction?   When False, the yaw misalignment is the same across the sampled wind
+            directions. When True, the turbine orientation is fixed to the nominal wind
+            direction such that the yaw misalignment changes depending on the sampled wind
+            direction.  Defaults to False.
         verbose (bool, optional): Verbosity flag for printing messages. Defaults to False.
     """
 

--- a/tests/uncertain_floris_model_integration_test.py
+++ b/tests/uncertain_floris_model_integration_test.py
@@ -88,7 +88,7 @@ def test_expand_wind_directions_with_yaw_nom():
     np.testing.assert_almost_equal(output_array[0, 0], 267)
 
     # Check the first yaw
-    np.testing.assert_almost_equal(output_array[0, 4], 3)
+    np.testing.assert_almost_equal(output_array[0, 4], -3)
 
     # Rerun with fix_yaw_to_nominal_direction = False, and now the yaw should be 0
     output_array = ufmodel._expand_wind_directions(input_array, wd_sample_points, False, n_turbines)

--- a/tests/uncertain_floris_model_integration_test.py
+++ b/tests/uncertain_floris_model_integration_test.py
@@ -67,6 +67,39 @@ def test_expand_wind_directions():
     np.testing.assert_almost_equal(output_array[-1, 0], 14.0)
 
 
+def test_expand_wind_directions_with_yaw_nom():
+    ufmodel = UncertainFlorisModel(configuration=YAML_INPUT)
+
+    # Assume 2 turbine
+    n_turbines = 2
+
+    # Assume n_findex = 2
+    input_array = np.array(
+        [[270.0, 8.0, 0.6, 0.0, 0.0, 0.0, 0.0], [270.0, 8.0, 0.6, 0.0, 2.0, 0.0, 0.0]]
+    )
+
+    # 3 sample points
+    wd_sample_points = [-3, 0, 3]
+
+    # Test correction operations
+    output_array = ufmodel._expand_wind_directions(input_array, wd_sample_points, True, n_turbines)
+
+    # Check the first direction
+    np.testing.assert_almost_equal(output_array[0, 0], 267)
+
+    # Check the first yaw
+    np.testing.assert_almost_equal(output_array[0, 4], 3)
+
+    # Rerun with fix_yaw_to_nominal_direction = False, and now the yaw should be 0
+    output_array = ufmodel._expand_wind_directions(input_array, wd_sample_points, False, n_turbines)
+
+    # Check the first direction
+    np.testing.assert_almost_equal(output_array[0, 0], 267)
+
+    # Check the first yaw
+    np.testing.assert_almost_equal(output_array[0, 4], 0)
+
+
 def test_get_unique_inputs():
     ufmodel = UncertainFlorisModel(configuration=YAML_INPUT)
 
@@ -131,8 +164,8 @@ def test_uncertain_floris_model():
 
     np.testing.assert_allclose(np.sum(nom_powers * weights), unc_powers)
 
-def test_uncertain_floris_model_setpoints():
 
+def test_uncertain_floris_model_setpoints():
     fmodel = FlorisModel(configuration=YAML_INPUT)
     ufmodel = UncertainFlorisModel(configuration=YAML_INPUT, wd_sample_points=[-3, 0, 3], wd_std=3)
 


### PR DESCRIPTION
# Add fix_yaw_to_nominal_direction

This pull request re-includes the option in the UncertainFlorisModel to fix the yaws into the frame of the nominal wind direction.  Currently for example, if yaw angle is 0, and wind direction is 270, uncertainty is computed over a range of wind direction while holding yaw = 0.  This pull request adds the flag fix_yaw_to_nominal_direction, which changes the computations such that the yaw is modified to always be 0 relative to the nominal 270 degrees (so it would be +3 when checking 267 for nominal 270)

Specific changes:

- Incorporates the changes and bugfixes to UncertainFlorisModel already in #843 
- Adds the fix_yaw_to_nominal_direction functionality
- Adds tests for the new functionality