### PR TITLE
[BUGFIX] Update CubatureGrid for 4-dimensional data structures

### DIFF
--- a/floris/core/grid.py
+++ b/floris/core/grid.py
@@ -359,7 +359,7 @@ class TurbineCubatureGrid(Grid):
             integration coefficients, "r", "t", "q", "A" and "B".
         """
 
-        if N < 1 and N < 10:
+        if N < 1 or N > 10:
             raise ValueError(
                 f"Order of cubature integration must be between '1' and '10', given {N}."
             )


### PR DESCRIPTION
# Update CubatureGrid for 4-dimensional data structures
In #764, the core data structures in FLORIS were changed from 5-dimensional to 4-dimensional by collapsing the two left-most dimensions. Some parts of the CubatureGrid class were updated then, but it was not fully changed. Since this grid-type is not included in the automated tests, the error was not caught.

Separately, the check for a valid grid resolution was incorrect, so that has also been updated here.

This change can be verified to work with the following script. Before this change, the script raises an error.

```python
from floris import FlorisModel
fmodel = FlorisModel("inputs/gch.yaml")
solver_settings = {
    "type": "turbine_cubature_grid",
    "turbine_grid_points": 3
}
fmodel.set(solver_settings=solver_settings)
fmodel.run()

turbine_powers = fmodel.get_turbine_powers()
print(turbine_powers.flatten())
```

## Related issue
Tangentially related to #709.

## Impacted areas of the software
CubatureGrid class