### PR TITLE
[BUGFIX] Circular upsampling across wind directions

### DIFF
--- a/examples/003_wind_data_objects.py
+++ b/examples/003_wind_data_objects.py
@@ -224,7 +224,7 @@ fmodel.set(wind_data=wind_rose)
 # bins for which frequency is zero are not simulated.  This can be changed by setting the
 # compute_zero_freq_occurrence parameter to True.
 wind_directions = np.array([200.0, 300.0])
-wind_speeds = np.array([5.0, 1.00])
+wind_speeds = np.array([5.0, 10.0])
 freq_table = np.array([[0.5, 0], [0.5, 0]])
 wind_rose = WindRose(
     wind_directions=wind_directions, wind_speeds=wind_speeds, ti_table=0.06, freq_table=freq_table

--- a/examples/examples_layout_optimization/002_optimize_layout_with_heterogeneity.py
+++ b/examples/examples_layout_optimization/002_optimize_layout_with_heterogeneity.py
@@ -26,10 +26,10 @@ fmodel = FlorisModel("../inputs/gch.yaml")
 
 # Setup 2 wind directions (due east and due west)
 # and 1 wind speed with uniform probability
-wind_directions = np.array([270.0, 90.0])
+wind_directions = np.array([90.0, 270.0])
 n_wds = len(wind_directions)
-wind_speeds = [8.0] * np.ones_like(wind_directions)
-turbulence_intensities = 0.06 * np.ones_like(wind_directions)
+wind_speeds = np.array([8.0])
+
 # Shape frequency distribution to match number of wind directions and wind speeds
 freq_table = np.ones((len(wind_directions), len(wind_speeds)))
 freq_table = freq_table / freq_table.sum()
@@ -106,7 +106,7 @@ ax = plt.gca()
 fig = plt.gcf()
 sm = ax.tricontourf(x_locs, y_locs, speed_multipliers[0], cmap="coolwarm")
 fig.colorbar(sm, ax=ax, label="Speed multiplier")
-ax.legend(["Initial layout", "Optimized layout", "Optimization boundary"])
+ax.legend(["Optimization boundary", "Initial layout", "Optimized layout" ])
 ax.set_title("Geometric yaw disabled")
 
 
@@ -144,7 +144,7 @@ ax = plt.gca()
 fig = plt.gcf()
 sm = ax.tricontourf(x_locs, y_locs, speed_multipliers[0], cmap="coolwarm")
 fig.colorbar(sm, ax=ax, label="Speed multiplier")
-ax.legend(["Initial layout", "Optimized layout", "Optimization boundary"])
+ax.legend(["Optimization boundary", "Initial layout", "Optimized layout"])
 ax.set_title("Geometric yaw enabled")
 
 print(

--- a/examples/examples_layout_optimization/002_optimize_layout_with_heterogeneity.py
+++ b/examples/examples_layout_optimization/002_optimize_layout_with_heterogeneity.py
@@ -106,7 +106,7 @@ ax = plt.gca()
 fig = plt.gcf()
 sm = ax.tricontourf(x_locs, y_locs, speed_multipliers[0], cmap="coolwarm")
 fig.colorbar(sm, ax=ax, label="Speed multiplier")
-ax.legend(["Optimization boundary", "Initial layout", "Optimized layout" ])
+ax.legend(["_Optimization boundary", "Initial layout", "Optimized layout" ])
 ax.set_title("Geometric yaw disabled")
 
 
@@ -144,7 +144,7 @@ ax = plt.gca()
 fig = plt.gcf()
 sm = ax.tricontourf(x_locs, y_locs, speed_multipliers[0], cmap="coolwarm")
 fig.colorbar(sm, ax=ax, label="Speed multiplier")
-ax.legend(["Optimization boundary", "Initial layout", "Optimized layout"])
+ax.legend(["_Optimization boundary", "Initial layout", "Optimized layout"])
 ax.set_title("Geometric yaw enabled")
 
 print(

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -88,6 +88,67 @@ def wrap_360(x):
 
     return x % 360.0
 
+def identify_step_size(wind_directions):
+    """
+    This function identifies the step size in a series of wind directions. The function will
+    return the step size if the wind directions are evenly spaced, otherwise it will raise an
+    error.
+
+    Args:
+        wind_directions (np.ndarray): Array of wind directions.
+
+    Returns:
+        float: The step size of the wind directions.
+    """
+
+    if len(wind_directions) < 2:
+        raise ValueError("Array must contain at least 2 elements")
+
+    # First compute the steps between each wind direction
+    steps = np.diff(wind_directions)
+
+    # Confirm that the steps are all positive
+    if not np.all(steps > 0):
+        raise ValueError("wind_directions must be monotonically increasing")
+
+    # Check the step from the last to the first element
+    last_step = wind_directions[0] - wind_directions[-1] + 360
+
+    # If len(window_directions) == 2, then return whichever step is smaller
+    if len(wind_directions) == 2:
+        return min(steps[0], last_step)
+
+    # If len(window_directions) == 3 make some checks
+    elif len(wind_directions) == 3:
+        if np.all(steps == steps[0]):
+            return steps[0]
+        elif steps[0] == last_step:
+            return steps[0]
+        elif steps[1] == last_step:
+            return steps[1]
+        else:
+            raise ValueError("wind_directions must be evenly spaced")
+
+    else:
+        if np.all(steps == steps[0]):
+            return steps[0]
+
+        # If all but one of the steps are the same
+        values, counts = np.unique(steps, return_counts=True)
+
+        # Check for the case where there are more than two different step sizes
+        if len(values) > 2:
+            raise ValueError("wind_directions must be evenly spaced")
+
+        # In the case there are only two step sizes, ensure that one only happens once
+        if np.min(counts) > 1:
+            raise ValueError("wind_directions must be evenly spaced")
+
+        # If the last step equals the most common step, return the most common step
+        if last_step == values[np.argmax(counts)]:
+            return values[np.argmax(counts)]
+
+        raise ValueError("wind_directions must be evenly spaced")
 
 def wind_delta(wind_directions: NDArrayFloat | float):
     """

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -180,7 +180,14 @@ def make_wind_directions_adjacent(wind_directions: NDArrayFloat) -> NDArrayFloat
             (wind_directions[idx+1:] - 360, wind_directions[:idx+1])
         )
 
-    return wind_directions
+        # Return the wind directions and indices to go from the original to the new
+        sort_indices = np.array(list(range(idx+1,len(wind_directions))) + list(range(idx+1)))
+
+        return wind_directions, sort_indices
+
+    else:
+
+        return wind_directions, np.arange(len(wind_directions))
 
 
 def wind_delta(wind_directions: NDArrayFloat | float):

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -152,7 +152,9 @@ def check_and_identify_step_size(wind_directions):
 
 def make_wind_directions_adjacent(wind_directions: NDArrayFloat) -> NDArrayFloat:
     """
-    This function ...
+    This function reorders the wind directions so that they are adjacent. The function will
+    return the reordered wind directions if the wind directions are not adjacent, otherwise it
+    will return the input wind directions
 
     Args:
         wind_directions (NDArrayFloat): Array of wind directions.

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -88,7 +88,7 @@ def wrap_360(x):
 
     return x % 360.0
 
-def identify_step_size(wind_directions):
+def check_and_identify_step_size(wind_directions):
     """
     This function identifies the step size in a series of wind directions. The function will
     return the step size if the wind directions are evenly spaced, otherwise it will raise an
@@ -149,6 +149,37 @@ def identify_step_size(wind_directions):
             return values[np.argmax(counts)]
 
         raise ValueError("wind_directions must be evenly spaced")
+
+def make_wind_directions_adjacent(wind_directions: NDArrayFloat) -> NDArrayFloat:
+    """
+    This function ...
+
+    Args:
+        wind_directions (NDArrayFloat): Array of wind directions.
+
+    Returns:
+        NDArrayFloat: The reordered wind directions to be adjacent.
+    """
+
+    # Check the step size of the wind directions
+    step_size = check_and_identify_step_size(wind_directions)
+
+    # Get a list of steps
+    steps = np.diff(wind_directions)
+
+    # There will be at most one step with a size larger than the step size
+    # If there is one, find it
+    if np.any(steps > step_size):
+        idx = np.argmax(steps)
+
+        # Now change wind_directions such that for each direction after that index
+        # subtract 360 and move that block to the front
+        wind_directions = np.concatenate(
+            (wind_directions[idx+1:] - 360, wind_directions[:idx+1])
+        )
+
+    return wind_directions
+
 
 def wind_delta(wind_directions: NDArrayFloat | float):
     """

--- a/floris/wind_data.py
+++ b/floris/wind_data.py
@@ -452,25 +452,50 @@ class WindRose(WindDataBase):
                 "Available methods are 'linear' and 'nearest'"
             )
 
+        # First establish the current ws_step and wd_step
+        if len(self.wind_speeds) >= 2:
+            ws_step_current = self.wind_speeds[1] - self.wind_speeds[0]
+        else:  # wind rose will have only a single wind speed, and we assume a ws_step of 1
+            ws_step_current = 1.0
+
+        if len(self.wind_directions) >= 2:
+            wd_step_current = self.wind_directions[1] - self.wind_directions[0]
+        else:  # wind rose will have only a single wind direction, and we assume a wd_step of 1
+            wd_step_current = 1.0
+
         # If either ws_step or wd_step is None, set it to the current step
         if ws_step is None:
-            if len(self.wind_speeds) >= 2:
-                ws_step = self.wind_speeds[1] - self.wind_speeds[0]
-            else:  # wind rose will have only a single wind speed, and we assume a ws_step of 1
-                ws_step = 1.0
+            ws_step = ws_step_current
         if wd_step is None:
-            if len(self.wind_directions) >= 2:
-                wd_step = self.wind_directions[1] - self.wind_directions[0]
-            else:  # wind rose will have only a single wind direction, and we assume a wd_step of 1
-                wd_step = 1.0
+            wd_step = wd_step_current
 
-        # Set up the new wind direction and wind speed bins
-        new_wind_directions = np.arange(
-            self.wind_directions[0], self.wind_directions[-1] + wd_step / 2.0, wd_step
-        )
-        new_wind_speeds = np.arange(
-            self.wind_speeds[0], self.wind_speeds[-1] + ws_step / 2.0, ws_step
-        )
+        # Set up the new wind directions
+        wd_range_min_current = np.min(self.wind_directions) - wd_step_current / 2.0
+        wd_range_max_current = np.max(self.wind_directions) + wd_step_current / 2.0
+
+        if wd_range_max_current > 360:
+            # TODO: This could probably be more clear
+            raise ValueError(
+                "Cannot upsample wind rose for case when wind directions are defined"
+                " such that 0 degrees is included by bins to the left of 0 degrees. "
+            )
+
+        wd_min_new = wd_range_min_current + wd_step / 2.0
+        wd_max_new = wd_range_max_current - wd_step / 2.0
+
+        new_wind_directions = np.arange(wd_min_new, wd_max_new + wd_step / 2.0, wd_step)
+
+        # Set up the new wind speeds
+        ws_range_min_current = np.min(self.wind_speeds) - ws_step_current / 2.0
+        ws_range_max_current = np.max(self.wind_speeds) + ws_step_current / 2.0
+        ws_min_new = ws_range_min_current + ws_step / 2.0
+        ws_max_new = ws_range_max_current - ws_step / 2.0
+
+        # Force the new ws_min to 0 if negative
+        if ws_min_new < 0:
+            ws_min_new = 0.0
+
+        new_wind_speeds = np.arange(ws_min_new, ws_max_new + ws_step / 2.0, ws_step)
 
         # Set up for interpolation
         wind_direction_column = self.wind_directions.copy()
@@ -482,16 +507,60 @@ class WindRose(WindDataBase):
         else:
             value_matrix = None
 
-        # If the first entry of wind_direction column is 0, and the last entry is not 360, then
-        # pad 360 to the end of the wind direction column and the last row of the ti_matrix and
-        # freq_matrix by copying the 0 entry
-        if len(wind_direction_column) > 1:
-            if wind_direction_column[0] == 0 and wind_direction_column[-1] != 360:
-                wind_direction_column = np.append(wind_direction_column, 360)
-                ti_matrix = np.vstack((ti_matrix, ti_matrix[0, :]))
-                freq_matrix = np.vstack((freq_matrix, freq_matrix[0, :]))
-                if self.value_table is not None:
-                    value_matrix = np.vstack((value_matrix, value_matrix[0, :]))
+        # Make sure everything sorted by wind direction and wind speed
+        sort_indices_wd = np.argsort(wind_direction_column)
+        wind_direction_column = wind_direction_column[sort_indices_wd]
+        sort_indices_ws = np.argsort(wind_speed_column)
+        wind_speed_column = wind_speed_column[sort_indices_ws]
+        ti_matrix = ti_matrix[sort_indices_wd, :]
+        ti_matrix = ti_matrix[:, sort_indices_ws]
+        freq_matrix = freq_matrix[sort_indices_wd, :]
+        freq_matrix = freq_matrix[:, sort_indices_ws]
+        if self.value_table is not None:
+            value_matrix = value_matrix[sort_indices_wd, :]
+            value_matrix = value_matrix[:, sort_indices_ws]
+
+        # Pad out the wind directions and wind speeds to the min and max ranges
+        # Add the min range to the wind direction column
+        wind_direction_column = np.append(wd_range_min_current, wind_direction_column)
+        ti_matrix = ti_matrix = np.vstack((ti_matrix[0, :], ti_matrix))
+        freq_matrix = np.vstack((freq_matrix[0, :], freq_matrix))
+        if self.value_table is not None:
+            value_matrix = np.vstack((value_matrix[0, :], value_matrix))
+
+        # Add the max range to the wind direction column
+        wind_direction_column = np.append(wind_direction_column, wd_range_max_current)
+        ti_matrix = np.vstack((ti_matrix, ti_matrix[-1, :]))
+        freq_matrix = np.vstack((freq_matrix, freq_matrix[-1, :]))
+        if self.value_table is not None:
+            value_matrix = np.vstack((value_matrix, value_matrix[-1, :]))
+
+        # Pad out the wind speeds
+        wind_speed_column = np.append(ws_range_min_current, wind_speed_column)
+        ti_matrix = np.hstack((ti_matrix[:, 0].reshape((-1,1)), ti_matrix))
+        freq_matrix = np.hstack((freq_matrix[:, 0].reshape((-1,1)), freq_matrix))
+        if self.value_table is not None:
+            value_matrix = np.hstack((value_matrix[:, 0].reshape((-1,1)), value_matrix))
+
+        wind_speed_column = np.append(wind_speed_column, ws_range_max_current)
+        ti_matrix = np.hstack((ti_matrix, ti_matrix[:, -1].reshape((-1,1))))
+        freq_matrix = np.hstack((freq_matrix, freq_matrix[:, -1].reshape((-1,1))))
+        if self.value_table is not None:
+            value_matrix = np.hstack((value_matrix, value_matrix[:, -1].reshape((-1,1))))
+
+        # If wd_range_min_current is less than 0, then pad the wind_direction column with
+        # that value + 360 and expand the matrices accordingly (this avoids interpolation errors)
+        if wd_range_min_current < 0:
+            # Pad wind direction column with min_wd + 360
+            wind_direction_column = np.append(
+                wind_direction_column, np.min(self.wind_directions) + 360.0
+            )
+
+            # Pat the remaining with the appropriate value
+            ti_matrix = ti_matrix = np.vstack((ti_matrix, ti_matrix[0, :]))
+            freq_matrix = np.vstack((freq_matrix, freq_matrix[0, :]))
+            if self.value_table is not None:
+                value_matrix = np.vstack((value_matrix, value_matrix[0, :]))
 
         # If the wind_direction columns has length 1, then pad the wind_direction column with
         # that value + and - 1 and expand the matrices accordingly
@@ -555,6 +624,18 @@ class WindRose(WindDataBase):
             )
         else:
             new_value_matrix = None
+
+        # Wrap new_wind_directions to 0-360
+        new_wind_directions = new_wind_directions % 360
+
+        # Finally sort new_wind_directions, and re-order new_ti_matrix, new_freq_matrix
+        # and new_value_matrix accordingly
+        sort_indices = np.argsort(new_wind_directions)
+        new_wind_directions = new_wind_directions[sort_indices]
+        new_ti_matrix = new_ti_matrix[sort_indices, :]
+        new_freq_matrix = new_freq_matrix[sort_indices, :]
+        if self.value_table is not None:
+            new_value_matrix = new_value_matrix[sort_indices, :]
 
         # Create the resampled wind rose
         resampled_wind_rose = WindRose(
@@ -1262,9 +1343,7 @@ class WindTIRose(WindDataBase):
 
         return self.upsample(wd_step, ws_step, method, inplace)
 
-    def upsample(
-        self, wd_step=None, ws_step=None, ti_step=None, method="linear", inplace=False
-    ):
+    def upsample(self, wd_step=None, ws_step=None, ti_step=None, method="linear", inplace=False):
         """
 
         Resample the wind TI rose using interpolation.  The method can be either

--- a/floris/wind_data.py
+++ b/floris/wind_data.py
@@ -567,18 +567,15 @@ class WindRose(WindDataBase):
         # This is the case when wind directions doesn't cover the full range of possible
         # degrees (0-360)
         if np.abs((wd_range_min_current % 360.0) - (wd_range_max_current % 360.0)) > 1e-6:
-            wind_direction_column = np.append(wd_range_min_current, wind_direction_column)
-            ti_matrix = ti_matrix = np.vstack((ti_matrix[0, :], ti_matrix))
-            freq_matrix = np.vstack((freq_matrix[0, :], freq_matrix))
+            wind_direction_column = np.concatenate((
+                np.array([wd_range_min_current]),
+                wind_direction_column,
+                np.array([wd_range_max_current])
+            ))
+            ti_matrix = ti_matrix = np.vstack((ti_matrix[0, :], ti_matrix, ti_matrix[-1,:]))
+            freq_matrix = np.vstack((freq_matrix[0, :], freq_matrix, freq_matrix[-1,:]))
             if self.value_table is not None:
-                value_matrix = np.vstack((value_matrix[0, :], value_matrix))
-
-            # Add the max range to the wind direction column
-            wind_direction_column = np.append(wind_direction_column, wd_range_max_current)
-            ti_matrix = np.vstack((ti_matrix, ti_matrix[-1, :]))
-            freq_matrix = np.vstack((freq_matrix, freq_matrix[-1, :]))
-            if self.value_table is not None:
-                value_matrix = np.vstack((value_matrix, value_matrix[-1, :]))
+                value_matrix = np.vstack((value_matrix[0, :], value_matrix, value_matrix[-1,:]))
 
         # In the alternative case, where the wind directions cover the full range
         # ie, 0, 10, 20 30, ...350, then need to place 0 at 360 and 350 at -10

--- a/floris/wind_data.py
+++ b/floris/wind_data.py
@@ -205,7 +205,7 @@ class WindRose(WindDataBase):
         if heterogeneous_map is not None and heterogeneous_inflow_config_by_wd is not None:
             raise ValueError(
                 "Only one of heterogeneous_map and heterogeneous_inflow_config_by_wd can be"
-                +" defined."
+                + " defined."
             )
 
         # If heterogeneous_inflow_config_by_wd is not None, then create a HeterogeneousMap object
@@ -539,16 +539,16 @@ class WindRose(WindDataBase):
 
         # Pad out the wind speeds
         wind_speed_column = np.append(ws_range_min_current, wind_speed_column)
-        ti_matrix = np.hstack((ti_matrix[:, 0].reshape((-1,1)), ti_matrix))
-        freq_matrix = np.hstack((freq_matrix[:, 0].reshape((-1,1)), freq_matrix))
+        ti_matrix = np.hstack((ti_matrix[:, 0].reshape((-1, 1)), ti_matrix))
+        freq_matrix = np.hstack((freq_matrix[:, 0].reshape((-1, 1)), freq_matrix))
         if self.value_table is not None:
-            value_matrix = np.hstack((value_matrix[:, 0].reshape((-1,1)), value_matrix))
+            value_matrix = np.hstack((value_matrix[:, 0].reshape((-1, 1)), value_matrix))
 
         wind_speed_column = np.append(wind_speed_column, ws_range_max_current)
-        ti_matrix = np.hstack((ti_matrix, ti_matrix[:, -1].reshape((-1,1))))
-        freq_matrix = np.hstack((freq_matrix, freq_matrix[:, -1].reshape((-1,1))))
+        ti_matrix = np.hstack((ti_matrix, ti_matrix[:, -1].reshape((-1, 1))))
+        freq_matrix = np.hstack((freq_matrix, freq_matrix[:, -1].reshape((-1, 1))))
         if self.value_table is not None:
-            value_matrix = np.hstack((value_matrix, value_matrix[:, -1].reshape((-1,1))))
+            value_matrix = np.hstack((value_matrix, value_matrix[:, -1].reshape((-1, 1))))
 
         # If wd_range_min_current is less than 0, then pad the wind_direction column with
         # that value + 360 and expand the matrices accordingly (this avoids interpolation errors)
@@ -688,7 +688,7 @@ class WindRose(WindDataBase):
             rects = []
             freq_table_sub = freq_table[wd_idx, :].flatten()
             for ws_idx, ws in reversed(list(enumerate(ws_bins))):
-                plot_val = freq_table_sub[:ws_idx + 1].sum()
+                plot_val = freq_table_sub[: ws_idx + 1].sum()
                 rects.append(
                     ax.bar(
                         np.radians(wd),
@@ -1086,7 +1086,7 @@ class WindTIRose(WindDataBase):
         if heterogeneous_map is not None and heterogeneous_inflow_config_by_wd is not None:
             raise ValueError(
                 "Only one of heterogeneous_map and heterogeneous_inflow_config_by_wd can be"
-                +" defined."
+                + " defined."
             )
 
         # If heterogeneous_inflow_config_by_wd is not None, then create a HeterogeneousMap object
@@ -1348,33 +1348,71 @@ class WindTIRose(WindDataBase):
                 "Available methods are 'linear' and 'nearest'"
             )
 
-        # If either ws_step or wd_step is None, set it to the current step
-        if ws_step is None:
-            if len(self.wind_speeds) >= 2:
-                ws_step = self.wind_speeds[1] - self.wind_speeds[0]
-            else:  # wind rose will have only a single wind speed, and we assume a ws_step of 1
-                ws_step = 1.0
-        if wd_step is None:
-            if len(self.wind_directions) >= 2:
-                wd_step = self.wind_directions[1] - self.wind_directions[0]
-            else:  # wind rose will have only a single wind direction, and we assume a wd_step of 1
-                wd_step = 1.0
-        if ti_step is None:
-            if len(self.turbulence_intensities) >= 2:
-                ti_step = self.turbulence_intensities[1] - self.turbulence_intensities[0]
-            else:
-                ti_step = 1.0
+        # First establish the current ws_step and wd_step and ti_step
+        if len(self.wind_speeds) >= 2:
+            ws_step_current = self.wind_speeds[1] - self.wind_speeds[0]
+        else:  # wind rose will have only a single wind speed, and we assume a ws_step of 1
+            ws_step_current = 1.0
 
-        # Set up the new wind direction and wind speed and turbulence intensity bins
-        new_wind_directions = np.arange(
-            self.wind_directions[0], self.wind_directions[-1] + wd_step / 2.0, wd_step
-        )
-        new_wind_speeds = np.arange(
-            self.wind_speeds[0], self.wind_speeds[-1] + ws_step / 2.0, ws_step
-        )
-        new_turbulence_intensities = np.arange(
-            self.turbulence_intensities[0], self.turbulence_intensities[-1] + ti_step / 2.0, ti_step
-        )
+        if len(self.wind_directions) >= 2:
+            wd_step_current = self.wind_directions[1] - self.wind_directions[0]
+        else:  # wind rose will have only a single wind direction, and we assume a wd_step of 1
+            wd_step_current = 1.0
+
+        if len(self.turbulence_intensities) >= 2:
+            ti_step_current = self.turbulence_intensities[1] - self.turbulence_intensities[0]
+        else:  # wind rose will have only a single turbulence intensity,
+            # and we assume a ti_step of 1
+            ti_step_current = 1.0
+
+        # If either ws_step or wd_step or ti_step is None, set it to the current step
+        if ws_step is None:
+            ws_step = ws_step_current
+        if wd_step is None:
+            wd_step = wd_step_current
+        if ti_step is None:
+            ti_step = ti_step_current
+
+        # Identify the covered range of wind directions
+        wd_range_min_current = np.min(self.wind_directions) - wd_step_current / 2.0
+        wd_range_max_current = np.max(self.wind_directions) + wd_step_current / 2.0
+
+        # Look for unlikely case where for example wind directions are 8, 28, ... 358
+        if wd_range_max_current > 360:
+            raise ValueError(
+                "Cannot upsample wind rose for case when wind directions are defined"
+                " such that 0 degrees is included by bins to the left of 0 degrees. "
+            )
+
+        # Identify the new minimum wind direction
+        wd_min_new = wd_range_min_current + wd_step / 2.0
+        wd_max_new = wd_range_max_current - wd_step / 2.0
+
+        new_wind_directions = np.arange(wd_min_new, wd_max_new + wd_step / 2.0, wd_step)
+
+        # Set up the new wind speeds
+        ws_range_min_current = np.min(self.wind_speeds) - ws_step_current / 2.0
+        ws_range_max_current = np.max(self.wind_speeds) + ws_step_current / 2.0
+        ws_min_new = ws_range_min_current + ws_step / 2.0
+        ws_max_new = ws_range_max_current - ws_step / 2.0
+
+        # Force the new ws_min to 0 if negative
+        if ws_min_new < 0:
+            ws_min_new = 0.0
+
+        new_wind_speeds = np.arange(ws_min_new, ws_max_new + ws_step / 2.0, ws_step)
+
+        # Set up the new turbulence intensities
+        ti_range_min_current = np.min(self.turbulence_intensities) - ti_step_current / 2.0
+        ti_range_max_current = np.max(self.turbulence_intensities) + ti_step_current / 2.0
+        ti_min_new = ti_range_min_current + ti_step / 2.0
+        ti_max_new = ti_range_max_current - ti_step / 2.0
+
+        # Force the new ti_min to 0 if negative
+        if ti_min_new < 0:
+            ti_min_new = 0.0
+
+        new_turbulence_intensities = np.arange(ti_min_new, ti_max_new + ti_step / 2.0, ti_step)
 
         # Set up for interpolation
         wind_direction_column = self.wind_directions.copy()
@@ -1386,88 +1424,77 @@ class WindTIRose(WindDataBase):
         else:
             value_matrix = None
 
-        # If the first entry of wind_direction column is 0, and the last entry is not 360, then
-        # pad 360 to the end of the wind direction column and the last row of the ti_matrix and
-        # freq_matrix by copying the 0 entry
-        if len(wind_direction_column) > 1:
-            if wind_direction_column[0] == 0 and wind_direction_column[-1] != 360:
-                wind_direction_column = np.append(wind_direction_column, 360)
-                freq_matrix = np.concatenate(
-                    (freq_matrix, freq_matrix[0, :, :][None, :, :]), axis=0
-                )
-                if self.value_table is not None:
-                    value_matrix = np.concatenate((value_matrix, value_matrix[0, :, :][None, :, :]))
+        # Make sure everything sorted by wind direction and wind speed
+        # and turbulence intensities
+        # This should be the case but it's possible user can pass in unsorted data
+        sort_indices_wd = np.argsort(wind_direction_column)
+        wind_direction_column = wind_direction_column[sort_indices_wd]
+        sort_indices_ws = np.argsort(wind_speed_column)
+        wind_speed_column = wind_speed_column[sort_indices_ws]
+        sort_indices_ti = np.argsort(turbulence_intensity_column)
+        turbulence_intensity_column = turbulence_intensity_column[sort_indices_ti]
+        freq_matrix = freq_matrix[sort_indices_wd, :, :]
+        freq_matrix = freq_matrix[:, sort_indices_ws, :]
+        freq_matrix = freq_matrix[:, :, sort_indices_ti]
+        if self.value_table is not None:
+            value_matrix = value_matrix[sort_indices_wd, :, :]
+            value_matrix = value_matrix[:, sort_indices_ws, :]
+            value_matrix = value_matrix[:, :, sort_indices_ti]
 
-        # If the wind_direction columns has length 1, then pad the wind_direction column with
-        # that value + and - 1 and expand the matrices accordingly
-        # (this avoids interpolation errors)
-        if len(wind_direction_column) == 1:
-            wind_direction_column = np.array(
-                [
-                    wind_direction_column[0] - 1,
-                    wind_direction_column[0],
-                    wind_direction_column[0] + 1,
-                ]
+        # Pad out the wind directions and wind speeds to the min and max ranges
+        # Add the min range to the wind direction column
+        wind_direction_column = np.append(wd_range_min_current, wind_direction_column)
+        freq_matrix = np.concatenate((freq_matrix[0, :, :][None, :, :], freq_matrix), axis=0)
+        if self.value_table is not None:
+            value_matrix = np.concatenate((value_matrix[0, :, :][None, :, :], value_matrix), axis=0)
+
+        # Add the max range to the wind direction column
+        wind_direction_column = np.append(wind_direction_column, wd_range_max_current)
+        freq_matrix = np.concatenate((freq_matrix, freq_matrix[-1, :, :][None, :, :]), axis=0)
+        if self.value_table is not None:
+            value_matrix = np.concatenate(
+                (value_matrix, value_matrix[-1, :, :][None, :, :]), axis=0
             )
-            freq_matrix = np.concatenate(
-                (freq_matrix, freq_matrix[0, :, :][None, :, :], freq_matrix[0, :, :][None, :, :]),
-                axis=0,
+
+        # Pad out the wind speeds
+        wind_speed_column = np.append(ws_range_min_current, wind_speed_column)
+        freq_matrix = np.concatenate((freq_matrix[:, 0, :][:, None, :], freq_matrix), axis=1)
+        if self.value_table is not None:
+            value_matrix = np.concatenate((value_matrix[:, 0, :][:, None, :], value_matrix), axis=1)
+
+        wind_speed_column = np.append(wind_speed_column, ws_range_max_current)
+        freq_matrix = np.concatenate((freq_matrix, freq_matrix[:, -1, :][:, None, :]), axis=1)
+        if self.value_table is not None:
+            value_matrix = np.concatenate(
+                (value_matrix, value_matrix[:, -1, :][:, None, :]), axis=1
             )
+
+        # Pad out the turbulence intensities
+        turbulence_intensity_column = np.append(ti_range_min_current, turbulence_intensity_column)
+        freq_matrix = np.concatenate((freq_matrix[:, :, 0][:, :, None], freq_matrix), axis=2)
+        if self.value_table is not None:
+            value_matrix = np.concatenate((value_matrix[:, :, 0][:, :, None], value_matrix), axis=2)
+
+        turbulence_intensity_column = np.append(turbulence_intensity_column, ti_range_max_current)
+        freq_matrix = np.concatenate((freq_matrix, freq_matrix[:, :, -1][:, :, None]), axis=2)
+        if self.value_table is not None:
+            value_matrix = np.concatenate(
+                (value_matrix, value_matrix[:, :, -1][:, :, None]), axis=2
+            )
+
+        # If wd_range_min_current is less than 0, then pad the wind_direction column with
+        # that value + 360 and expand the matrices accordingly (this avoids interpolation errors)
+        if wd_range_min_current < 0:
+            # Pad wind direction column with min_wd + 360
+            wind_direction_column = np.append(
+                wind_direction_column, np.min(self.wind_directions) + 360.0
+            )
+
+            # Pad the remaining with the appropriate value
+            freq_matrix = np.concatenate((freq_matrix, freq_matrix[0, :, :][None, :, :]), axis=0)
             if self.value_table is not None:
                 value_matrix = np.concatenate(
-                    (
-                        value_matrix,
-                        value_matrix[0, :, :][None, :, :],
-                        value_matrix[0, :, :][None, :, :],
-                    ),
-                    axis=0,
-                )
-
-        # If the wind_speed column has length 1, then pad the wind_speed column with
-        # that value + and - 1
-        # and expand the matrices accordingly (this avoids interpolation errors)
-        if len(wind_speed_column) == 1:
-            wind_speed_column = np.array(
-                [wind_speed_column[0] - 1, wind_speed_column[0], wind_speed_column[0] + 1]
-            )
-            freq_matrix = np.concatenate(
-                (freq_matrix, freq_matrix[:, 0, :][:, None, :], freq_matrix[:, 0, :][:, None, :]),
-                axis=1,
-            )
-            if self.value_table is not None:
-                value_matrix = np.concatenate(
-                    (
-                        value_matrix,
-                        value_matrix[:, 0, :][:, None, :],
-                        value_matrix[:, 0, :][:, None, :],
-                    ),
-                    axis=1,
-                )
-
-        # If the turbulence_intensity column has length 1, then
-        # pad the turbulence_intensity column with
-        # that value + and - 1
-        # and expand the matrices accordingly (this avoids interpolation errors)
-        if len(turbulence_intensity_column) == 1:
-            turbulence_intensity_column = np.array(
-                [
-                    turbulence_intensity_column[0] - 1,
-                    turbulence_intensity_column[0],
-                    turbulence_intensity_column[0] + 1,
-                ]
-            )
-            freq_matrix = np.concatenate(
-                (freq_matrix, freq_matrix[:, :, 0][:, :, None], freq_matrix[:, :, 0][:, :, None]),
-                axis=2,
-            )
-            if self.value_table is not None:
-                value_matrix = np.concatenate(
-                    (
-                        value_matrix,
-                        value_matrix[:, :, 0][:, :, None],
-                        value_matrix[:, :, 0][:, :, None],
-                    ),
-                    axis=2,
+                    (value_matrix, value_matrix[0, :, :][None, :, :]), axis=0
                 )
 
         # Grid wind directions and wind speeds to match the ti_matrix and freq_matrix when flattened
@@ -1502,6 +1529,17 @@ class WindTIRose(WindDataBase):
             )
         else:
             new_value_matrix = None
+
+        # Wrap new_wind_directions to 0-360
+        new_wind_directions = new_wind_directions % 360
+
+        # Finally sort new_wind_directions, and re-order new_ti_matrix, new_freq_matrix
+        # and new_value_matrix accordingly
+        sort_indices = np.argsort(new_wind_directions)
+        new_wind_directions = new_wind_directions[sort_indices]
+        new_freq_matrix = new_freq_matrix[sort_indices, :, :]
+        if self.value_table is not None:
+            new_value_matrix = new_value_matrix[sort_indices, :, :]
 
         # Create the resampled wind rose
         resampled_wind_rose = WindTIRose(
@@ -1600,7 +1638,7 @@ class WindTIRose(WindDataBase):
             rects = []
             freq_table_sub = freq_table[wd_idx, :].flatten()
             for var_idx, ws in reversed(list(enumerate(var_bins))):
-                plot_val = freq_table_sub[:var_idx + 1].sum()
+                plot_val = freq_table_sub[: var_idx + 1].sum()
                 rects.append(
                     ax.bar(
                         np.radians(wd),
@@ -1986,7 +2024,7 @@ class TimeSeries(WindDataBase):
         ):
             raise ValueError(
                 "Only one of heterogeneous_inflow_config_by_wd, "
-                +"heterogeneous_map, and heterogeneous_inflow_config can be not None."
+                + "heterogeneous_map, and heterogeneous_inflow_config can be not None."
             )
 
         # if heterogeneous_inflow_config is not None, then the speed_multipliers

--- a/floris/wind_data.py
+++ b/floris/wind_data.py
@@ -145,6 +145,26 @@ class WindRose(WindDataBase):
         if not isinstance(wind_speeds, np.ndarray):
             raise TypeError("wind_speeds must be a NumPy array")
 
+        # Confirm that both wind_directions and wind_speeds are monitonically
+        # increasing and evenly spaced
+        if len(wind_directions) > 1:
+            # Check monotonically increasing
+            if not np.all(np.diff(wind_directions) > 0):
+                raise ValueError("wind_directions must be monotonically increasing")
+
+            # Check evenly spaced
+            if not np.allclose(np.diff(wind_directions), wind_directions[1] - wind_directions[0]):
+                raise ValueError("wind_directions must be evenly spaced")
+
+        if len(wind_speeds) > 1:
+            # Check monotonically increasing
+            if not np.all(np.diff(wind_speeds) > 0):
+                raise ValueError("wind_speeds must be monotonically increasing")
+
+            # Check evenly spaced
+            if not np.allclose(np.diff(wind_speeds), wind_speeds[1] - wind_speeds[0]):
+                raise ValueError("wind_speeds must be evenly spaced")
+
         # Save the wind speeds and directions
         self.wind_directions = wind_directions
         self.wind_speeds = wind_speeds
@@ -469,12 +489,28 @@ class WindRose(WindDataBase):
         if wd_step is None:
             wd_step = wd_step_current
 
+        # Make sure upsampling is appropriate
+        if wd_step > wd_step_current:
+            raise ValueError(
+                f"Provided wd_step ({wd_step}) is larger than the current "
+                f" wind direction step size.  ({wd_step_current} degrees)"
+                " Use the downsample method."
+            )
+
+        if ws_step > ws_step_current:
+            raise ValueError(
+                f"Provided ws_step ({ws_step}) is larger than "
+                f"the current wind speed step size.  ({ws_step_current} m/s)"
+                " Use the downsample method."
+            )
+
         # Identify the covered range of wind directions
         wd_range_min_current = np.min(self.wind_directions) - wd_step_current / 2.0
         wd_range_max_current = np.max(self.wind_directions) + wd_step_current / 2.0
 
         # Look for unlikely case where for example wind directions are 8, 28, ... 358
         if wd_range_max_current > 360:
+            # TODO: Handle this case without an error
             raise ValueError(
                 "Cannot upsample wind rose for case when wind directions are defined"
                 " such that 0 degrees is included by bins to the left of 0 degrees. "
@@ -1040,6 +1076,39 @@ class WindTIRose(WindDataBase):
 
         if not isinstance(turbulence_intensities, np.ndarray):
             raise TypeError("turbulence_intensities must be a NumPy array")
+
+        # Confirm that both wind_directions and wind_speeds
+        # and turbulence intensities are monotonically
+        # increasing and evenly spaced
+        if len(wind_directions) > 1:
+            # Check monotonically increasing
+            if not np.all(np.diff(wind_directions) > 0):
+                raise ValueError("wind_directions must be monotonically increasing")
+
+            # Check evenly spaced
+            if not np.allclose(np.diff(wind_directions), wind_directions[1] - wind_directions[0]):
+                raise ValueError("wind_directions must be evenly spaced")
+
+        if len(wind_speeds) > 1:
+            # Check monotonically increasing
+            if not np.all(np.diff(wind_speeds) > 0):
+                raise ValueError("wind_speeds must be monotonically increasing")
+
+            # Check evenly spaced
+            if not np.allclose(np.diff(wind_speeds), wind_speeds[1] - wind_speeds[0]):
+                raise ValueError("wind_speeds must be evenly spaced")
+
+        if len(turbulence_intensities) > 1:
+            # Check monotonically increasing
+            if not np.all(np.diff(turbulence_intensities) > 0):
+                raise ValueError("turbulence_intensities must be monotonically increasing")
+
+            # Check evenly spaced
+            if not np.allclose(
+                np.diff(turbulence_intensities),
+                turbulence_intensities[1] - turbulence_intensities[0],
+            ):
+                raise ValueError("turbulence_intensities must be evenly spaced")
 
         # Save the wind speeds and directions
         self.wind_directions = wind_directions

--- a/floris/wind_data.py
+++ b/floris/wind_data.py
@@ -558,7 +558,7 @@ class WindRose(WindDataBase):
             value_matrix = value_matrix[sort_indices_wd, :]
             value_matrix = value_matrix[:, sort_indices_ws]
 
-        # Pad out the wind directions and wind speeds to the min and max ranges
+        # Pad out the wind directions to the min and max ranges
         # Add the min range to the wind direction column
         wind_direction_column = np.append(wd_range_min_current, wind_direction_column)
         ti_matrix = ti_matrix = np.vstack((ti_matrix[0, :], ti_matrix))

--- a/floris/wind_data.py
+++ b/floris/wind_data.py
@@ -12,6 +12,11 @@ from scipy.interpolate import LinearNDInterpolator, NearestNDInterpolator
 
 from floris.heterogeneous_map import HeterogeneousMap
 from floris.type_dec import NDArrayFloat
+from floris.utilities import (
+    check_and_identify_step_size,
+    make_wind_directions_adjacent,
+    wrap_180,
+)
 
 
 class WindDataBase:
@@ -91,8 +96,10 @@ class WindRose(WindDataBase):
     wind direction and wind speed.
 
     Args:
-        wind_directions: NumPy array of wind directions (NDArrayFloat).
-        wind_speeds: NumPy array of wind speeds (NDArrayFloat).
+        wind_directions: NumPy array of wind directions (NDArrayFloat).  Must
+            be evenly spaced and monotonically increasing.
+        wind_speeds: NumPy array of wind speeds (NDArrayFloat).  Must be
+            evenly spaced and monotonically increasing.
         ti_table: Turbulence intensity table for binned wind direction, wind
             speed values (float, NDArrayFloat).  Can be an array with dimensions
             (n_wind_directions, n_wind_speeds) or a single float value.  If a
@@ -152,9 +159,8 @@ class WindRose(WindDataBase):
             if not np.all(np.diff(wind_directions) > 0):
                 raise ValueError("wind_directions must be monotonically increasing")
 
-            # Check evenly spaced
-            if not np.allclose(np.diff(wind_directions), wind_directions[1] - wind_directions[0]):
-                raise ValueError("wind_directions must be evenly spaced")
+            # Check evenly spaced (Function will raise error if not)
+            check_and_identify_step_size(wind_directions=wind_directions)
 
         if len(wind_speeds) > 1:
             # Check monotonically increasing
@@ -387,7 +393,7 @@ class WindRose(WindDataBase):
         # If wd_step is passed in, confirm is it at least as large as the current step
         if wd_step is not None:
             if len(self.wind_directions) >= 2:
-                current_wd_step = self.wind_directions[1] - self.wind_directions[0]
+                current_wd_step = check_and_identify_step_size(wind_directions=self.wind_directions)
                 if wd_step < current_wd_step:
                     raise ValueError(
                         "wd_step provided must be at least as large as the current wd_step "
@@ -402,7 +408,7 @@ class WindRose(WindDataBase):
                 ws_step = 1.0
         if wd_step is None:
             if len(self.wind_directions) >= 2:
-                wd_step = self.wind_directions[1] - self.wind_directions[0]
+                wd_step = check_and_identify_step_size(wind_directions=self.wind_directions)
             else:  # wind rose will have only a single wind direction, and we assume a wd_step of 1
                 wd_step = 1.0
 
@@ -479,7 +485,8 @@ class WindRose(WindDataBase):
             ws_step_current = 1.0
 
         if len(self.wind_directions) >= 2:
-            wd_step_current = self.wind_directions[1] - self.wind_directions[0]
+            # Identify the current step size
+            wd_step_current = check_and_identify_step_size(wind_directions=self.wind_directions)
         else:  # wind rose will have only a single wind direction, and we assume a wd_step of 1
             wd_step_current = 1.0
 
@@ -504,9 +511,18 @@ class WindRose(WindDataBase):
                 " Use the downsample method."
             )
 
+        # Get the current wind directions in adjacent from (ie 0, 2 358 -> -2, 0 ,2)
+        if len(self.wind_directions) >= 2:
+            current_wind_directions, adjacent_sort_index = make_wind_directions_adjacent(
+                self.wind_directions
+            )
+        else:
+            current_wind_directions = self.wind_directions
+            adjacent_sort_index = np.arange(len(current_wind_directions))
+
         # Identify the covered range of wind directions
-        wd_range_min_current = np.min(self.wind_directions) - wd_step_current / 2.0
-        wd_range_max_current = np.max(self.wind_directions) + wd_step_current / 2.0
+        wd_range_min_current = np.min(current_wind_directions) - wd_step_current / 2.0
+        wd_range_max_current = np.max(current_wind_directions) + wd_step_current / 2.0
 
         # Look for unlikely case where for example wind directions are 8, 28, ... 358
         if wd_range_max_current > 360:
@@ -534,44 +550,54 @@ class WindRose(WindDataBase):
 
         new_wind_speeds = np.arange(ws_min_new, ws_max_new + ws_step / 2.0, ws_step)
 
-        # Set up for interpolation
-        wind_direction_column = self.wind_directions.copy()
+        # Set up for interpolation by copying the current values
+        # and making sure they are sorted according to the adjacent wind directions
+        wind_direction_column = current_wind_directions.copy()
         wind_speed_column = self.wind_speeds.copy()
-        ti_matrix = self.ti_table.copy()
-        freq_matrix = self.freq_table.copy()
+        ti_matrix = self.ti_table.copy()[adjacent_sort_index, :]
+        freq_matrix = self.freq_table.copy()[adjacent_sort_index, :]
         if self.value_table is not None:
-            value_matrix = self.value_table.copy()
+            value_matrix = self.value_table.copy()[adjacent_sort_index, :]
         else:
             value_matrix = None
 
-        # Make sure everything sorted by wind direction and wind speed
-        # This should be the case but it's possible user can pass in unsorted data
-        sort_indices_wd = np.argsort(wind_direction_column)
-        wind_direction_column = wind_direction_column[sort_indices_wd]
-        sort_indices_ws = np.argsort(wind_speed_column)
-        wind_speed_column = wind_speed_column[sort_indices_ws]
-        ti_matrix = ti_matrix[sort_indices_wd, :]
-        ti_matrix = ti_matrix[:, sort_indices_ws]
-        freq_matrix = freq_matrix[sort_indices_wd, :]
-        freq_matrix = freq_matrix[:, sort_indices_ws]
-        if self.value_table is not None:
-            value_matrix = value_matrix[sort_indices_wd, :]
-            value_matrix = value_matrix[:, sort_indices_ws]
+        # For padding wind directions, there are two cases to consider.  In the first,
+        # say that the wind directions are 30, 40, 50.  In this case it's important append
+        # 30 and 50 to 35 and 55 to ensure the interpolation covers the full range of data
+        # This is the case when wind directions doesn't cover the full range of possible
+        # degrees (0-360)
+        if np.abs((wd_range_min_current % 360.0) - (wd_range_max_current % 360.0)) > 1e-6:
+            wind_direction_column = np.append(wd_range_min_current, wind_direction_column)
+            ti_matrix = ti_matrix = np.vstack((ti_matrix[0, :], ti_matrix))
+            freq_matrix = np.vstack((freq_matrix[0, :], freq_matrix))
+            if self.value_table is not None:
+                value_matrix = np.vstack((value_matrix[0, :], value_matrix))
 
-        # Pad out the wind directions to the min and max ranges
-        # Add the min range to the wind direction column
-        wind_direction_column = np.append(wd_range_min_current, wind_direction_column)
-        ti_matrix = ti_matrix = np.vstack((ti_matrix[0, :], ti_matrix))
-        freq_matrix = np.vstack((freq_matrix[0, :], freq_matrix))
-        if self.value_table is not None:
-            value_matrix = np.vstack((value_matrix[0, :], value_matrix))
+            # Add the max range to the wind direction column
+            wind_direction_column = np.append(wind_direction_column, wd_range_max_current)
+            ti_matrix = np.vstack((ti_matrix, ti_matrix[-1, :]))
+            freq_matrix = np.vstack((freq_matrix, freq_matrix[-1, :]))
+            if self.value_table is not None:
+                value_matrix = np.vstack((value_matrix, value_matrix[-1, :]))
 
-        # Add the max range to the wind direction column
-        wind_direction_column = np.append(wind_direction_column, wd_range_max_current)
-        ti_matrix = np.vstack((ti_matrix, ti_matrix[-1, :]))
-        freq_matrix = np.vstack((freq_matrix, freq_matrix[-1, :]))
-        if self.value_table is not None:
-            value_matrix = np.vstack((value_matrix, value_matrix[-1, :]))
+        # In the alternative case, where the wind directions cover the full range
+        # ie, 0, 10, 20 30, ...350, then need to place 0 at 360 and 350 at -10
+        # to cover all interpolations
+        else:
+            # Pad wind direction column with min_wd + 360
+            wind_direction_column = np.concatenate(
+                (
+                    [np.max(self.wind_directions) - 360.0],
+                    wind_direction_column,
+                    [np.min(self.wind_directions) + 360.0],
+                )
+            )
+
+            # Pad the remaining with the appropriate value
+            ti_matrix = ti_matrix = np.vstack((ti_matrix[-1, :], ti_matrix, ti_matrix[0, :]))
+            freq_matrix = np.vstack((freq_matrix[-1, :], freq_matrix, freq_matrix[0, :]))
+            if self.value_table is not None:
+                value_matrix = np.vstack((value_matrix[-1, :], value_matrix, value_matrix[0, :]))
 
         # Pad out the wind speeds
         wind_speed_column = np.append(ws_range_min_current, wind_speed_column)
@@ -585,20 +611,6 @@ class WindRose(WindDataBase):
         freq_matrix = np.hstack((freq_matrix, freq_matrix[:, -1].reshape((-1, 1))))
         if self.value_table is not None:
             value_matrix = np.hstack((value_matrix, value_matrix[:, -1].reshape((-1, 1))))
-
-        # If wd_range_min_current is less than 0, then pad the wind_direction column with
-        # that value + 360 and expand the matrices accordingly (this avoids interpolation errors)
-        if wd_range_min_current < 0:
-            # Pad wind direction column with min_wd + 360
-            wind_direction_column = np.append(
-                wind_direction_column, np.min(self.wind_directions) + 360.0
-            )
-
-            # Pad the remaining with the appropriate value
-            ti_matrix = ti_matrix = np.vstack((ti_matrix, ti_matrix[0, :]))
-            freq_matrix = np.vstack((freq_matrix, freq_matrix[0, :]))
-            if self.value_table is not None:
-                value_matrix = np.vstack((value_matrix, value_matrix[0, :]))
 
         # Grid wind directions and wind speeds to match the ti_matrix and freq_matrix when flattened
         wd_grid, ws_grid = np.meshgrid(wind_direction_column, wind_speed_column, indexing="ij")
@@ -1085,9 +1097,8 @@ class WindTIRose(WindDataBase):
             if not np.all(np.diff(wind_directions) > 0):
                 raise ValueError("wind_directions must be monotonically increasing")
 
-            # Check evenly spaced
-            if not np.allclose(np.diff(wind_directions), wind_directions[1] - wind_directions[0]):
-                raise ValueError("wind_directions must be evenly spaced")
+            # Check evenly spaced (Function will raise error if not)
+            check_and_identify_step_size(wind_directions=wind_directions)
 
         if len(wind_speeds) > 1:
             # Check monotonically increasing
@@ -1314,7 +1325,7 @@ class WindTIRose(WindDataBase):
         # If wd_step is passed in, confirm is it at least as large as the current step
         if wd_step is not None:
             if len(self.wind_directions) >= 2:
-                current_wd_step = self.wind_directions[1] - self.wind_directions[0]
+                current_wd_step = check_and_identify_step_size(wind_directions=self.wind_directions)
                 if wd_step < current_wd_step:
                     raise ValueError(
                         "wd_step provided must be at least as large as the current wd_step "
@@ -1339,7 +1350,7 @@ class WindTIRose(WindDataBase):
                 ws_step = 1.0
         if wd_step is None:
             if len(self.wind_directions) >= 2:
-                wd_step = self.wind_directions[1] - self.wind_directions[0]
+                wd_step = check_and_identify_step_size(wind_directions=self.wind_directions)
             else:  # wind rose will have only a single wind direction, and we assume a wd_step of 1
                 wd_step = 1.0
         if ti_step is None:
@@ -1424,7 +1435,7 @@ class WindTIRose(WindDataBase):
             ws_step_current = 1.0
 
         if len(self.wind_directions) >= 2:
-            wd_step_current = self.wind_directions[1] - self.wind_directions[0]
+            wd_step_current = check_and_identify_step_size(wind_directions=self.wind_directions)
         else:  # wind rose will have only a single wind direction, and we assume a wd_step of 1
             wd_step_current = 1.0
 
@@ -1442,12 +1453,44 @@ class WindTIRose(WindDataBase):
         if ti_step is None:
             ti_step = ti_step_current
 
+        # Make sure upsampling is appropriate
+        if wd_step > wd_step_current:
+            raise ValueError(
+                f"Provided wd_step ({wd_step}) is larger than the current "
+                f" wind direction step size.  ({wd_step_current} degrees)"
+                " Use the downsample method."
+            )
+
+        if ws_step > ws_step_current:
+            raise ValueError(
+                f"Provided ws_step ({ws_step}) is larger than "
+                f"the current wind speed step size.  ({ws_step_current} m/s)"
+                " Use the downsample method."
+            )
+
+        if ti_step > ti_step_current:
+            raise ValueError(
+                f"Provided ti_step ({ti_step}) is larger than "
+                f"the current turbulence intensity step size.  ({ti_step_current})"
+                " Use the downsample method."
+            )
+
+        # Get the current wind directions in adjacent from (ie 0, 2 358 -> -2, 0 ,2)
+        if len(self.wind_directions) >= 2:
+            current_wind_directions, adjacent_sort_index = make_wind_directions_adjacent(
+                self.wind_directions
+            )
+        else:
+            current_wind_directions = self.wind_directions
+            adjacent_sort_index = np.arange(len(current_wind_directions))
+
         # Identify the covered range of wind directions
-        wd_range_min_current = np.min(self.wind_directions) - wd_step_current / 2.0
-        wd_range_max_current = np.max(self.wind_directions) + wd_step_current / 2.0
+        wd_range_min_current = np.min(current_wind_directions) - wd_step_current / 2.0
+        wd_range_max_current = np.max(current_wind_directions) + wd_step_current / 2.0
 
         # Look for unlikely case where for example wind directions are 8, 28, ... 358
         if wd_range_max_current > 360:
+            # TODO: Handle this case without an error
             raise ValueError(
                 "Cannot upsample wind rose for case when wind directions are defined"
                 " such that 0 degrees is included by bins to the left of 0 degrees. "
@@ -1483,47 +1526,63 @@ class WindTIRose(WindDataBase):
 
         new_turbulence_intensities = np.arange(ti_min_new, ti_max_new + ti_step / 2.0, ti_step)
 
-        # Set up for interpolation
-        wind_direction_column = self.wind_directions.copy()
+        # Set up for interpolation by copying the current values
+        # and making sure they are sorted according to the adjacent wind directions
+        wind_direction_column = current_wind_directions.copy()
         wind_speed_column = self.wind_speeds.copy()
         turbulence_intensity_column = self.turbulence_intensities.copy()
-        freq_matrix = self.freq_table.copy()
+        freq_matrix = self.freq_table.copy()[adjacent_sort_index, :, :]
         if self.value_table is not None:
-            value_matrix = self.value_table.copy()
+            value_matrix = self.value_table.copy()[adjacent_sort_index, :, :]
         else:
             value_matrix = None
 
-        # Make sure everything sorted by wind direction and wind speed
-        # and turbulence intensities
-        # This should be the case but it's possible user can pass in unsorted data
-        sort_indices_wd = np.argsort(wind_direction_column)
-        wind_direction_column = wind_direction_column[sort_indices_wd]
-        sort_indices_ws = np.argsort(wind_speed_column)
-        wind_speed_column = wind_speed_column[sort_indices_ws]
-        sort_indices_ti = np.argsort(turbulence_intensity_column)
-        turbulence_intensity_column = turbulence_intensity_column[sort_indices_ti]
-        freq_matrix = freq_matrix[sort_indices_wd, :, :]
-        freq_matrix = freq_matrix[:, sort_indices_ws, :]
-        freq_matrix = freq_matrix[:, :, sort_indices_ti]
-        if self.value_table is not None:
-            value_matrix = value_matrix[sort_indices_wd, :, :]
-            value_matrix = value_matrix[:, sort_indices_ws, :]
-            value_matrix = value_matrix[:, :, sort_indices_ti]
+        # For padding wind directions, there are two cases to consider.  In the first,
+        # say that the wind directions are 30, 40, 50.  In this case it's important append
+        # 30 and 50 to 35 and 55 to ensure the interpolation covers the full range of data
+        # This is the case when wind directions doesn't cover the full range of possible
+        # degrees (0-360)
+        if np.abs((wd_range_min_current % 360.0) - (wd_range_max_current % 360.0)) > 1e-6:
+            wind_direction_column = np.append(wd_range_min_current, wind_direction_column)
+            freq_matrix = np.concatenate((freq_matrix[0, :, :][None, :, :], freq_matrix), axis=0)
+            if self.value_table is not None:
+                value_matrix = np.concatenate(
+                    (value_matrix[0, :, :][None, :, :], value_matrix), axis=0
+                )
 
-        # Pad out the wind directions and wind speeds to the min and max ranges
-        # Add the min range to the wind direction column
-        wind_direction_column = np.append(wd_range_min_current, wind_direction_column)
-        freq_matrix = np.concatenate((freq_matrix[0, :, :][None, :, :], freq_matrix), axis=0)
-        if self.value_table is not None:
-            value_matrix = np.concatenate((value_matrix[0, :, :][None, :, :], value_matrix), axis=0)
+            # Add the max range to the wind direction column
+            wind_direction_column = np.append(wind_direction_column, wd_range_max_current)
+            freq_matrix = np.concatenate((freq_matrix, freq_matrix[-1, :, :][None, :, :]), axis=0)
+            if self.value_table is not None:
+                value_matrix = np.concatenate(
+                    (value_matrix, value_matrix[-1, :, :][None, :, :]), axis=0
+                )
 
-        # Add the max range to the wind direction column
-        wind_direction_column = np.append(wind_direction_column, wd_range_max_current)
-        freq_matrix = np.concatenate((freq_matrix, freq_matrix[-1, :, :][None, :, :]), axis=0)
-        if self.value_table is not None:
-            value_matrix = np.concatenate(
-                (value_matrix, value_matrix[-1, :, :][None, :, :]), axis=0
+        # In the alternative case, where the wind directions cover the full range
+        # ie, 0, 10, 20 30, ...350, then need to place 0 at 360 and 350 at -10
+        # to cover all interpolations
+        else:
+            # Pad wind direction column with min_wd + 360
+            wind_direction_column = np.concatenate(
+                (
+                    [np.max(self.wind_directions) - 360.0],
+                    wind_direction_column,
+                    [np.min(self.wind_directions) + 360.0],
+                )
             )
+
+            # Pad the remaining with the appropriate value
+            freq_matrix = np.vstack(
+                (freq_matrix[-1, :, :][None, :, :], freq_matrix, freq_matrix[0, :, :][None, :, :])
+            )
+            if self.value_table is not None:
+                value_matrix = np.vstack(
+                    (
+                        value_matrix[-1, :, :][None, :, :],
+                        value_matrix,
+                        value_matrix[0, :, :][None, :, :],
+                    )
+                )
 
         # Pad out the wind speeds
         wind_speed_column = np.append(ws_range_min_current, wind_speed_column)

--- a/tests/reg_tests/random_search_layout_opt_regression_test.py
+++ b/tests/reg_tests/random_search_layout_opt_regression_test.py
@@ -45,7 +45,7 @@ def test_random_search_layout_opt(sample_inputs_fixture):
 
     fmodel = FlorisModel(sample_inputs_fixture.core)
     wd_array = np.arange(0, 360.0, 5.0)
-    ws_array = 8.0 * np.ones_like(wd_array)
+    ws_array = np.array([8.0])
 
     wind_rose = WindRose(
         wind_directions=wd_array,

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -96,8 +96,10 @@ def test_make_wind_directions_adjacent():
         wind_directions = np.array(test_cond[0])
         expected_wind_directions = np.array(test_cond[1])
 
-        wind_directions_adjacent = make_wind_directions_adjacent(wind_directions)
+        wind_directions_adjacent, sort_indices = make_wind_directions_adjacent(wind_directions)
         np.testing.assert_array_equal(wind_directions_adjacent, expected_wind_directions)
+        np.testing.assert_array_equal(wind_directions[sort_indices]%360.0,
+                                      wind_directions_adjacent%360.0)
 
 def test_check_and_identify_step_size():
     # First set up a matrix of input directions, upsampling steps and expected ouputs

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from floris.utilities import (
     cosd,
+    identify_step_size,
     nested_get,
     nested_set,
     reverse_rotate_coordinates_rel_west,
@@ -76,6 +77,45 @@ def test_wind_delta():
     assert wind_delta(180.0) == 270.0
     assert wind_delta(-10.0) == 80.0
     assert wind_delta(-100.0) == 350.0
+
+
+def test_identify_step_size():
+    # First set up a matrix of input directions, upsampling steps and expected ouputs
+    test_conditions = [
+        [[270.0, 280.0], 10.0],
+        [[0.0, 4.0], 4.0],
+        [[0.0, 358.0], 2.0],
+        [[0, 358], 2],
+        [[10, 20, 30], 10],
+        [[0, 10, 350], 10],
+        [[0,1,359],1.0],
+        [[0,356,358],2.0],
+        [[4, 8, 12, 16], 4],
+        [[0, 90, 180, 270], 90],
+        [[0, 5, 10,355], 5],
+        [np.arange(0,360,1), 1],
+        [sorted(np.arange(330,390,1)%360), 1],
+    ]
+
+    for test_cond in test_conditions:
+        wind_directions = np.array(test_cond[0])
+        expected_step = test_cond[1]
+
+        step_size = identify_step_size(wind_directions)
+        assert step_size == expected_step
+
+
+def test_identify_step_size_value_error():
+    # First set up a matrix of input directions, upsampling steps and expected ouputs
+    test_conditions = [
+        [1,3,7], # Inconsistent step size
+        [4, 3, 2], # Decreasing
+        [5, 10, 15, 45], #Inconsistent step not connected to a wrapping
+    ]
+
+    for wind_directions in test_conditions:
+        with pytest.raises(ValueError):
+            identify_step_size(wind_directions)
 
 
 def test_rotate_coordinates_rel_west():

--- a/tests/utilities_unit_test.py
+++ b/tests/utilities_unit_test.py
@@ -6,8 +6,9 @@ import numpy as np
 import pytest
 
 from floris.utilities import (
+    check_and_identify_step_size,
     cosd,
-    identify_step_size,
+    make_wind_directions_adjacent,
     nested_get,
     nested_set,
     reverse_rotate_coordinates_rel_west,
@@ -78,8 +79,27 @@ def test_wind_delta():
     assert wind_delta(-10.0) == 80.0
     assert wind_delta(-100.0) == 350.0
 
+def test_make_wind_directions_adjacent():
 
-def test_identify_step_size():
+    test_conditions = [
+        [[0.0, 10.0], [0.0, 10.0]],
+        [[0.0, 350.], [-10., 0.]],
+        [[20.0, 25., 30.], [20.0, 25., 30.]],
+        [[0.0, 350., 355., ], [-10., -5, 0]],
+        [[0 ,2, 358], [-2, 0, 2]],
+        [[0, 1, 359], [-1, 0, 1]],
+        [np.arange(0,360,1), np.arange(0,360,1)],
+        [sorted(np.arange(330,390,1)%360),np.arange(-30,30,1) ],
+    ]
+
+    for test_cond in test_conditions:
+        wind_directions = np.array(test_cond[0])
+        expected_wind_directions = np.array(test_cond[1])
+
+        wind_directions_adjacent = make_wind_directions_adjacent(wind_directions)
+        np.testing.assert_array_equal(wind_directions_adjacent, expected_wind_directions)
+
+def test_check_and_identify_step_size():
     # First set up a matrix of input directions, upsampling steps and expected ouputs
     test_conditions = [
         [[270.0, 280.0], 10.0],
@@ -101,11 +121,11 @@ def test_identify_step_size():
         wind_directions = np.array(test_cond[0])
         expected_step = test_cond[1]
 
-        step_size = identify_step_size(wind_directions)
+        step_size = check_and_identify_step_size(wind_directions)
         assert step_size == expected_step
 
 
-def test_identify_step_size_value_error():
+def test_check_and_identify_step_size_value_error():
     # First set up a matrix of input directions, upsampling steps and expected ouputs
     test_conditions = [
         [1,3,7], # Inconsistent step size
@@ -115,7 +135,7 @@ def test_identify_step_size_value_error():
 
     for wind_directions in test_conditions:
         with pytest.raises(ValueError):
-            identify_step_size(wind_directions)
+            check_and_identify_step_size(wind_directions)
 
 
 def test_rotate_coordinates_rel_west():

--- a/tests/wind_data_integration_test.py
+++ b/tests/wind_data_integration_test.py
@@ -247,52 +247,48 @@ def test_upsample():
     ti_table = np.array([[0.06, 0.06], [0.07, 0.07]])
     wind_rose = WindRose(wind_directions, wind_speeds, ti_table=ti_table)
 
-    wind_rose_resample = wind_rose.upsample(
-        wd_step=5.0, ws_step=1.0, inplace=False
-    )
+    wind_rose_resample = wind_rose.upsample(wd_step=5.0, ws_step=1.0, inplace=False)
 
     # Check that the resample ti_table is correct
-    np.testing.assert_allclose(wind_rose_resample.wind_directions, [270, 275, 280])
+    np.testing.assert_allclose(wind_rose_resample.wind_directions, [267.5, 272.5, 277.5, 282.5])
     np.testing.assert_allclose(wind_rose_resample.wind_speeds, [6, 7])
     np.testing.assert_allclose(
-        wind_rose_resample.ti_table, np.array([[0.06, 0.06], [0.065, 0.065], [0.07, 0.07]])
+        wind_rose_resample.ti_table,
+        np.array([[0.06, 0.06], [0.0625, 0.0625], [0.0675, 0.0675], [0.07, 0.07]]),
     )
 
     # Test interpolating frequency along the wind speed axis
     freq_table = np.array([[1 / 6, 2 / 6], [1 / 6, 2 / 6]])
     wind_rose = WindRose(wind_directions, wind_speeds, ti_table=0.06, freq_table=freq_table)
 
-    wind_rose_resample = wind_rose.upsample(
-        wd_step=10.0, ws_step=0.5, inplace=False
-    )
+    wind_rose_resample = wind_rose.upsample(wd_step=10.0, ws_step=0.5, inplace=False)
 
-    freq_table_expected = np.array([[1 / 6, 1.5 / 6, 2 / 6], [1 / 6, 1.5 / 6, 2 / 6]])
+    freq_table_expected = np.array(
+        [[1 / 6, 1.25 / 6, 1.75 / 6, 2 / 6], [1 / 6, 1.25 / 6, 1.75 / 6, 2 / 6]]
+    )
     freq_table_expected = freq_table_expected / np.sum(freq_table_expected)
 
     # Check that the resample freq_table is correct
     np.testing.assert_allclose(wind_rose_resample.wind_directions, [270, 280])
-    np.testing.assert_allclose(wind_rose_resample.wind_speeds, [6, 6.5, 7])
+    np.testing.assert_allclose(wind_rose_resample.wind_speeds, [5.75, 6.25, 6.75, 7.25])
     np.testing.assert_allclose(wind_rose_resample.freq_table, freq_table_expected)
 
     # Test resampling both wind speed and wind directions
     ti_table = np.array([[0.01, 0.02], [0.03, 0.04]])
     wind_rose = WindRose(wind_directions, wind_speeds, ti_table=ti_table)
-    wind_rose_resample = wind_rose.upsample(
-        wd_step=5.0, ws_step=0.5, inplace=False
-    )
+    wind_rose_resample = wind_rose.upsample(wd_step=5.0, ws_step=0.5, inplace=False)
 
     # Check that the resample ti_table is correct
-    ti_table_expected = np.array([[0.01, 0.015, 0.02], [0.02, 0.025, 0.03], [0.03, 0.035, 0.04]])
-    np.testing.assert_allclose(wind_rose_resample.wind_directions, [270, 275, 280])
-    np.testing.assert_allclose(wind_rose_resample.wind_speeds, [6, 6.5, 7])
-    np.testing.assert_allclose(wind_rose_resample.ti_table, ti_table_expected)
+    np.testing.assert_allclose(wind_rose_resample.wind_directions, [267.5, 272.5, 277.5, 282.5])
+    np.testing.assert_allclose(wind_rose_resample.wind_speeds, [5.75, 6.25, 6.75, 7.25])
 
     # Test the using the old function name returns the same result
     wind_rose_resample_old = wind_rose.resample_by_interpolation(
         wd_step=5.0, ws_step=0.5, inplace=False
     )
-    np.testing.assert_allclose(wind_rose_resample.wind_directions,
-                               wind_rose_resample_old.wind_directions)
+    np.testing.assert_allclose(
+        wind_rose_resample.wind_directions, wind_rose_resample_old.wind_directions
+    )
     np.testing.assert_allclose(wind_rose_resample.wind_speeds, wind_rose_resample_old.wind_speeds)
     np.testing.assert_allclose(wind_rose_resample.ti_table, wind_rose_resample_old.ti_table)
     np.testing.assert_allclose(wind_rose_resample.freq_table, wind_rose_resample_old.freq_table)
@@ -305,9 +301,11 @@ def test_upsample():
     wind_rose_resample = wind_rose.upsample(wd_step=5.0, inplace=False)
 
     # Check that the resample ti_table is correct
-    np.testing.assert_allclose(wind_rose_resample.wind_directions, [270, 275, 280])
+    np.testing.assert_allclose(wind_rose_resample.wind_directions, [267.5, 272.5, 277.5, 282.5])
     np.testing.assert_allclose(wind_rose_resample.wind_speeds, [6])
-    np.testing.assert_allclose(wind_rose_resample.ti_table, np.array([[0.06], [0.065], [0.07]]))
+    np.testing.assert_allclose(
+        wind_rose_resample.ti_table, np.array([[0.06], [0.0625], [0.0675], [0.07]])
+    )
 
     # Test resampling wind speeds when wind directions is 1D
     wind_directions = np.array([270])
@@ -318,8 +316,42 @@ def test_upsample():
 
     # Check that the resample ti_table is correct
     np.testing.assert_allclose(wind_rose_resample.wind_directions, [270])
-    np.testing.assert_allclose(wind_rose_resample.wind_speeds, [6, 6.5, 7])
-    np.testing.assert_allclose(wind_rose_resample.ti_table, np.array([[0.06, 0.065, 0.07]]))
+    np.testing.assert_allclose(wind_rose_resample.wind_speeds, [5.75, 6.25, 6.75, 7.25])
+    np.testing.assert_allclose(
+        wind_rose_resample.ti_table, np.array([[0.06, 0.0625, 0.0675, 0.07]])
+    )
+
+
+def test_upsample_wrap_wd():
+    wind_directions = np.arange(0, 360, 2.0)
+    wind_speeds = np.array([8.0])
+    freq_table = np.ones((len(wind_directions), len(wind_speeds)))
+    freq_table = freq_table / np.sum(freq_table)
+
+    wind_rose = WindRose(wind_directions, wind_speeds, ti_table=0.06, freq_table=freq_table)
+
+    wind_rose_resample = wind_rose.upsample(inplace=False, wd_step=1.0)
+
+    np.testing.assert_allclose(wind_rose_resample.wind_directions, np.arange(0.5, 360, 1.0))
+
+    # Test that the frequency table is the uniform
+    np.testing.assert_allclose(wind_rose_resample.freq_table, np.ones((360, 1)) / 360)
+
+
+def test_upsample_ws():
+    wind_directions = np.array([270.0])
+    wind_speeds = np.arange(0, 26, 2.0)
+    freq_table = np.ones((len(wind_directions), len(wind_speeds)))
+    freq_table = freq_table / np.sum(freq_table)
+
+    wind_rose = WindRose(wind_directions, wind_speeds, ti_table=0.06, freq_table=freq_table)
+
+    wind_rose_resample = wind_rose.upsample(inplace=False, ws_step=1.0)
+
+    np.testing.assert_allclose(wind_rose_resample.wind_speeds, np.arange(0.0, 25, 1.0))
+
+    # Test that the frequency table is the uniform
+    np.testing.assert_allclose(wind_rose_resample.freq_table, np.ones((1, 25)) / 25)
 
 
 def test_upsample_ti_rose():

--- a/tests/wind_data_integration_test.py
+++ b/tests/wind_data_integration_test.py
@@ -69,6 +69,18 @@ def test_wind_rose_init():
     The wind directions and wind speeds can have any length, but the frequency
     array must have shape (n wind directions, n wind speeds)
     """
+
+    # Test that passing in unevenly spaced wind directions or wind speeds raises an error
+    with pytest.raises(ValueError):
+        WindRose(np.array([270, 280, 290, 310]), np.array([6, 7]), 0.06)
+
+    with pytest.raises(ValueError):
+        WindRose(np.array([270, 280, 290]), np.array([6, 7, 10]), 0.06)
+
+    # Test that passing in decreasing wind directions raises an error
+    with pytest.raises(ValueError):
+        WindRose(np.array([290, 280, 270]), np.array([6, 7]), 0.06)
+
     wind_directions = np.array([270, 280, 290])
     wind_speeds = np.array([6, 7])
 

--- a/tests/wind_data_integration_test.py
+++ b/tests/wind_data_integration_test.py
@@ -222,19 +222,19 @@ def test_wind_rose_downsample():
     # Test that aggregate function returns identical result to downsample function
     wind_rose_aggregate = wind_rose.aggregate(wd_step=5.0, inplace=False)
     wind_rose_downsample = wind_rose.downsample(wd_step=5.0, inplace=False)
-    np.testing.assert_allclose(wind_rose_aggregate.freq_table_flat,
-                               wind_rose_downsample.freq_table_flat)
+    np.testing.assert_allclose(
+        wind_rose_aggregate.freq_table_flat, wind_rose_downsample.freq_table_flat
+    )
 
 
 def test_wind_rose_upsample_directions():
-
     # Test wind direction upsampling under a range of conditions
 
     # First set up a matrix of input directions, upsampling steps and expected ouputs
     test_conditions = [
         [[270.0, 280.0], 5.0, [267.5, 272.5, 277.5, 282.5]],
-        [[10,12,14.0], 1.0, [9.5, 10.5, 11.5, 12.5, 13.5, 14.5]],
-        [[0.0, 90.0, 180.0, 270.0], 1.0, np.arange(0.5,360,1.0)]
+        [[10, 12, 14.0], 1.0, [9.5, 10.5, 11.5, 12.5, 13.5, 14.5]],
+        [[0.0, 90.0, 180.0, 270.0], 1.0, np.arange(0.5, 360, 1.0)],
     ]
 
     for test_cond in test_conditions:
@@ -270,14 +270,14 @@ def test_wind_rose_upsample_directions():
         np.testing.assert_allclose(wind_rose_resample.wind_speeds, wind_speeds)
         np.testing.assert_allclose(wind_rose_resample.freq_table, expected_freq_table)
 
-def test_wind_rose_upsample_speeds():
 
+def test_wind_rose_upsample_speeds():
     # Test wind speed upsampling under a range of conditions
 
     # First set up a matrix of input directions, upsampling steps and expected ouputs
     test_conditions = [
-        [[5,10.0], 1.0, [3., 4., 5.,6., 7., 8., 9., 10., 11.,12.]],
-        [np.arange(0,25,2.0), 1.0, np.arange(0,25,1.0)]
+        [[5, 10.0], 1.0, [3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0]],
+        [np.arange(0, 25, 2.0), 1.0, np.arange(0, 25, 1.0)],
     ]
 
     for test_cond in test_conditions:
@@ -313,8 +313,8 @@ def test_wind_rose_upsample_speeds():
         np.testing.assert_allclose(wind_rose_resample.wind_speeds, expected_speeds)
         np.testing.assert_allclose(wind_rose_resample.freq_table, expected_freq_table)
 
-def test_upsample():
 
+def test_wind_rose_upsample():
     # Test that interpolating without specifying new steps returns the same wind rose
     wind_directions = np.array([0, 2, 4, 6, 8, 10])
     wind_speeds = np.array([8, 10])
@@ -381,6 +381,135 @@ def test_upsample():
     np.testing.assert_allclose(wind_rose_resample.freq_table, wind_rose_resample_old.freq_table)
 
 
+def test_wind_ti_rose_upsample_directions():
+    # Test wind direction upsampling under a range of conditions
+
+    # First set up a matrix of input directions, upsampling steps and expected ouputs
+    test_conditions = [
+        [[270.0, 280.0], 5.0, [267.5, 272.5, 277.5, 282.5]],
+        [[10, 12, 14.0], 1.0, [9.5, 10.5, 11.5, 12.5, 13.5, 14.5]],
+        [[0.0, 90.0, 180.0, 270.0], 1.0, np.arange(0.5, 360, 1.0)],
+    ]
+
+    for test_cond in test_conditions:
+        wind_directions = np.array(test_cond[0])
+        wd_step = test_cond[1]
+        expected_directions = np.array(test_cond[2])
+
+        # Single wind speed / ti case
+        wind_speeds = np.array([8.0])
+        turbulence_intensities = np.array([0.06])
+        freq_table = np.ones((len(wind_directions), len(wind_speeds), len(turbulence_intensities)))
+        freq_table = freq_table / np.sum(freq_table)
+        expected_freq_table = np.ones(
+            (len(expected_directions), len(wind_speeds), len(turbulence_intensities))
+        )
+        expected_freq_table = expected_freq_table / np.sum(expected_freq_table)
+
+        wind_ti_rose = WindTIRose(
+            wind_directions,
+            wind_speeds,
+            turbulence_intensities=turbulence_intensities,
+            freq_table=freq_table,
+        )
+        wind_ti_rose_resample = wind_ti_rose.upsample(wd_step=wd_step)
+
+        np.testing.assert_allclose(wind_ti_rose_resample.wind_directions, expected_directions)
+        np.testing.assert_allclose(wind_ti_rose_resample.wind_speeds, wind_speeds)
+        np.testing.assert_allclose(
+            wind_ti_rose_resample.turbulence_intensities, turbulence_intensities
+        )
+        np.testing.assert_allclose(wind_ti_rose_resample.freq_table, expected_freq_table)
+
+        # Multiple wind speed / ti case
+        wind_speeds = np.array([8.0, 10.0])
+        turbulence_intensities = np.array([0.06, 0.07])
+        freq_table = np.ones((len(wind_directions), len(wind_speeds), len(turbulence_intensities)))
+        freq_table = freq_table / np.sum(freq_table)
+        expected_freq_table = np.ones(
+            (len(expected_directions), len(wind_speeds), len(turbulence_intensities))
+        )
+        expected_freq_table = expected_freq_table / np.sum(expected_freq_table)
+
+        wind_ti_rose = WindTIRose(
+            wind_directions,
+            wind_speeds,
+            turbulence_intensities=turbulence_intensities,
+            freq_table=freq_table,
+        )
+        wind_ti_rose_resample = wind_ti_rose.upsample(wd_step=wd_step)
+
+        np.testing.assert_allclose(wind_ti_rose_resample.wind_directions, expected_directions)
+        np.testing.assert_allclose(wind_ti_rose_resample.wind_speeds, wind_speeds)
+        np.testing.assert_allclose(
+            wind_ti_rose_resample.turbulence_intensities, turbulence_intensities
+        )
+        np.testing.assert_allclose(wind_ti_rose_resample.freq_table, expected_freq_table)
+
+
+def test_wind_ti_rose_upsample_speeds():
+    # Test wind speed upsampling under a range of conditions
+
+    # First set up a matrix of input directions, upsampling steps and expected ouputs
+    test_conditions = [
+        [[5, 10.0], 1.0, [3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0]],
+        [np.arange(0, 25, 2.0), 1.0, np.arange(0, 25, 1.0)],
+    ]
+
+    for test_cond in test_conditions:
+        wind_speeds = np.array(test_cond[0])
+        ws_step = test_cond[1]
+        expected_speeds = np.array(test_cond[2])
+
+        # Single wind direction / ti case
+        wind_directions = np.array([270.0])
+        turbulence_intensities = np.array([0.06])
+        freq_table = np.ones((len(wind_directions), len(wind_speeds), len(turbulence_intensities)))
+        freq_table = freq_table / np.sum(freq_table)
+        expected_freq_table = np.ones(
+            (len(wind_directions), len(expected_speeds), len(turbulence_intensities))
+        )
+        expected_freq_table = expected_freq_table / np.sum(expected_freq_table)
+
+        wind_ti_rose = WindTIRose(
+            wind_directions,
+            wind_speeds,
+            turbulence_intensities=turbulence_intensities,
+            freq_table=freq_table,
+        )
+        wind_ti_rose_resample = wind_ti_rose.upsample(ws_step=ws_step)
+
+        np.testing.assert_allclose(wind_ti_rose_resample.wind_directions, wind_directions)
+        np.testing.assert_allclose(wind_ti_rose_resample.wind_speeds, expected_speeds)
+        np.testing.assert_allclose(
+            wind_ti_rose_resample.turbulence_intensities, turbulence_intensities
+        )
+        np.testing.assert_allclose(wind_ti_rose_resample.freq_table, expected_freq_table)
+
+        # Multiple wind direction / ti case
+        wind_directions = np.array([270.0, 280.0])
+        turbulence_intensities = np.array([0.06, 0.07])
+        freq_table = np.ones((len(wind_directions), len(wind_speeds), len(turbulence_intensities)))
+        freq_table = freq_table / np.sum(freq_table)
+        expected_freq_table = np.ones(
+            (len(wind_directions), len(expected_speeds), len(turbulence_intensities))
+        )
+        expected_freq_table = expected_freq_table / np.sum(expected_freq_table)
+        wind_ti_rose = WindTIRose(
+            wind_directions,
+            wind_speeds,
+            turbulence_intensities=turbulence_intensities,
+            freq_table=freq_table,
+        )
+        wind_ti_rose_resample = wind_ti_rose.upsample(ws_step=ws_step)
+
+        np.testing.assert_allclose(wind_ti_rose_resample.wind_directions, wind_directions)
+        np.testing.assert_allclose(wind_ti_rose_resample.wind_speeds, expected_speeds)
+        np.testing.assert_allclose(
+            wind_ti_rose_resample.turbulence_intensities, turbulence_intensities
+        )
+        np.testing.assert_allclose(wind_ti_rose_resample.freq_table, expected_freq_table)
+
 
 def test_upsample_ti_rose():
     wind_directions = np.array([0, 2, 4, 6, 8, 10])
@@ -405,7 +534,7 @@ def test_upsample_ti_rose():
 
     # Test interpolating frequency along the wind speed axis
     wind_directions = np.array([270, 280])
-    wind_speeds = np.array([6, 7])
+    wind_speeds = np.array([6, 8])
     turbulence_intensities = np.array([0.05, 0.1])
     freq_table = np.ones((2, 2, 2))
     freq_table[:, 1, :] = 2.0
@@ -415,42 +544,21 @@ def test_upsample_ti_rose():
     )
 
     wind_ti_rose_resample = wind_ti_rose.upsample(
-        wd_step=10.0, ws_step=0.5, ti_step=0.05, inplace=False
+        wd_step=10.0, ws_step=1.0, ti_step=0.05, inplace=False
     )
 
-    freq_table_expected = np.ones((2, 3, 2))
-    freq_table_expected[:, 2, :] = 2.0
-    freq_table_expected[:, 1, :] = 1.5
+    freq_table_expected = np.ones((2, 4, 2))
+    freq_table_expected[:, 0, :] = 1.0
+    freq_table_expected[:, 1, :] = 1.25
+    freq_table_expected[:, 2, :] = 1.75
+    freq_table_expected[:, 3, :] = 2.0
     freq_table_expected = freq_table_expected / np.sum(freq_table_expected)
 
     # Check that the resample freq_table is correct
     np.testing.assert_allclose(wind_ti_rose_resample.wind_directions, [270, 280])
-    np.testing.assert_allclose(wind_ti_rose_resample.wind_speeds, [6, 6.5, 7])
+    np.testing.assert_allclose(wind_ti_rose_resample.wind_speeds, [5.5, 6.5, 7.5, 8.5])
     np.testing.assert_allclose(wind_ti_rose_resample.turbulence_intensities, [0.05, 0.1])
     np.testing.assert_allclose(wind_ti_rose_resample.freq_table, freq_table_expected)
-
-    # # Test resampling wind directions when wind speeds and TI are 1D
-    wind_directions = np.array([270, 280])
-    wind_speeds = np.array([6])
-    turbulence_intensities = np.array([0.05])
-    freq_table = np.ones((2, 1, 1))
-    freq_table[1, :, :] = 2.0
-    freq_table = freq_table / np.sum(freq_table)
-    wind_ti_rose = WindTIRose(
-        wind_directions, wind_speeds, turbulence_intensities, freq_table=freq_table
-    )
-    wind_ti_rose_resample = wind_ti_rose.upsample(wd_step=5.0, inplace=False)
-
-    excepted_freq_table = np.ones((3, 1, 1))
-    excepted_freq_table[1, :, :] = 1.5
-    excepted_freq_table[2, :, :] = 2.0
-    excepted_freq_table = excepted_freq_table / np.sum(excepted_freq_table)
-
-    # Check that the resample ti_table is correct
-    np.testing.assert_allclose(wind_ti_rose_resample.wind_directions, [270, 275, 280])
-    np.testing.assert_allclose(wind_ti_rose_resample.wind_speeds, [6])
-    np.testing.assert_allclose(wind_ti_rose_resample.turbulence_intensities, [0.05])
-    np.testing.assert_allclose(wind_ti_rose_resample.freq_table, excepted_freq_table)
 
 
 def test_wrap_wind_directions_near_360():
@@ -739,7 +847,6 @@ def test_time_series_to_WindTIRose():
     np.testing.assert_almost_equal(freq_table[0, 1, :], [0, 0])
 
 
-
 def test_gen_heterogeneous_inflow_config():
     wind_directions = np.array([259.8, 260.2, 260.3, 260.1, 270.0])
     wind_speeds = 8.0
@@ -769,9 +876,7 @@ def test_gen_heterogeneous_inflow_config():
 
     expected_result = np.array([[1.0, 1.0], [1.0, 1.0], [1.0, 1.0], [1.0, 1.0], [1.1, 1.2]])
     np.testing.assert_allclose(heterogeneous_inflow_config["speed_multipliers"], expected_result)
-    np.testing.assert_allclose(
-        heterogeneous_inflow_config["x"], heterogeneous_inflow_config["x"]
-    )
+    np.testing.assert_allclose(heterogeneous_inflow_config["x"], heterogeneous_inflow_config["x"])
 
 
 def test_heterogeneous_inflow_config_by_wd():
@@ -822,14 +927,7 @@ def test_heterogeneous_inflow_config_by_wd():
 
 def test_gen_heterogeneous_inflow_config_with_wind_directions_and_wind_speeds():
     heterogeneous_map_config = {
-        "speed_multipliers": np.array(
-            [
-                [0.9, 0.9],
-                [1.0, 1.0],
-                [1.1, 1.2],
-                [1.2, 1.3]
-            ]
-        ),
+        "speed_multipliers": np.array([[0.9, 0.9], [1.0, 1.0], [1.1, 1.2], [1.2, 1.3]]),
         "wind_directions": np.array([250, 260, 250, 260]),
         "wind_speeds": np.array([5, 5, 10, 10]),
         "x": np.array([0, 1000]),
@@ -837,27 +935,21 @@ def test_gen_heterogeneous_inflow_config_with_wind_directions_and_wind_speeds():
     }
 
     time_series = TimeSeries(
-        wind_directions = np.array([259.8, 260.2, 260.3, 260.1, 200.0]),
-        wind_speeds = np.array([4, 9, 4, 9, 4]),
+        wind_directions=np.array([259.8, 260.2, 260.3, 260.1, 200.0]),
+        wind_speeds=np.array([4, 9, 4, 9, 4]),
         turbulence_intensities=0.06,
         heterogeneous_map=heterogeneous_map_config,
     )
 
     (_, _, _, _, _, heterogeneous_inflow_config) = time_series.unpack()
 
-    expected_result = np.array([[1.0, 1.0],[1.2, 1.3],[1.0, 1.0],[1.2, 1.3],[0.9, 0.9]])
+    expected_result = np.array([[1.0, 1.0], [1.2, 1.3], [1.0, 1.0], [1.2, 1.3], [0.9, 0.9]])
     np.testing.assert_allclose(heterogeneous_inflow_config["speed_multipliers"], expected_result)
+
 
 def test_gen_heterogeneous_inflow_config_with_wind_directions_and_wind_speeds_wind_rose():
     heterogeneous_map_config = {
-        "speed_multipliers": np.array(
-            [
-                [0.9, 0.9],
-                [1.0, 1.0],
-                [1.1, 1.2],
-                [1.2, 1.3]
-            ]
-        ),
+        "speed_multipliers": np.array([[0.9, 0.9], [1.0, 1.0], [1.1, 1.2], [1.2, 1.3]]),
         "wind_directions": np.array([250, 260, 250, 260]),
         "wind_speeds": np.array([5, 5, 10, 10]),
         "x": np.array([0, 1000]),
@@ -865,8 +957,8 @@ def test_gen_heterogeneous_inflow_config_with_wind_directions_and_wind_speeds_wi
     }
 
     wind_rose = WindRose(
-        wind_directions = np.array([250.0, 260.]),
-        wind_speeds = np.array([9.0]),
+        wind_directions=np.array([250.0, 260.0]),
+        wind_speeds=np.array([9.0]),
         ti_table=0.06,
         heterogeneous_map=heterogeneous_map_config,
     )
@@ -875,6 +967,7 @@ def test_gen_heterogeneous_inflow_config_with_wind_directions_and_wind_speeds_wi
 
     expected_result = np.array([[1.1, 1.2], [1.2, 1.3]])
     np.testing.assert_allclose(heterogeneous_inflow_config["speed_multipliers"], expected_result)
+
 
 def test_read_csv_long():
     # Read in the wind rose data from the csv file

--- a/tests/wind_data_integration_test.py
+++ b/tests/wind_data_integration_test.py
@@ -247,6 +247,7 @@ def test_wind_rose_upsample_directions():
         [[270.0, 280.0], 5.0, [267.5, 272.5, 277.5, 282.5]],
         [[10, 12, 14.0], 1.0, [9.5, 10.5, 11.5, 12.5, 13.5, 14.5]],
         [[0.0, 90.0, 180.0, 270.0], 1.0, np.arange(0.5, 360, 1.0)],
+        [[0.0, 10., 20.,], 5.0, [2.5, 7.5,12.5,  17.5, 22.5, 357.5]],
     ]
 
     for test_cond in test_conditions:
