### PR TITLE
Update coloredlogs requirement

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        os: [ubuntu-latest] #, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest] #, macos-latest, windows-latest]
       fail-fast: False
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        os: [ubuntu-latest, macos-latest] #, macos-latest, windows-latest]
+        os: [ubuntu-latest] #, macos-latest, windows-latest]
       fail-fast: False
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/floris/optimization/yaw_optimization/yaw_optimization_tools.py
+++ b/floris/optimization/yaw_optimization/yaw_optimization_tools.py
@@ -76,18 +76,18 @@ def derive_downstream_turbines(fmodel, wind_direction, wake_slope=0.30, plot_lin
             y = (y0 + D[ii]) + (x - x0) * wake_slope
             if isinstance(y, (float, np.float64, np.float32)):
                 if x < (x0 + 0.01):
-                    y = -np.Inf
+                    y = -np.inf
             else:
-                y[x < x0 + 0.01] = -np.Inf
+                y[x < x0 + 0.01] = -np.inf
             return y
 
         def wake_profile_lb_turbii(x):
             y = (y0 - D[ii]) - (x - x0) * wake_slope
             if isinstance(y, (float, np.float64, np.float32)):
                 if x < (x0 + 0.01):
-                    y = -np.Inf
+                    y = -np.inf
             else:
-                y[x < x0 + 0.01] = -np.Inf
+                y[x < x0 + 0.01] = -np.inf
             return y
 
         def determine_if_in_wake(xt, yt):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIRED = [
     "attrs",
     "pyyaml~=6.0",
     "numexpr~=2.0",
-    "numpy~=1.20",
+    "numpy~=2.0",
     "scipy~=1.1",
 
     # tools
@@ -27,7 +27,7 @@ REQUIRED = [
     "shapely~=2.0",
 
     # utilities
-    "coloredlogs~=10.0",
+    "coloredlogs~=15.0",
 ]
 
 # What packages are optional?

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIRED = [
     "attrs",
     "pyyaml~=6.0",
     "numexpr~=2.0",
-    "numpy~=2.0",
+    "numpy~=1.20",
     "scipy~=1.1",
 
     # tools


### PR DESCRIPTION
# Update requirements

FLORIS uses the compatible release clause (`~=`) when specificying versioning (c.f. https://peps.python.org/pep-0440/#compatible-release).  This PR updates to newer versions of certain requirements that have had major releases to catch up with: numpy and colored-logs.

~It further adds macos to list of OS to try in CI~

## Related issue
Issue #938 
