### PR TITLE
[BUGFIX] Fix turbine selector in random search layout optimizer

### DIFF
--- a/floris/optimization/layout_optimization/layout_optimization_random_search.py
+++ b/floris/optimization/layout_optimization/layout_optimization_random_search.py
@@ -18,7 +18,6 @@ from time import perf_counter as timerpc
 
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import random
 from scipy.spatial.distance import cdist, pdist
 from shapely.geometry import Point, Polygon
 
@@ -84,11 +83,11 @@ def _gen_dist_based_init(
     np.random.seed(s)
 
     # Choose the initial point randomly
-    init_x = float(random.randint(int(min_x),int(max_x)))
-    init_y = float(random.randint(int(min_y),int(max_y)))
+    init_x = float(np.random.randint(int(min_x),int(max_x)))
+    init_y = float(np.random.randint(int(min_y),int(max_y)))
     while not (poly_outer.contains(Point([init_x,init_y]))):
-        init_x = float(random.randint(int(min_x),int(max_x)))
-        init_y = float(random.randint(int(min_y),int(max_y)))
+        init_x = float(np.random.randint(int(min_x),int(max_x)))
+        init_y = float(np.random.randint(int(min_y),int(max_y)))
 
     # Intialize the layout arrays
     layout_x = np.array([init_x])
@@ -649,7 +648,7 @@ def _single_individual_opt(
             if get_new_point: #If the last test wasn't successful
 
                 # Randomly select a turbine to nudge
-                tr = random.randint(0,num_turbines-1)
+                tr = np.random.randint(0,num_turbines)
 
                 # Randomly select a direction to nudge in (uniform direction)
                 rand_dir = np.random.uniform(low=0.0, high=2*np.pi)

--- a/tests/reg_tests/random_search_layout_opt_regression_test.py
+++ b/tests/reg_tests/random_search_layout_opt_regression_test.py
@@ -17,11 +17,11 @@ DEFLECTION_MODEL = "gauss"
 
 locations_baseline_aep = np.array(
     [
-        [0.0, 571.5416296, 1260.0],
-        [0.0, 496.57085993, 0.],
+        [0.0, 619.07183266, 1260.0],
+        [0.0, 499.88056089, 0.0]
     ]
 )
-baseline_aep = 44787987324.21652
+baseline_aep = 44798828639.17205
 
 locations_baseline_value = np.array(
     [


### PR DESCRIPTION
While working on #919 , @paulf81 and I found a bug that meant that, during the selection of a random turbine to move in the `LayoutOptimizationRandomSearch` optimization routine, the `num_turbines`th (last) turbine was never selected. 

The issue stems from [numpy's `randint`](https://numpy.org/doc/stable/reference/random/generated/numpy.random.randint.html) _excluding_ the high value, compared to the [builtin `randint`](https://www.geeksforgeeks.org/python-randint-function/) _including_ the high value. I introduced the bug when I switched from importing the builtin `random` to importing `random` from numpy in 76a1465.

The fix is simply to move to the high value being `num_turbines`, rather than `num_turbines - 1`. However, to avoid confusion, I've also made the usage of numpy explicit by removing the direct import of `random` from numpy and instead using `np.random.randint()`.

The following code demonstrates the difference between the builtin `random.randint()` and `np.random.randint()`. The first `for` loop produces both 0 and 1s, whereas the second produces only 0s.

```python
from random import randint
import numpy as np

print("Built in")
for _ in range(20):
    print(randint(0,1))

print("\n\nnumpy")
for _ in range(20):
    print(np.random.randint(0,1))
```

# Notes
- The test random_search_layout_opt_regression_test.py values were updated as this changed the regression test results.
- Merging this into develop will likely create a small merge conflict with #919, where this is partially fixed. I will resolve that merge conflict once this is approved and in the develop branch.
- `np.random.randint` is also used in selecting initial positions in `_gen_dist_based_init()`. Here, the usage will mean that the (integer) maximum value will not actually be selected. However, moving 1m less than the max is essentially equivalent in this case; moreover, `_gen_dist_based_init()` is only used for generating initial positions that will very likely be updated by the main optimization routines. I think we don't need to change the operation of these lines, but I've still changed them to be explicit in their numpy usage after removing the `from numpy import random` line.
