### PR TITLE
[BUGFIX] Fix bug in check_turbine example (not resetting operation)

### DIFF
--- a/examples/examples_turbine/001_check_turbine.py
+++ b/examples/examples_turbine/001_check_turbine.py
@@ -43,6 +43,7 @@ fig_pow_ct, axarr_pow_ct = plt.subplots(2, 1, sharex=True, figsize=(10, 10))
 for t in turbines:
     # Set t as the turbine
     fmodel.set(turbine_type=[t])
+    fmodel.reset_operation() # Remove any previously applied yaw angles
 
     # Since we are changing the turbine type, make a matching change to the reference wind height
     fmodel.assign_hub_height_to_ref_height()
@@ -80,6 +81,7 @@ for t in turbines:
             wind_directions=wd_array,
             turbulence_intensities=turbulence_intensities,
         )
+        fmodel.reset_operation() # Remove any previously applied yaw angles
         fmodel.run()
         turbine_powers = fmodel.get_turbine_powers().flatten() / 1e3
         if density == 1.225:


### PR DESCRIPTION
@aclerc recently pointed out that [examples/examples_turbine/001_check_turbine.py](https://github.com/NREL/floris/pull/962/files#diff-898f12d839a184736bc46adc128b83f27019cd5b96edd284eed080b49a850f79) was producing unexpected results, apparently increasing the power of the IEA 10MW turbine with decreasing air density. After looking into this, it turned out to be that control setpoints (yaw angles, in particular) were not being reset, leading to erroneous results. 

Prior to the bug fix, 001_check_turbine.py produced the following (note the blue curve to the left of the black curve in the left plot):
![iea10MW_prior](https://github.com/user-attachments/assets/18c4d8d1-f0c5-4c68-971e-6238534eda07)

Following the bug fix, these change to the expected:
![iea10MW_post](https://github.com/user-attachments/assets/6316e9f9-0b18-498d-8eb3-522d70edc3e0)
