### PR TITLE
[BUGFIX] Add enable_active_wake_mixing field to v3 to v4 documentation and conversion

### DIFF
--- a/docs/v3_to_v4.md
+++ b/docs/v3_to_v4.md
@@ -108,11 +108,15 @@ in v3. However, there are a few changes to the fields on each that mean that exi
 will not run in v4 as is.
 
 #### Main FLORIS input yaml
-The only change in fields on the main FLORIS input file is that the `turbulence_intensity` field,
+On the main FLORIS input file, the `turbulence_intensity` field,
 which was specified as a scalar in FLORIS v3, has been changed to `turbulence_intensities`, and
 should now contain a list of turbulence intensities that is of the same length as `wind_directions`
 and `wind_speeds`. Additionally, the length of the lists for `wind_directions` and `wind_speeds`
 _must_ now be of equal length.
+
+In addition, a new field `enable_active_wake_mixing` has been added, which users may set to
+`false` unless they would like to use active wake mixing strategies such as
+[Helix](empirical_gauss_model.md#Added-mixing-by-active-wake-control).
 
 #### Turbine input yaml
 To reflect the transition to more flexible [operation models](#operation-model), there are a

--- a/docs/v3_to_v4.md
+++ b/docs/v3_to_v4.md
@@ -108,15 +108,15 @@ in v3. However, there are a few changes to the fields on each that mean that exi
 will not run in v4 as is.
 
 #### Main FLORIS input yaml
-On the main FLORIS input file, the `turbulence_intensity` field,
+On the main FLORIS input file, the `turbulence_intensity` field (on `flow_field`),
 which was specified as a scalar in FLORIS v3, has been changed to `turbulence_intensities`, and
 should now contain a list of turbulence intensities that is of the same length as `wind_directions`
 and `wind_speeds`. Additionally, the length of the lists for `wind_directions` and `wind_speeds`
 _must_ now be of equal length.
 
-In addition, a new field `enable_active_wake_mixing` has been added, which users may set to
-`false` unless they would like to use active wake mixing strategies such as
-[Helix](empirical_gauss_model.md#Added-mixing-by-active-wake-control).
+In addition, a new field `enable_active_wake_mixing` has been added to the `wake` field,
+which users may set to `false` unless they would like to use active wake mixing strategies such 
+as [Helix](empirical_gauss_model.md#Added-mixing-by-active-wake-control).
 
 #### Turbine input yaml
 To reflect the transition to more flexible [operation models](#operation-model), there are a

--- a/floris/convert_floris_input_v3_to_v4.py
+++ b/floris/convert_floris_input_v3_to_v4.py
@@ -61,6 +61,9 @@ if __name__ == "__main__":
         )
         v4_floris_input_dict["wake"]["model_strings"]["velocity_model"] = "gauss"
 
+    # Add enable_active_wake_mixing field
+    v4_floris_input_dict["wake"]["enable_active_wake_mixing"] = False
+
     yaml.dump(
             v4_floris_input_dict,
             open(output_path, "w"),


### PR DESCRIPTION
As part of the merge of #842 , a new field `enable_active_wake_mixing` was added to the `wake` field of the main floris input yaml.

The documentation describing the switch from v3 to v4 missed this detail; additionally, the converter utility convert_floris_input_v3_to_v4.py does not currently add this necessary field, so converted floris input files would currently not actually run.

In this PR, I've fixed the documentation added the `enable_active_wake_mixing` field to the converter, and tested it by converting a [v3 GCH floris input file](https://github.com/NREL/floris/blob/b4d9d1eddca9f4fa197f3e76a295d2349a63d584/examples/inputs/gch.yaml) to v4 and running the first example with it.

I'd also like to fix the [Helix operation model documentation](https://nrel.github.io/floris/operation_models_user.html#awc-model), which I plan to add to this PR before we merge it..