@@ -286,7 +287,7 @@ def test_wind_rose_upsample_directions():
 def test_wind_rose_upsample_speeds():
     # Test wind speed upsampling under a range of conditions
 
-    # First set up a matrix of input directions, upsampling steps and expected ouputs
+    # First set up a matrix of input directions, upsampling steps and expected outputs
     test_conditions = [
         [[5, 10.0], 1.0, [3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0]],
         [np.arange(0, 25, 2.0), 1.0, np.arange(0, 25, 1.0)],
@@ -391,6 +392,36 @@ def test_wind_rose_upsample():
     np.testing.assert_allclose(wind_rose_resample.wind_speeds, wind_rose_resample_old.wind_speeds)
     np.testing.assert_allclose(wind_rose_resample.ti_table, wind_rose_resample_old.ti_table)
     np.testing.assert_allclose(wind_rose_resample.freq_table, wind_rose_resample_old.freq_table)
+
+def test_wind_rose_upsample_wrapping():
+
+    # Test that interpolating without specifying new steps returns the same wind rose
+    wind_directions = np.array([0, 10, 350])
+    wind_speeds = np.array([8])
+    freq_table = np.ones((3, 1))
+    freq_table[-1:, :] = 0.0
+    freq_table[1, :] = 2.0
+    freq_table = freq_table / np.sum(freq_table)
+
+    wind_rose = WindRose(wind_directions, wind_speeds, ti_table=0.06, freq_table=freq_table)
+    wind_rose_resample = wind_rose.upsample(wd_step = 5.0, inplace=False)
+
+    np.testing.assert_allclose(wind_rose_resample.wind_directions,
+                                [2.5, 7.5, 12.5, 347.5, 352.5, 357.5])
+    np.testing.assert_allclose(wind_rose.wind_speeds, wind_rose_resample.wind_speeds)
+
+    expected_freq_table = np.ones((6, 1))
+    expected_freq_table[0, :] = 1.25
+    expected_freq_table[1, :] = 1.75
+    expected_freq_table[2, :] = 2.0
+    expected_freq_table[3, :] = 0.0
+    expected_freq_table[4, :] = 0.25
+    expected_freq_table[5, :] = 0.75
+    expected_freq_table = expected_freq_table / np.sum(expected_freq_table)
+
+
+    np.testing.assert_allclose(wind_rose_resample.freq_table, expected_freq_table)
+
 
 
 def test_wind_ti_rose_upsample_directions():
@@ -570,6 +601,36 @@ def test_upsample_ti_rose():
     np.testing.assert_allclose(wind_ti_rose_resample.wind_directions, [270, 280])
     np.testing.assert_allclose(wind_ti_rose_resample.wind_speeds, [5.5, 6.5, 7.5, 8.5])
     np.testing.assert_allclose(wind_ti_rose_resample.turbulence_intensities, [0.05, 0.1])
+    np.testing.assert_allclose(wind_ti_rose_resample.freq_table, freq_table_expected)
+
+
+    # Test interpolating frequency along the wind direction axis with wrapping
+    wind_directions = np.array([0, 350])
+    wind_speeds = np.array([7])
+    turbulence_intensities = np.array([0.1])
+    freq_table = np.ones((2, 1, 1))
+    freq_table[1, :, :] = 2.0
+    freq_table = freq_table / np.sum(freq_table)
+    wind_ti_rose = WindTIRose(
+        wind_directions, wind_speeds, turbulence_intensities, freq_table=freq_table
+    )
+
+    wind_ti_rose_resample = wind_ti_rose.upsample(
+        wd_step=5.0, inplace=False
+    )
+
+    freq_table_expected = np.ones((4, 1, 1))
+    freq_table_expected[0, :, :] = 1.0
+    freq_table_expected[1, :, :] = 2.0
+    freq_table_expected[2, :, :] = 1.75
+    freq_table_expected[3, :, :] = 1.25
+
+    freq_table_expected = freq_table_expected / np.sum(freq_table_expected)
+
+    # Check that the resample freq_table is correct
+    np.testing.assert_allclose(wind_ti_rose_resample.wind_directions, [ 2.5, 347.5, 352.5, 357.5])
+    np.testing.assert_allclose(wind_ti_rose_resample.wind_speeds, [7.0])
+    np.testing.assert_allclose(wind_ti_rose_resample.turbulence_intensities, [0.1])
     np.testing.assert_allclose(wind_ti_rose_resample.freq_table, freq_table_expected)
 
 


### PR DESCRIPTION
# Fix upsample

(Note this is cleaned up version of #942 from a git history perspective, closing that one in favor of this one)

The upsample function in wind_data.py (both `WindRose` and `WindTIRose`) has a subtle issue.  Because the current implementation assumes the same range of wind directions and wind speeds in the resampled rose as in the original, there can be a gap in the range implied by the combination of the original wind direction steps and bin size.  The issue is illustrated by the code snippet:

```
"""Example X: Demo Wind Sample Update Issue (Temporary)

Demonstrate the issue with upsampling a wind rose

"""


import matplotlib.pyplot as plt
import numpy as np

from floris import (
    WindRose,
)

# Say that you start with a wind rose with 10-degree wind direction bins and 2 m/s wind speed bins
wind_directions = np.arange(0, 360, 10.0)
wind_speeds = np.arange(4, 20, 2.0)

# Uniform frequency
freq_table = np.ones((len(wind_directions), len(wind_speeds)))
freq_table = freq_table / np.sum(freq_table)

wind_rose = WindRose(
    wind_directions=wind_directions,
    wind_speeds=wind_speeds,
    ti_table=0.06,
    freq_table=freq_table,
)

# Upsample the wind rose to 1-degree bins
wind_rose_upsampled = wind_rose.upsample(wd_step=2.0)

# Show the original and resample wind roses
fig, axarr = plt.subplots(1, 2, figsize=(12, 5), subplot_kw={"polar": True})
wind_rose.plot(ax=axarr[0])
axarr[0].set_title("Original Wind Rose")

wind_rose_upsampled.plot(ax=axarr[1])
axarr[1].set_title("Upsampled Wind Rose")

plt.show()

```

Which produces:

![image](https://github.com/NREL/floris/assets/6117702/9777c069-ee7b-4505-82ec-731806a56beb)

This pull request fixes the issue by setting the new wind directions to cover the complete span of the covered directions.  This change is not breaking per se, but does require changing some of the tests to match the new expected behavior.  For example, a previous test was:

```
# Test interpolating TI along the wind direction axis
wind_directions = np.array([270, 280])
wind_speeds = np.array([6, 7])
ti_table = np.array([[0.06, 0.06], [0.07, 0.07]])
wind_rose = WindRose(wind_directions, wind_speeds, ti_table=ti_table)

wind_rose_resample = wind_rose.upsample(wd_step=5.0, ws_step=1.0, inplace=False)

np.testing.assert_allclose(wind_ti_rose_resample.wind_directions, [270, 275, 280])
```

But note this result only extends to 267.5, not the 265 of the original version.  The new test concludes with:

```
np.testing.assert_allclose(wind_rose_resample.wind_directions, [267.5, 272.5, 277.5, 282.5])
```


With the improvements, above figure is now:

![image](https://github.com/NREL/floris/assets/6117702/6cf53b83-87ee-48de-92d0-cc625dd2ef6d)


## Related issue
This pull request takes into more focus work originally done within #919 but we thought should be its own pull request to make the changes clearer


## Impacted areas of the software
wind_data.py
