### PR TITLE
Ignore includes in v3->v4 conversions

### DIFF
--- a/floris/convert_floris_input_v3_to_v4.py
+++ b/floris/convert_floris_input_v3_to_v4.py
@@ -1,10 +1,7 @@
-
 import sys
 from pathlib import Path
 
 import yaml
-
-from floris.utilities import load_yaml
 
 
 """
@@ -19,11 +16,19 @@ and is appended _v4.
 """
 
 
+def ignore_include(loader, node):
+    # Parrot back the !include tag
+    return node.tag + " " + node.value
+
+
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         raise Exception(
             "Usage: python convert_floris_input_v3_to_v4.py <path/to/floris_input>.yaml"
         )
+
+    # Set the yaml loader to ignore the !include tag
+    yaml.SafeLoader.add_constructor("!include", ignore_include)
 
     input_yaml = sys.argv[1]
 
@@ -32,11 +37,12 @@ if __name__ == "__main__":
     split_input = input_path.parts
     [filename_v3, extension] = split_input[-1].split(".")
     filename_v4 = filename_v3 + "_v4"
-    split_output = list(split_input[:-1]) + [filename_v4+"."+extension]
+    split_output = list(split_input[:-1]) + [filename_v4 + "." + extension]
     output_path = Path(*split_output)
 
     # Load existing v3 model
-    v3_floris_input_dict = load_yaml(input_yaml)
+    with open(input_yaml, "r") as file:
+        v3_floris_input_dict = yaml.safe_load(file)
     v4_floris_input_dict = v3_floris_input_dict.copy()
 
     # Change turbulence_intensity field to turbulence_intensities as list
@@ -44,9 +50,9 @@ if __name__ == "__main__":
         if "turbulence_intensity" in v3_floris_input_dict["flow_field"]:
             del v4_floris_input_dict["flow_field"]["turbulence_intensity"]
     elif "turbulence_intensity" in v3_floris_input_dict["flow_field"]:
-        v4_floris_input_dict["flow_field"]["turbulence_intensities"] = (
-            [v3_floris_input_dict["flow_field"]["turbulence_intensity"]]
-        )
+        v4_floris_input_dict["flow_field"]["turbulence_intensities"] = [
+            v3_floris_input_dict["flow_field"]["turbulence_intensity"]
+        ]
         del v4_floris_input_dict["flow_field"]["turbulence_intensity"]
 
     # Change multidim_cp_ct velocity model to gauss
@@ -64,10 +70,20 @@ if __name__ == "__main__":
     # Add enable_active_wake_mixing field
     v4_floris_input_dict["wake"]["enable_active_wake_mixing"] = False
 
-    yaml.dump(
-            v4_floris_input_dict,
-            open(output_path, "w"),
-            sort_keys=False
-        )
+    yaml.dump(v4_floris_input_dict, open(output_path, "w"), sort_keys=False)
+
+    # Open the output file and loop through line by line
+    # if a line contains the substring !include, then strip all
+    # occurrences of ' from the line
+    temp_output_path = output_path.with_name("temp.yaml")
+    with open(temp_output_path, "w") as file:
+        with open(output_path, "r") as f:
+            for line in f:
+                if "!include" in line:
+                    line = line.replace("'", "")
+                file.write(line)
+
+    # Move the temp file to the output file
+    temp_output_path.replace(output_path)
 
     print(output_path, "created.")

--- a/tests/convert_v3_to_v4_test.py
+++ b/tests/convert_v3_to_v4_test.py
@@ -22,20 +22,19 @@ def test_v3_to_v4_convert():
     # Change directory to the test folder
     os.chdir(CONVERT_FOLDER)
 
-    # Print the current directory
-    print(os.getcwd())
-
     # Run the converter on the turbine file
     os.system(f"python convert_turbine_v3_to_v4.py {filename_v3_turbine}")
 
     # Run the converter on the floris file
     os.system(f"python convert_floris_input_v3_to_v4.py {filename_v3_floris}")
 
-    # Go through the file filename_v4_floris and where the place-holder string "XXXXX" is found
-    # replace it with the string f"!include {filename_v4_turbine}"
+    # Go through the file filename_v4_floris and replace f"!include {filename_v3_turbine}"
+    # with f"!include {filename_v4_turbine}"
     with open(filename_v4_floris, "r") as file:
         filedata = file.read()
-    filedata = filedata.replace("XXXXX", f"!include {filename_v4_turbine}")
+    filedata = filedata.replace(
+        f"!include {filename_v3_turbine}", f"!include {filename_v4_turbine}"
+    )
     with open(filename_v4_floris, "w") as file:
         file.write(filedata)
 

--- a/tests/v3_to_v4_convert_test/gch.yaml
+++ b/tests/v3_to_v4_convert_test/gch.yaml
@@ -87,7 +87,7 @@ farm:
   # The types can be either a name included in the turbine_library or
   # a full definition of a wind turbine directly.
   turbine_type:
-  - XXXXX
+  - !include nrel_5MW_v3.yaml
 
 ###
 # Configure the atmospheric conditions.


### PR DESCRIPTION
# Ignore includes in v3->v4 conversions

Currently when you convert an input yaml from v3 -> v4 using the converter script, any !include statements to turbine files get unpacked within the yaml file and then dumped into the file.  While this can work, it means that the yaml file can get quite long if there were a number of turbines listed, and also the yaml is no longer tied to the turbine file, and changes made to the turbine file will have to be made to each instance within the yaml.

This pull pull request modifies the yaml load/dump routines within the converter to pass through those include statements directly.  It further updates the convert script test to confirm the new methods are working.  Previously, to avoid this issue a sentinal "XXXXX" string was used but this can now go back to the turbine yaml name
