### PR TITLE
Speed up turbine loading operation

### DIFF
--- a/floris/core/farm.py
+++ b/floris/core/farm.py
@@ -121,7 +121,7 @@ class Farm(BaseClass):
     internal_turbine_library: Path = field(init=False, default=default_turbine_library_path)
 
     # Private attributes
-    _turbine_types: List = field(init=False, validator=iter_validator(list, str))
+    _turbine_types: List = field(init=False, validator=iter_validator(list, str), factory=list)
     _turbine_definition_cache: dict = field(init=False, factory=dict)
 
     def __attrs_post_init__(self) -> None:

--- a/floris/core/farm.py
+++ b/floris/core/farm.py
@@ -122,7 +122,7 @@ class Farm(BaseClass):
 
     # Private attributes
     _turbine_types: List = field(init=False, validator=iter_validator(list, str))
-    _turbine_definition_cache: dict = field(init=False)
+    _turbine_definition_cache: dict = field(init=False, factory=dict)
 
     def __attrs_post_init__(self) -> None:
         # Turbine definitions can be supplied in three ways:
@@ -139,7 +139,6 @@ class Farm(BaseClass):
         # In other words, if the turbine type is already in the cache, skip that iteration of
         # the for-loop.
 
-        self._turbine_definition_cache = {}
         for t in self.turbine_type:
             # If a turbine type is a dict, then it was either preprocessed by the yaml
             # library to resolve the "!include" or it was set in a script as a dict. In either case,

--- a/floris/core/farm.py
+++ b/floris/core/farm.py
@@ -151,7 +151,14 @@ class Farm(BaseClass):
                 # each turbine. Would then need to update the name somehow to handle the case where
                 # the "turbine_type" key is the same
                 if t["turbine_type"] in turbine_definition_cache:
-                    continue # Skip t if already loaded
+                    if turbine_definition_cache[t["turbine_type"]] == t:
+                        continue # Skip t if already loaded
+                    else:
+                        raise ValueError(
+                            "Two different turbine definitions have the same name: "\
+                            f"'{t['turbine_type']}'. "\
+                            "Please specify a unique 'turbine_type' for each turbine definition."
+                        )
                 turbine_definition_cache[t["turbine_type"]] = t
 
             # If a turbine type is a string, then it is expected in the internal or external

--- a/floris/core/farm.py
+++ b/floris/core/farm.py
@@ -139,17 +139,12 @@ class Farm(BaseClass):
         # In other words, if the turbine type is already in the cache, skip that iteration of
         # the for-loop.
 
-        # TODO: How can we give each one a different name, to avoid the issue raised in #864?
         turbine_definition_cache = {}
-        # Is this loop slow if turbine_type is long?
         for t in self.turbine_type:
             # If a turbine type is a dict, then it was either preprocessed by the yaml
             # library to resolve the "!include" or it was set in a script as a dict. In either case,
             # add an entry to the cache
             if isinstance(t, dict):
-                # TODO: If this check was more robust, could avoid needing to change the name of
-                # each turbine. Would then need to update the name somehow to handle the case where
-                # the "turbine_type" key is the same
                 if t["turbine_type"] in turbine_definition_cache:
                     if turbine_definition_cache[t["turbine_type"]] == t:
                         continue # Skip t if already loaded
@@ -305,9 +300,6 @@ class Farm(BaseClass):
         )
 
     def construct_turbine_map(self):
-        # The line below is slow and often unnecessary. We should just be loading
-        # each different turbine type, _not_ each turbine.
-        #self.turbine_map = [Turbine.from_dict(turb) for turb in self.turbine_definitions]
         turbine_map_unique = {
             k: Turbine.from_dict(v) for k, v in self._turbine_definition_cache.items()
         }

--- a/tests/farm_unit_test.py
+++ b/tests/farm_unit_test.py
@@ -115,6 +115,24 @@ def test_check_turbine_type(sample_inputs_fixture: SampleInputs):
     assert len(farm.turbine_type) == 5
     assert len(farm.turbine_definitions) == 5
 
+    # Check that error is correctly raised if two turbines have the same name
+    farm_data = deepcopy(sample_inputs_fixture.farm)
+    external_library = Path(__file__).parent / "data"
+    farm_data["layout_x"] = np.arange(0, 500, 100)
+    farm_data["layout_y"] = np.zeros(5)
+    turbine_def = load_yaml(external_library / "nrel_5MW_custom.yaml")
+    turbine_def_mod = deepcopy(turbine_def)
+    turbine_def_mod["hub_height"] = 100.0 # Change the hub height of the last turbine
+    farm_data["turbine_type"] = [turbine_def]*4 + [turbine_def_mod]
+    with pytest.raises(ValueError):
+        farm = Farm.from_dict(farm_data)
+    # Check this also raises an error in a nested level of the turbine definition
+    turbine_def_mod = deepcopy(turbine_def)
+    turbine_def_mod["power_thrust_table"]["wind_speed"][-1] = -100.0
+    farm_data["turbine_type"] = [turbine_def]*4 + [turbine_def_mod]
+    with pytest.raises(ValueError):
+        farm = Farm.from_dict(farm_data)
+
     # Duplicate type found in external and internal library
     farm_data = deepcopy(sample_inputs_fixture.farm)
     external_library = Path(__file__).parent / "data"


### PR DESCRIPTION
@Bartdoekemeijer points out in #965 that instantiating the `FlorisModel` can be slow, especially when there are many turbines. @achenry had also pointed out a similar problem in #885. 

After looking into this some, and using the profiling method suggested by @achenry, I found that a lot of time is being spent in the `construct_turbine_map()` method of `Farm`. Essentially, each `Turbine` is being instantiated separately, even if all turbines are the same type (which is often the case). 

This PR proposes a fix to this that only calls `Turbine.from_dict()` once for each _type_ of turbine, and then uses those (fewer) instantiations to construct the `Farm.turbine_map`. I'm seeing a substantial speed up, and now I think (after the change) that instantiation speed is dominated by `n_findex` rather than `n_turbines`.

There may be other opportunities for speed up during instantiation, but I think this may be the lowest hanging fruit.

### Notes
I took the opportunity to also partly address #864, which raises the issue that the `"turbine_type"` key of the turbine dictionary _must_ be changed in order to implement changes to other parts of the dictionary. While the changes I have made here do not necessarily "fix" the issue, now an informative error is raised when this situation arises.

### Affected areas of the code
- floris/core/farm.py

### Tests
- All existing tests pass
- New test for checking that an error is raised if two different turbine definitions are given with the same `"turbine_type"`
- New test that checks that modified turbine definitions make it into the `turbine_map` correctly

### Examples
The main relevant example is examples/examples_turbine/002_multiple_turbine_types.py. I see no change to the outputs, as expected.

### Performance
Using the example code in #965, I get the following performance on the develop branch:
![dis965](https://github.com/user-attachments/assets/380f3e9e-ec22-48d3-bbbf-acd4ec27a669)


while this PR provides:
![dis965_fix](https://github.com/user-attachments/assets/727018c0-6da1-44c7-9879-6addc84eca60)


 
