### PR TITLE
Add op_rose class

### DIFF
--- a/floris/op_rose.py
+++ b/floris/op_rose.py
@@ -1,0 +1,1 @@
+from __future__ import annotations


### PR DESCRIPTION
# Add operating rose

In Floris v4, it is assumed operating inputs must be passed in with shape n_findex x n_turbines.  This can be challenging when operating use rose type wind data options (WindRose, WindTIRose, WindRoseWRG) since those allow wind inputs to be shaped n_wd x n_ws x (n_ti) and the FlorisModel will reshape the turbine outputs to match (n_wd x n_ws x (n_ti) x n_turbines).

This pull request adds a new class which the FlorisModel can accept to set the inputs, which specifies them in a way which matches the wind rose input.  The change will be made backward compatible with FlorisV4.  This initial draft pull reqeust is to catch the items and requirements (@misi9170 please feel free to edit).

- [ ] To clarify #963, require `compute_zero_freq_occurrence=True` is passing in operating controls with a wind rose type object, or add better errors
- [ ] Is OpRose the right name if can be used with TimeSeries?
- [ ] Define OpRose
- [ ] Provide checking in OpRose that it is sized to match WindData
- [ ] Create methods to export the controls in n_findex order depending on the matched WindData object
- [ ] Allow OpRose passing to set() method
- [ ] Expand tests to cover
- [ ] Expand documentation
- [ ] Increase documentation and errors of existing methods to make clear n_findex sizing of methods passed without OpRose
- [ ] Ensure works will all control types / add tests

## Related issue
This is meant to more generally address #963 

## Impacted areas of the software
TBD

## Additional supporting information
TBD

## Test results, if applicable
TBD


