### PR TITLE
[BUGFIX] Create reproducible version of random search layout optimizer for testing

### DIFF
--- a/floris/optimization/layout_optimization/layout_optimization_random_search.py
+++ b/floris/optimization/layout_optimization/layout_optimization_random_search.py
@@ -328,6 +328,9 @@ class LayoutOptimizationRandomSearch(LayoutOptimization):
         # Delete stored x and y to avoid confusion
         del self.x, self.y
 
+        # Set up to run in normal mode
+        self.debug = False
+
     def describe(self):
         print("Random Layout Optimization")
         print(f"Number of turbines to optimize = {self.N_turbines}")
@@ -534,7 +537,8 @@ class LayoutOptimizationRandomSearch(LayoutOptimization):
                 self.distance_pmf,
                 self.enable_geometric_yaw,
                 multi_random_seeds[i],
-                self.use_value
+                self.use_value,
+                self.debug
             )
                 for i in range(self.n_individuals)
         ]
@@ -585,6 +589,7 @@ class LayoutOptimizationRandomSearch(LayoutOptimization):
         self._PoolExecutor = None
         self.max_workers = None
         self.n_individuals = 1
+        self.debug = True
 
         self._initialize_optimization()
 
@@ -641,7 +646,8 @@ def _single_individual_opt(
     dist_pmf,
     enable_geometric_yaw,
     s,
-    use_value
+    use_value,
+    debug
 ):
     # Set random seed
     np.random.seed(s)
@@ -675,8 +681,19 @@ def _single_individual_opt(
     # disabled.
     use_momentum = False
 
+    # Special handling for debug mode
+    if debug:
+        debug_iterations = 100
+        stop_time = np.inf
+        dd = 0
+
     # Loop as long as we've not hit the stop time
     while timerpc() < stop_time:
+
+        if debug and dd >= debug_iterations:
+            break
+        elif debug:
+            dd += 1
 
         if not use_momentum:
             get_new_point = True

--- a/tests/reg_tests/random_search_layout_opt_regression_test.py
+++ b/tests/reg_tests/random_search_layout_opt_regression_test.py
@@ -17,11 +17,11 @@ DEFLECTION_MODEL = "gauss"
 
 locations_baseline_aep = np.array(
     [
-        [0.0, 619.07183266, 1260.0],
-        [0.0, 499.88056089, 0.0]
+        [0.0, 243.05304475, 1260.0],
+        [0.0, 959.83979244,    0.0],
     ]
 )
-baseline_aep = 44798828639.17205
+baseline_aep = 45226182795.34081
 
 locations_baseline_value = np.array(
     [
@@ -68,7 +68,7 @@ def test_random_search_layout_opt(sample_inputs_fixture):
         use_dist_based_init=False,
         random_seed=0,
     )
-    sol = layout_opt.optimize()
+    sol = layout_opt._test_optimize()
     optimized_aep = sol[0]
     locations_opt = np.array([sol[1], sol[2]])
 
@@ -130,7 +130,7 @@ def test_random_search_layout_opt_value(sample_inputs_fixture):
         random_seed=0,
         use_value=True,
     )
-    sol = layout_opt.optimize()
+    sol = layout_opt._test_optimize()
     optimized_value = sol[0]
     locations_opt = np.array([sol[1], sol[2]])
 


### PR DESCRIPTION
As reported in #936 , the regression tests for the random search layout optimizer can _sometimes_ fail. I believe that the cause for this is that the optimizer is run for one second during the test; however, depending on the machine, it may take more or less steps over that period.

This PR alters the `LayoutOptimizationRandomSearch` code to make it modular, and then adds a debugging version of the optimization routine that will take a fixed number of steps (in particular, 100 random perturbations per generation, 1 individual per generation, and 2 generations).

This should enable reproducible regression test results.
