### PR TITLE
[BUGFIX] Include turbulence_intensities in turbine_previewer.py

### DIFF
--- a/floris/turbine_library/turbine_previewer.py
+++ b/floris/turbine_library/turbine_previewer.py
@@ -104,6 +104,7 @@ class TurbineInterface:
             power_mw = {
                 k: power(
                     velocities=wind_speeds.reshape(shape),
+                    turbulence_intensities=np.zeros(shape),
                     air_density=np.full(shape, v["ref_air_density"]),
                     power_functions={self.turbine.turbine_type: self.turbine.power_function},
                     yaw_angles=np.zeros(shape),
@@ -120,6 +121,7 @@ class TurbineInterface:
         else:
             power_mw = power(
                 velocities=wind_speeds.reshape(shape),
+                turbulence_intensities=np.zeros(shape),
                 air_density=np.full(shape, self.turbine.power_thrust_table["ref_air_density"]),
                 power_functions={self.turbine.turbine_type: self.turbine.power_function},
                 yaw_angles=np.zeros(shape),
@@ -155,6 +157,7 @@ class TurbineInterface:
             ct_curve = {
                 k: thrust_coefficient(
                     velocities=wind_speeds.reshape(shape),
+                    turbulence_intensities=np.zeros(shape),
                     air_density=np.full(shape, v["ref_air_density"]),
                     yaw_angles=np.zeros(shape),
                     tilt_angles=np.full(shape, v["ref_tilt"]),
@@ -174,6 +177,7 @@ class TurbineInterface:
         else:
             ct_curve = thrust_coefficient(
                 velocities=wind_speeds.reshape(shape),
+                turbulence_intensities=np.zeros(shape),
                 air_density=np.full(shape, self.turbine.power_thrust_table["ref_air_density"]),
                 yaw_angles=np.zeros(shape),
                 tilt_angles=np.full(shape, self.turbine.power_thrust_table["ref_tilt"]),


### PR DESCRIPTION
When merging #888 , the [deployment of the documentation failed](https://github.com/NREL/floris/actions/runs/8975149379) because one of the documentation notebooks calls methods on the `TurbineInterface` class, which I had missed when passing the `turbulence_intensities` keyword argument to calls to `power()` and `thrust_coefficient()`.  This fixes that problem.

Perhaps a bigger issue is that `TurbineInterface` does not seem to be covered by tests and examples (it is only used in the documentation). I've opened #901 to discuss.

Note that here, for simplicity, I'm passing 0 in for `turbulence_intensities`. That works, for now, because turbulence intensity is anyway not used in most operation models. However, if in future we expand the usage of the `TurbineInterface` class to be more broadly compatible with operation models, we may want to add `turbulence_intensities` as an input to some of the methods (so that, if an operation model whose output depends on the turbulence intensity is used, that dependency can be demonstrated).
