### PR TITLE
[BUGFIX] set_operation_model ordering with layout

### DIFF
--- a/floris/core/farm.py
+++ b/floris/core/farm.py
@@ -209,7 +209,8 @@ class Farm(BaseClass):
         if len(value) != 1 and len(value) != self.n_turbines:
             raise ValueError(
                 "turbine_type must have the same number of entries as layout_x/layout_y or have "
-                "a single turbine_type value."
+                "a single turbine_type value. This error can arise if you set the turbine_type or "
+                "alter the operation model before setting the layout."
             )
 
     @turbine_library_path.validator

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1317,7 +1317,7 @@ class FlorisModel(LoggingManager):
                 return
             else:
                 operation_model = [operation_model]*self.core.farm.n_turbines
-        
+
         if len(operation_model) != self.core.farm.n_turbines:
             raise ValueError(
                     "The length of the operation_model list must be "

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1309,13 +1309,23 @@ class FlorisModel(LoggingManager):
             operation_model (str): The operation model to set.
         """
         if isinstance(operation_model, str):
-            operation_model = [operation_model]*self.core.farm.n_turbines
-        elif len(operation_model) != self.core.farm.n_turbines:
+            if len(self.core.farm.turbine_type) == 1:
+                # Set a single one here, then, and return
+                turbine_type = self.core.farm.turbine_definitions[0]
+                turbine_type["operation_model"] = operation_model
+                self.set(turbine_type=[turbine_type])
+                return
+            else:
+                operation_model = [operation_model]*self.core.farm.n_turbines
+        
+        if len(operation_model) != self.core.farm.n_turbines:
             raise ValueError(
-                "The length of the operation_model list must be equal to the number of turbines."
-            )
+                    "The length of the operation_model list must be "
+                    "equal to the number of turbines."
+                )
 
         turbine_type_list = self.core.farm.turbine_definitions
+
         for tindex in range(self.core.farm.n_turbines):
             turbine_type_list[tindex]["turbine_type"] = (
                 turbine_type_list[tindex]["turbine_type"]+"_"+operation_model[tindex]

--- a/tests/floris_model_integration_test.py
+++ b/tests/floris_model_integration_test.py
@@ -591,3 +591,30 @@ def test_set_operation_model():
     fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
     fmodel.set_operation_model(["simple-derating", "cosine-loss"])
     assert fmodel.get_operation_model() == ["simple-derating", "cosine-loss"]
+
+    # Check that setting a single turbine type, and then altering the operation model works
+    fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
+    fmodel.set(turbine_type=["nrel_5MW"])
+    fmodel.set_operation_model("simple-derating")
+    assert fmodel.get_operation_model() == "simple-derating"
+
+    # Check that setting over mutliple turbine types works
+    fmodel.set(turbine_type=["nrel_5MW", "iea_15MW"])
+    fmodel.set_operation_model("simple-derating")
+    assert fmodel.get_operation_model() == "simple-derating"
+    fmodel.set_operation_model(["simple-derating", "cosine-loss"])
+    assert fmodel.get_operation_model() == ["simple-derating", "cosine-loss"]
+
+    # Check setting over single turbine type; then updating layout works
+    fmodel.set(turbine_type=["nrel_5MW"])
+    fmodel.set_operation_model("simple-derating")
+    fmodel.set(layout_x=[0, 0, 0], layout_y=[0, 1000, 2000])
+    assert fmodel.get_operation_model() == "simple-derating"
+
+    # Check that setting for multiple turbine types and then updating layout breaks
+    fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
+    fmodel.set(turbine_type=["nrel_5MW"])
+    fmodel.set_operation_model(["simple-derating", "cosine-loss"])
+    assert fmodel.get_operation_model() == ["simple-derating", "cosine-loss"]
+    with pytest.raises(ValueError):
+        fmodel.set(layout_x=[0, 0, 0], layout_y=[0, 1000, 2000])

--- a/tests/floris_model_integration_test.py
+++ b/tests/floris_model_integration_test.py
@@ -618,3 +618,11 @@ def test_set_operation_model():
     assert fmodel.get_operation_model() == ["simple-derating", "cosine-loss"]
     with pytest.raises(ValueError):
         fmodel.set(layout_x=[0, 0, 0], layout_y=[0, 1000, 2000])
+
+    # Check one more variation
+    fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
+    fmodel.set(turbine_type=["nrel_5MW", "iea_15MW"])
+    fmodel.set_operation_model("simple-derating")
+    fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
+    with pytest.raises(ValueError):
+        fmodel.set(layout_x=[0, 0, 0], layout_y=[0, 1000, 2000])


### PR DESCRIPTION
In #856 , which fixed a bug that hardcoded a single turbine, I introduced a new bug that meant that if `set_operation_model` is called _before_ changing the layout, and error was raised because the `set_operation_model` call broadcast the turbine type to the number of currently available turbines.

This PR addresses this issue by:
- allowing `set_operation_model` before changing the layout IF there is only a single turbine type currently AND only a single `operation_model` is passed to set
- providing a more informative warning if there is an inconsistency between the number of turbine types and the layout that could have been caused by setting the operation model (or setting multiple operation models)
- testing these capabilities.
