### PR TITLE
Add link to GRS layout optimization paper

### DIFF
--- a/docs/heterogeneous_map.ipynb
+++ b/docs/heterogeneous_map.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# HeterogeneousMap"
+    "(heterogeneous_map)=\n",
+    "\n",
+    "# Heterogeneous Map"
    ]
   },
   {

--- a/docs/layout_optimization.md
+++ b/docs/layout_optimization.md
@@ -1,6 +1,6 @@
 
 (layout_optimization)=
-# Layout optimization
+# Layout Optimization
 
 The FLORIS package provides layout optimization tools to place turbines within a specified
 boundary area to optimize annual energy production (AEP) or wind plant value. Layout
@@ -59,8 +59,8 @@ turbine placement
 - Set up to run cheap constraint checks prior to more expensive objective function evaluations
 to accelerate optimization
 
-The algorithm, described in full in an upcoming paper that will be linked here when it is
-publicly available, moves a random turbine and random distance in a random direction; checks
+The algorithm, described in full in {cite:t}`SinnerFleming2024grs`, 
+moves a random turbine and random distance in a random direction; checks
 that constraints are satisfied; evaluates the objective function (AEP or value); and then
 commits to the move if there is an objective function improvement. The main tuning parameter
 is the probability mass function for the random movement distance, which is a dictionary to be

--- a/docs/layout_optimization.md
+++ b/docs/layout_optimization.md
@@ -59,7 +59,7 @@ turbine placement
 - Set up to run cheap constraint checks prior to more expensive objective function evaluations
 to accelerate optimization
 
-The algorithm, described in full in {cite:t}`SinnerFleming2024grs`, 
+The algorithm, described in full in {cite:t}`SinnerFleming2024grs`,
 moves a random turbine and random distance in a random direction; checks
 that constraints are satisfied; evaluates the objective function (AEP or value); and then
 commits to the move if there is an objective function improvement. The main tuning parameter

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -272,3 +272,17 @@ PAGES = {1--28},
 URL = {https://wes.copernicus.org/preprints/wes-2022-17/},
 DOI = {10.5194/wes-2022-17}
 }
+
+@article{SinnerFleming2024grs,
+doi = {10.1088/1742-6596/2767/3/032036},
+url = {https://dx.doi.org/10.1088/1742-6596/2767/3/032036},
+year = {2024},
+month = {jun},
+publisher = {IOP Publishing},
+volume = {2767},
+number = {3},
+pages = {032036},
+author = {Michael Sinner and Paul Fleming},
+title = {Robust wind farm layout optimization},
+journal = {Journal of Physics: Conference Series},
+}

--- a/floris/optimization/layout_optimization/layout_optimization_random_search.py
+++ b/floris/optimization/layout_optimization/layout_optimization_random_search.py
@@ -140,7 +140,8 @@ class LayoutOptimizationRandomSearch(LayoutOptimization):
         use_value=False,
     ):
         """
-        _summary_
+        Optimize layout using genetic random search algorithm. Details of the algorithm can be found
+        in Sinner and Fleming, 2024: https://dx.doi.org/10.1088/1742-6596/2767/3/032036
 
         Args:
             fmodel (_type_): _description_


### PR DESCRIPTION
The published paper on the genetic random search algorithm is now available online: https://dx.doi.org/10.1088/1742-6596/2767/3/032036.

This small PR adds a citation to the paper for readers looking at the documentation and wanting to know more, or reading the `LayoutOptimizationRandomSearch` docstring.

I've also taken the opportunity to align the title styles for a couple of docs pages that were not consistent with the other docs.

I've also built the docs locally and verified that the citations work as expected.
