### PR TITLE
Make set_operation method public

### DIFF
--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -251,9 +251,19 @@ class FlorisModel(LoggingManager):
         """
         # Add operating conditions to the floris object
         if yaw_angles is not None:
+            if np.array(yaw_angles).shape[1] != self.core.farm.n_turbines:
+                raise ValueError(
+                    f"yaw_angles has a size of {np.array(yaw_angles).shape[1]} in the 1st "
+                    f"dimension, must be equal to n_turbines={self.core.farm.n_turbines}"
+                )
             self.core.farm.set_yaw_angles(yaw_angles)
 
         if power_setpoints is not None:
+            if np.array(power_setpoints).shape[1] != self.core.farm.n_turbines:
+                raise ValueError(
+                    f"power_setpoints has a size of {np.array(power_setpoints).shape[1]} in the 1st"
+                    f" dimension, must be equal to n_turbines={self.core.farm.n_turbines}"
+                )
             power_setpoints = np.array(power_setpoints)
 
             # Convert any None values to the default power setpoint
@@ -290,6 +300,9 @@ class FlorisModel(LoggingManager):
             # yaw_angles to 0 in all locations where disable_turbines is True
             self.core.farm.yaw_angles[disable_turbines] = 0.0
             self.core.farm.power_setpoints[disable_turbines] = POWER_SETPOINT_DISABLED
+
+        if any([yaw_angles is not None, power_setpoints is not None, disable_turbines is not None]):
+            self.core.state = State.UNINITIALIZED
 
     def set(
         self,

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -229,7 +229,7 @@ class FlorisModel(LoggingManager):
         # Create a new instance of floris and attach to self
         self.core = Core.from_dict(floris_dict)
 
-    def _set_operation(
+    def set_operation(
         self,
         yaw_angles: NDArrayFloat | list[float] | None = None,
         power_setpoints: NDArrayFloat | list[float] | list[float, None] | None = None,
@@ -237,6 +237,9 @@ class FlorisModel(LoggingManager):
     ):
         """
         Apply operating setpoints to the floris object.
+
+        This function is not meant to be called directly by most users---users should instead call
+        the set() method.
 
         Args:
             yaw_angles (NDArrayFloat | list[float] | None, optional): Turbine yaw angles. Defaults
@@ -372,7 +375,7 @@ class FlorisModel(LoggingManager):
             self.core.farm.set_power_setpoints(_power_setpoints)
 
         # Set the operation
-        self._set_operation(
+        self.set_operation(
             yaw_angles=yaw_angles,
             power_setpoints=power_setpoints,
             disable_turbines=disable_turbines,

--- a/floris/optimization/layout_optimization/layout_optimization_scipy.py
+++ b/floris/optimization/layout_optimization/layout_optimization_scipy.py
@@ -110,7 +110,7 @@ class LayoutOptimizationScipy(LayoutOptimization):
         self._change_coordinates(locs_unnorm)
         # Compute turbine yaw angles using PJ's geometric code (if enabled)
         yaw_angles = self._get_geoyaw_angles()
-        self.fmodel.set(yaw_angles=yaw_angles)
+        self.fmodel.set_operation(yaw_angles=yaw_angles)
         self.fmodel.run()
 
         if self.use_value:

--- a/tests/floris_model_integration_test.py
+++ b/tests/floris_model_integration_test.py
@@ -682,3 +682,26 @@ def test_set_operation_model():
     fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
     with pytest.raises(ValueError):
         fmodel.set(layout_x=[0, 0, 0], layout_y=[0, 1000, 2000])
+
+def test_set_operation():
+    fmodel = FlorisModel(configuration=YAML_INPUT)
+    fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
+
+    # Check that not allowed to run(), then set_operation, then collect powers
+    fmodel.run()
+    fmodel.set_operation(yaw_angles=np.array([[25.0, 0.0]]))
+    with pytest.raises(RuntimeError):
+        fmodel.get_turbine_powers()
+
+    # Check that no issue if run is called first
+    fmodel.run()
+    fmodel.get_turbine_powers()
+
+    # Check that if arguments do not match number of turbines, raises error
+    with pytest.raises(ValueError):
+        fmodel.set_operation(yaw_angles=np.array([[25.0, 0.0, 20.0]]))
+
+    # Check that if arguments do not match n_findex, raises error
+    with pytest.raises(ValueError):
+        fmodel.set_operation(yaw_angles=np.array([[25.0, 0.0], [25.0, 0.0]]))
+        fmodel.run()


### PR DESCRIPTION
As mentioned in #865, there are some cases where users may want to set _only_ the control setpoints. Currently, the method for doing this, `FlorisModel._set_operation()`, is private. This PR makes that method public so that it may be used.

We intend that only power users will use this functionality---most will simply use the `set` method to alter the control setpoints.

In making this change I found that there was no check that the `yaw_angles` or `power_setpoints` second dimension matched the number of turbines, and in fact it was possible to set and run `yaw_angles` with more than the number of turbines. This is now checked for.

I spoke to @rafmudaf about a possible issue created by the following workflow:
```python
fmodel.set_operation(yaw_angles=some_yaw_angles)
fmodel.run()
fmodel.set_operation(yaw_angles=some_other_yaw_angles)
powers = fmodel.get_turbine_powers()
```
This would be bad, because the `power` would have the wake caused by `some_yaw_angles` but the power behavior caused by `some_other_yaw_angles`.

To make sure this does not happen, I have set the `core`'s `state` back to `UNINITIALIZED` if `set_operation()` is called. This then throws a `RuntimeError` if `get_turbine_powers()` is called before calling `run()` again. I test for this in the tests.
