### PR TITLE
Change `power_thrust_model` key to `operation_model` at the user level

### DIFF
--- a/examples/40_test_derating.py
+++ b/examples/40_test_derating.py
@@ -19,7 +19,7 @@ with open(str(
     (fmodel.core.as_dict()["farm"]["turbine_type"][0] + ".yaml")
 )) as t:
     turbine_type = yaml.safe_load(t)
-turbine_type["power_thrust_model"] = "simple-derating"
+turbine_type["operation_model"] = "simple-derating"
 
 # Convert to a simple two turbine layout with derating turbines
 fmodel.set(layout_x=[0, 1000.0], layout_y=[0.0, 0.0], turbine_type=[turbine_type])
@@ -82,7 +82,7 @@ ax.set_xlabel("Power setpoint (kW)")
 ax.set_ylabel("Power produced (kW)")
 
 # Second example showing mixed model use.
-turbine_type["power_thrust_model"] = "mixed"
+turbine_type["operation_model"] = "mixed"
 yaw_angles = np.array([
     [0.0, 0.0],
     [0.0, 0.0],

--- a/examples/41_test_disable_turbines.py
+++ b/examples/41_test_disable_turbines.py
@@ -23,7 +23,7 @@ with open(
     )
 ) as t:
     turbine_type = yaml.safe_load(t)
-turbine_type["power_thrust_model"] = "mixed"
+turbine_type["operation_model"] = "mixed"
 fmodel.set(turbine_type=[turbine_type])
 
 # Consider a wind farm of 3 aligned wind turbines

--- a/floris/core/turbine/turbine.py
+++ b/floris/core/turbine/turbine.py
@@ -31,7 +31,7 @@ from floris.utilities import cosd
 
 
 TURBINE_MODEL_MAP = {
-    "power_thrust_model": {
+    "operation_model": {
         "simple": SimpleTurbine,
         "cosine-loss": CosineLossTurbine,
         "simple-derating": SimpleDeratingTurbine,
@@ -427,7 +427,7 @@ class Turbine(BaseClass):
     hub_height: float = field()
     TSR: float = field()
     power_thrust_table: dict = field(default={}) # conversion to numpy in __post_init__
-    power_thrust_model: str = field(default="cosine-loss")
+    operation_model: str = field(default="cosine-loss")
 
     correct_cp_ct_for_tilt: bool = field(default=False)
     floating_tilt_table: dict[str, NDArrayFloat] | None = field(default=None)
@@ -469,7 +469,7 @@ class Turbine(BaseClass):
             self.power_thrust_table = floris_numeric_dict_converter(self.power_thrust_table)
 
     def _initialize_power_thrust_functions(self) -> None:
-        turbine_function_model = TURBINE_MODEL_MAP["power_thrust_model"][self.power_thrust_model]
+        turbine_function_model = TURBINE_MODEL_MAP["operation_model"][self.operation_model]
         self.thrust_coefficient_function = turbine_function_model.thrust_coefficient
         self.axial_induction_function = turbine_function_model.axial_induction
         self.power_function = turbine_function_model.power

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1287,22 +1287,22 @@ class FlorisModel(LoggingManager):
 
         self.core.flow_field.reference_wind_height = unique_heights[0]
 
-    def get_power_thrust_model(self) -> str:
+    def get_operation_model(self) -> str:
         """Get the power thrust model of a FlorisModel.
 
         Returns:
-            str: The power_thrust_model.
+            str: The operation_model.
         """
-        return self.core.farm.turbine_definitions[0]["power_thrust_model"]
+        return self.core.farm.turbine_definitions[0]["operation_model"]
 
-    def set_power_thrust_model(self, power_thrust_model: str):
+    def set_operation_model(self, operation_model: str):
         """Set the power thrust model of a FlorisModel.
 
         Args:
-            power_thrust_model (str): The power thrust model to set.
+            operation_model (str): The power thrust model to set.
         """
         turbine_type = self.core.farm.turbine_definitions[0]
-        turbine_type["power_thrust_model"] = power_thrust_model
+        turbine_type["operation_model"] = operation_model
         self.set(turbine_type=[turbine_type])
 
     def copy(self):

--- a/floris/turbine_library/iea_10MW.yaml
+++ b/floris/turbine_library/iea_10MW.yaml
@@ -5,7 +5,7 @@ turbine_type: 'iea_10MW'
 hub_height: 119.0
 rotor_diameter: 198.0
 TSR: 8.0
-power_thrust_model: cosine-loss
+operation_model: cosine-loss
 power_thrust_table:
   ref_air_density: 1.225
   ref_tilt: 6.0

--- a/floris/turbine_library/iea_15MW.yaml
+++ b/floris/turbine_library/iea_15MW.yaml
@@ -7,7 +7,7 @@ turbine_type: 'iea_15MW'
 hub_height: 150.0
 rotor_diameter: 242.24
 TSR: 8.0
-power_thrust_model: cosine-loss
+operation_model: cosine-loss
 power_thrust_table:
   ref_air_density: 1.225
   ref_tilt: 6.0

--- a/floris/turbine_library/nrel_5MW.yaml
+++ b/floris/turbine_library/nrel_5MW.yaml
@@ -24,7 +24,7 @@ TSR: 8.0
 
 ###
 # Model for power and thrust curve interpretation.
-power_thrust_model: 'cosine-loss'
+operation_model: 'cosine-loss'
 
 ###
 # Cp and Ct as a function of wind speed for the turbine's full range of operating conditions.

--- a/floris/turbine_library/turbine_utilities.py
+++ b/floris/turbine_library/turbine_utilities.py
@@ -158,7 +158,7 @@ def build_cosine_loss_turbine_dict(
         "hub_height": hub_height,
         "rotor_diameter": rotor_diameter,
         "TSR": TSR,
-        "power_thrust_model": "cosine-loss",
+        "operation_model": "cosine-loss",
         "power_thrust_table": power_thrust_dict
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,7 @@ class SampleInputs:
             "turbine_type": "nrel_5mw",
             "rotor_diameter": 125.88,
             "hub_height": 90.0,
-            "power_thrust_model": "cosine-loss",
+            "operation_model": "cosine-loss",
             "power_thrust_table": {
                 "cosine_loss_exponent_yaw": 1.88,
                 "cosine_loss_exponent_tilt": 1.88,
@@ -532,7 +532,7 @@ class SampleInputs:
             "rotor_diameter": 125.88,
             "hub_height": 90.0,
             "generator_efficiency": 0.944,
-            "power_thrust_model": "cosine-loss",
+            "operation_model": "cosine-loss",
             "pP": 1.88,
             "pT": 1.88,
             "ref_density_cp_ct": 1.225,

--- a/tests/floris_model_integration_test.py
+++ b/tests/floris_model_integration_test.py
@@ -265,7 +265,7 @@ def test_disable_turbines():
         )
     ) as t:
         turbine_type = yaml.safe_load(t)
-    turbine_type["power_thrust_model"] = "mixed"
+    turbine_type["operation_model"] = "mixed"
     fmodel.set(turbine_type=[turbine_type])
 
     # Init to n-findex = 2, n_turbines = 3
@@ -577,12 +577,12 @@ def test_get_and_set_param():
     alpha = fmodel.get_param(['wake', 'wake_velocity_parameters', 'gauss', 'alpha'])
     assert alpha == 0.1
 
-def test_get_power_thrust_model():
+def test_get_operation_model():
     fmodel = FlorisModel(configuration=YAML_INPUT)
-    assert fmodel.get_power_thrust_model() == "cosine-loss"
+    assert fmodel.get_operation_model() == "cosine-loss"
 
-def test_set_power_thrust_model():
+def test_set_operation_model():
 
     fmodel = FlorisModel(configuration=YAML_INPUT)
-    fmodel.set_power_thrust_model("simple-derating")
-    assert fmodel.get_power_thrust_model() == "simple-derating"
+    fmodel.set_operation_model("simple-derating")
+    assert fmodel.get_operation_model() == "simple-derating"


### PR DESCRIPTION
There was a discrepancy between the term used for the turbine operation models at the user level (in turbine yamls and in getter and setters on `FlorisModel`), which was `power_thrust_model`, and the term "operation model" that we use in descriptions and throughout the code. 

This PR fixes that discrepancy by renaming `power_thrust_model` to `operation_model` at the user level.
