### PR TITLE
Fixing datatype of value in WindData objects

### DIFF
--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -843,11 +843,7 @@ class FlorisModel(LoggingManager):
                 "operation."
             )
 
-        if (
-            values is None
-            and not isinstance(self.wind_data, WindRose)
-            and not isinstance(self.wind_data, WindTIRose)
-        ):
+        if values is None and self.wind_data is None:
             self.logger.warning(
                 "Computing AVP with uniform value equal to 1. Results will be equivalent to "
                 "annual energy production."

--- a/floris/wind_data.py
+++ b/floris/wind_data.py
@@ -592,7 +592,7 @@ class WindRose(WindDataBase):
         """
 
         def piecewise_linear_value_func(wind_directions, wind_speeds):
-            value = np.zeros_like(wind_speeds)
+            value = np.zeros_like(wind_speeds, dtype=float)
             value[wind_speeds < ws_knee] = (
                 slope_1 * wind_speeds[wind_speeds < ws_knee] + value_zero_ws
             )
@@ -1146,7 +1146,7 @@ class WindTIRose(WindDataBase):
         """
 
         def piecewise_linear_value_func(wind_directions, wind_speeds, turbulence_intensities):
-            value = np.zeros_like(wind_speeds)
+            value = np.zeros_like(wind_speeds, dtype=float)
             value[wind_speeds < ws_knee] = (
                 slope_1 * wind_speeds[wind_speeds < ws_knee] + value_zero_ws
             )
@@ -1550,7 +1550,7 @@ class TimeSeries(WindDataBase):
         """
 
         def piecewise_linear_value_func(wind_directions, wind_speeds):
-            value = np.zeros_like(wind_speeds)
+            value = np.zeros_like(wind_speeds, dtype=float)
             value[wind_speeds < ws_knee] = (
                 slope_1 * wind_speeds[wind_speeds < ws_knee] + value_zero_ws
             )


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Bug fix: setting value as a float in WindData objects and removing a warning when computing AVP
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This PR fixes two small issues related to the WindData value array. 

- First, when wind speeds were defined as integers when creating a WindData object, the values array resulting from calling the WindData `assign_value_piecewise_linear` method would also be integers. Since we want values to be able to take non-integer values, `dtype=float` is now added when assigning values.
- Second, in `get_farm_AVP` in floris_model.py, a warning about values being treated as 1 was printed when the WindData attribute in the floris model was a TimeSeries object. However, TimeSeries objects have a value array, so this warning isn't necessary. Now it only prints the warning when the floris model has no WindData attribute.