### PR TITLE
[BUGFIX] Incorrect indexing to hub heights in `Farm.coordinates()`

### DIFF
--- a/floris/core/farm.py
+++ b/floris/core/farm.py
@@ -465,7 +465,7 @@ class Farm(BaseClass):
             np.array([x, y, z]) for x, y, z in zip(
                 self.layout_x,
                 self.layout_y,
-                self.hub_heights if len(self.hub_heights.shape) == 1 else self.hub_heights[0,0]
+                self.hub_heights if len(self.hub_heights.shape) == 1 else self.hub_heights[0]
             )
         ])
 


### PR DESCRIPTION
#846 introduced a bugfix to the `Farm.coordinates()` method, which was released and runs as expected in FLORIS [v3.6](https://github.com/NREL/floris/releases/tag/v3.6). However, when develop was merged back into the v4 branch in preparation for the release of FLORIS [v4.0](https://github.com/NREL/floris/releases/tag/v4.0), this line was missed in reducing from 5D to 4D data structures.

This PR fixes this issue by simply removing the now-redundant dimension in accessing `hub_heights`. 

The following code demonstrates the error that is raised:
```python
from floris import FlorisModel

fmodel = FlorisModel("inputs/gch.yaml")

# Changing the wind farm layout uses FLORIS' set method to a two-turbine layout
fmodel.set(layout_x=[0, 500.0], layout_y=[0.0, 0.0])

# Runs correctly
print(fmodel.get_turbine_layout())
print(fmodel.get_turbine_layout(True))

fmodel.run()

# Fails before the bugfix
print(fmodel.get_turbine_layout())
print(fmodel.get_turbine_layout(True))
```

With the bugfix, this produces
```
(array([  0., 500.]), array([0., 0.]))
(array([  0., 500.]), array([0., 0.]), array([90., 90.]))
(array([  0., 500.]), array([0., 0.]))
(array([  0., 500.]), array([0., 0.]), array([90., 90.]))
```
as expected. Prior to the bug fix (on the develop branch), the output is:
```
(array([  0., 500.]), array([0., 0.]))
(array([  0., 500.]), array([0., 0.]), array([90., 90.]))
Traceback (most recent call last):
  File "/Users/msinner/floris3/examples/dis887.py", line 18, in <module>
    print(fmodel.get_turbine_layout())
  File "/Users/msinner/floris3/floris/floris_model.py", line 1511, in get_turbine_layout
    xcoords, ycoords, zcoords = self.core.farm.coordinates.T
  File "/Users/msinner/floris3/floris/core/farm.py", line 465, in coordinates
    np.array([x, y, z]) for x, y, z in zip(
TypeError: 'numpy.float64' object is not iterable
```

Thank you to @AJP-47 for identifying this bug in #887, and to @rafmudaf for helping track it down.
