### PR TITLE
[BUGFIX] `NoneWakeTurbulence` returns zero (added) turbulence

### DIFF
--- a/examples/002_visualizations.py
+++ b/examples/002_visualizations.py
@@ -69,8 +69,10 @@ ax.set_title("Use Provided Turbine Names")
 # we show the horizontal plane at hub height, further examples are provided within
 # the examples_visualizations folder
 
-# For flow visualizations, the FlorisModel must be set to run a single condition
-# (n_findex = 1)
+# For flow visualizations, the FlorisModel may be set to run a single condition
+# (n_findex = 1). Otherwise, the user may set multiple conditions and then use
+# the findex_for_viz keyword argument to calculate_horizontal_plane to specify which
+# flow condition to visualize.
 fmodel.set(wind_speeds=[8.0], wind_directions=[290.0], turbulence_intensities=[0.06])
 horizontal_plane = fmodel.calculate_horizontal_plane(
     x_resolution=200,

--- a/floris/core/wake_turbulence/none.py
+++ b/floris/core/wake_turbulence/none.py
@@ -29,4 +29,4 @@ class NoneWakeTurbulence(BaseModel):
         self.logger.info(
             "The wake-turbulence model is set to 'none'. Turbulence model disabled."
         )
-        return np.ones_like(x) * ambient_TI
+        return np.zeros_like(x)

--- a/tests/reg_tests/turbulence_models_regression_test.py
+++ b/tests/reg_tests/turbulence_models_regression_test.py
@@ -12,18 +12,8 @@ def test_NoneWakeTurbulence(sample_inputs_fixture):
     sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
     sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
     sample_inputs_fixture.core["wake"]["model_strings"]["turbulence_model"] = "none"
-    sample_inputs_fixture.core["farm"]["layout_x"] = [
-        0.0,
-        0.0,
-        600.0,
-        600.0,
-    ]
-    sample_inputs_fixture.core["farm"]["layout_y"] = [
-        0.0,
-        600.0,
-        0.0,
-        600.0,
-    ]
+    sample_inputs_fixture.core["farm"]["layout_x"] = [0.0, 0.0, 600.0, 600.0]
+    sample_inputs_fixture.core["farm"]["layout_y"] = [0.0, 600.0, 0.0, 600.0]
     sample_inputs_fixture.core["flow_field"]["wind_directions"] = [270.0, 360.0]
     sample_inputs_fixture.core["flow_field"]["wind_speeds"] = [8.0, 8.0]
     sample_inputs_fixture.core["flow_field"]["turbulence_intensities"] = turbulence_intensities

--- a/tests/reg_tests/turbulence_models_regression_test.py
+++ b/tests/reg_tests/turbulence_models_regression_test.py
@@ -1,0 +1,40 @@
+from floris.core import Core
+from floris.core.wake_turbulence import NoneWakeTurbulence
+
+
+VELOCITY_MODEL = "gauss"
+DEFLECTION_MODEL = "gauss"
+
+def test_NoneWakeTurbulence(sample_inputs_fixture):
+
+    turbulence_intensities = [0.1, 0.05]
+
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["turbulence_model"] = "none"
+    sample_inputs_fixture.core["farm"]["layout_x"] = [
+        0.0,
+        0.0,
+        600.0,
+        600.0,
+    ]
+    sample_inputs_fixture.core["farm"]["layout_y"] = [
+        0.0,
+        600.0,
+        0.0,
+        600.0,
+    ]
+    sample_inputs_fixture.core["flow_field"]["wind_directions"] = [270.0, 360.0]
+    sample_inputs_fixture.core["flow_field"]["wind_speeds"] = [8.0, 8.0]
+    sample_inputs_fixture.core["flow_field"]["turbulence_intensities"] = turbulence_intensities
+
+    core = Core.from_dict(sample_inputs_fixture.core)
+    core.initialize_domain()
+    core.steady_state_atmospheric_condition()
+
+    assert (
+        core.flow_field.turbulence_intensity_field_sorted[0,:] == turbulence_intensities[0]
+    ).all()
+    assert (
+        core.flow_field.turbulence_intensity_field_sorted[1,:] == turbulence_intensities[1]
+    ).all()


### PR DESCRIPTION
As pointed out by @Bartdoekemeijer in #893, the `NoneWakeTurbulence` model currently returns the ambient turbulence. However, this is then _added_ (as wake added turbulence) to the existing ambient turbulence, meaning that the "final" turbine turbulence is above the ambient TI level.

The expected behavior is that `NoneWakeTurbulence` makes no change to the turbulence intensity in turbines' wakes. This PR implements that change.

To see the issue, and how this fixes it, change the gch.yaml input field `turbulence_model` to `none` (replacing `crespo-hernandez`, and switch off all secondary effects (`enable_secondary_steering`, `enable_yaw_added_recovery`, `enable_active_wake_mixing`, and `enable_transverse_velocities` all set to `false`). Then, add the following line to example 001_opening_floris_and_computing_power.py somewhere after `fmodel.run()`:

```python
print(fmodel.core.flow_field.turbulence_intensity_field_sorted[0,:,0,0])
```

Running the modified 001 example on the develop branches produces
```
[0.06       0.08485281]
```
where the second turbine clearly has higher turbulence due to the presence of the first turbine's wake, even though the `turbulence_model` is `none`.

After the fix, the example produces
```
[0.06 0.06]
```
as expected.



I'm also using this opportunity to update one of the comments in example 002_visualizations.py, which was noted to be incorrect in #892.
