### PR TITLE
[BUGFIX] Fix documentation examples build

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,7 @@ only_build_toc_files: false
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: auto
-  timeout: 360 # Give each notebook cell 6 minutes to execute
+  timeout: 420 # Give each notebook cell 7 minutes to execute
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -41,8 +41,8 @@ developer's guide, so please read on to learn more about each of these steps.
 
 ## Git and GitHub Workflows
 
-The majority of the collaboration and development for FLORIS takes place
-in the [GitHub repository](http://github.com/nrel/floris). There,
+The majority of the collaboration and development for FLORIS takes place in
+the [GitHub repository](http://github.com/nrel/floris). There,
 [issues](http://github.com/nrel/floris/issues) and
 [pull requests](http://github.com/nrel/floris/pulls) are managed,
 questions and ideas are [discussed](https://github.com/NREL/floris/discussions),


### PR DESCRIPTION
# Fix documentation build

The documentations haven't been building because one of the latest examples takes just over - by design - 6 minutes to run, exceeding the timeout limit in the jupyer-book configuration.  Extending the limit to 7 minutes resolves the issue.
