### PR TITLE
Add capabilities to parallel_floris_model

### DIFF
--- a/floris/parallel_floris_model.py
+++ b/floris/parallel_floris_model.py
@@ -604,7 +604,15 @@ class ParallelFlorisModel(LoggingManager):
         """
         self.fmodel.set_operation_model(operation_model)
 
-        #TODO: Based on set() function above, should we call __init__ here?
+        # Reinitialize settings
+        self.__init__(
+            fmodel=self.fmodel,
+            max_workers=self._max_workers,
+            n_wind_condition_splits=self._n_wind_condition_splits,
+            interface=self.interface,
+            propagate_flowfield_from_workers=self.propagate_flowfield_from_workers,
+            print_timings=self.print_timings,
+        )
 
     def get_param(self, param, param_idx=None):
         """Get the parameter of underlying fmodel.
@@ -629,7 +637,15 @@ class ParallelFlorisModel(LoggingManager):
         """
         self.fmodel.set_param(param, value, param_idx)
 
-        #TODO: Based on set() function above, should we call __init__ here?
+        # Reinitialize settings
+        self.__init__(
+            fmodel=self.fmodel,
+            max_workers=self._max_workers,
+            n_wind_condition_splits=self._n_wind_condition_splits,
+            interface=self.interface,
+            propagate_flowfield_from_workers=self.propagate_flowfield_from_workers,
+            print_timings=self.print_timings,
+        )
 
 
 
@@ -660,8 +676,3 @@ class ParallelFlorisModel(LoggingManager):
     @property
     def n_turbines(self):
         return self.fmodel.n_turbines
-
-
-    # @property
-    # def floris(self):
-    #     return self.fmodel.core

--- a/floris/parallel_floris_model.py
+++ b/floris/parallel_floris_model.py
@@ -157,11 +157,52 @@ class ParallelFlorisModel(LoggingManager):
         layout_x=None,
         layout_y=None,
         turbine_type=None,
+        turbine_library_path=None,
         solver_settings=None,
+        heterogeneous_inflow_config=None,
+        wind_data=None,
+        yaw_angles=None,
+        power_setpoints=None,
+        awc_modes=None,
+        awc_amplitudes=None,
+        awc_frequencies=None,
+        disable_turbines=None,
     ):
         """Pass to the FlorisModel set function. To allow users
         to directly replace a FlorisModel object with this
-        UncertainFlorisModel object, this function is required."""
+        UncertainFlorisModel object, this function is required
+
+        Args:
+            wind_speeds (NDArrayFloat | list[float] | None, optional): Wind speeds at each findex.
+                Defaults to None.
+            wind_directions (NDArrayFloat | list[float] | None, optional): Wind directions at each
+                findex. Defaults to None.
+            wind_shear (float | None, optional): Wind shear exponent. Defaults to None.
+            wind_veer (float | None, optional): Wind veer. Defaults to None.
+            reference_wind_height (float | None, optional): Reference wind height. Defaults to None.
+            turbulence_intensities (NDArrayFloat | list[float] | None, optional): Turbulence
+                intensities at each findex. Defaults to None.
+            air_density (float | None, optional): Air density. Defaults to None.
+            layout_x (NDArrayFloat | list[float] | None, optional): X-coordinates of the turbines.
+                Defaults to None.
+            layout_y (NDArrayFloat | list[float] | None, optional): Y-coordinates of the turbines.
+                Defaults to None.
+            turbine_type (list | None, optional): Turbine type. Defaults to None.
+            turbine_library_path (str | Path | None, optional): Path to the turbine library.
+                Defaults to None.
+            solver_settings (dict | None, optional): Solver settings. Defaults to None.
+            heterogeneous_inflow_config (None, optional): heterogeneous inflow configuration.
+                Defaults to None.
+            wind_data (type[WindDataBase] | None, optional): Wind data. Defaults to None.
+            yaw_angles (NDArrayFloat | list[float] | None, optional): Turbine yaw angles.
+                Defaults to None.
+            power_setpoints (NDArrayFloat | list[float] | list[float, None] | None, optional):
+                Turbine power setpoints.
+            disable_turbines (NDArrayBool | list[bool] | None, optional): NDArray with dimensions
+                n_findex x n_turbines. True values indicate the turbine is disabled at that findex
+                and the power setpoint at that position is set to 0. Defaults to None.
+
+        """
 
         if layout is not None:
             msg = "Use the `layout_x` and `layout_y` parameters in place of `layout` "
@@ -183,7 +224,16 @@ class ParallelFlorisModel(LoggingManager):
             layout_x=layout_x,
             layout_y=layout_y,
             turbine_type=turbine_type,
+            turbine_library_path=turbine_library_path,
             solver_settings=solver_settings,
+            heterogeneous_inflow_config=heterogeneous_inflow_config,
+            wind_data=wind_data,
+            yaw_angles=yaw_angles,
+            power_setpoints=power_setpoints,
+            awc_modes=awc_modes,
+            awc_amplitudes=awc_amplitudes,
+            awc_frequencies=awc_frequencies,
+            disable_turbines=disable_turbines,
         )
 
         # Reinitialize settings

--- a/floris/parallel_floris_model.py
+++ b/floris/parallel_floris_model.py
@@ -588,6 +588,22 @@ class ParallelFlorisModel(LoggingManager):
 
         return df_opt
 
+    def get_operation_model(self):
+        """Get the operation model of underlying fmodel.
+
+        Returns:
+            str: The operation_model.
+        """
+        return self.fmodel.get_operation_model()
+
+    def set_operation_model(self, operation_model):
+        """Set the operation model of underlying fmodel.
+
+        Args:
+            operation_model (str): The operation model to set.
+        """
+        self.fmodel.set_operation_model(operation_model)
+
     @property
     def layout_x(self):
         return self.fmodel.layout_x

--- a/floris/parallel_floris_model.py
+++ b/floris/parallel_floris_model.py
@@ -604,6 +604,35 @@ class ParallelFlorisModel(LoggingManager):
         """
         self.fmodel.set_operation_model(operation_model)
 
+        #TODO: Based on set() function above, should we call __init__ here?
+
+    def get_param(self, param, param_idx=None):
+        """Get the parameter of underlying fmodel.
+
+        Args:
+            param (List[str]): A list of keys to traverse the FlorisModel dictionary.
+            param_idx (Optional[int], optional): The index to get the value at. Defaults to None.
+                If None, the entire parameter is returned.
+
+        Returns:
+            Any: The value of the parameter.
+        """
+        return self.fmodel.get_param(param, param_idx)
+
+    def set_param(self, param, value, param_idx=None):
+        """Set the parameter of underlying fmodel.
+
+        Args:
+            param (List[str]): A list of keys to traverse the FlorisModel dictionary.
+            value (Any): The value to set.
+            param_idx (Optional[int], optional): The index to set the value at. Defaults to None.
+        """
+        self.fmodel.set_param(param, value, param_idx)
+
+        #TODO: Based on set() function above, should we call __init__ here?
+
+
+
     @property
     def layout_x(self):
         return self.fmodel.layout_x

--- a/tests/parallel_floris_model_integration_test.py
+++ b/tests/parallel_floris_model_integration_test.py
@@ -21,7 +21,7 @@ DEFLECTION_MODEL = "gauss"
 def test_parallel_turbine_powers(sample_inputs_fixture):
     """
     The parallel computing interface behaves like the floris interface, but distributes
-    calculations among available cores to speep up the necessary computations. This test compares
+    calculations among available cores to speed up the necessary computations. This test compares
     the individual turbine powers computed with the parallel interface to those computed with
     the serial floris interface. The expected result is that the turbine powers should be
     exactly the same.

--- a/tests/parallel_floris_model_integration_test.py
+++ b/tests/parallel_floris_model_integration_test.py
@@ -138,3 +138,34 @@ def test_parallel_uncertain_get_AEP(sample_inputs_fixture):
     parallel_farm_AEP = pfmodel.get_farm_AEP(freq=freq)
 
     assert np.allclose(parallel_farm_AEP, serial_farm_AEP)
+
+
+def test_parallel_uncertain_get_AEP_no_wake(sample_inputs_fixture):
+    """
+
+    """
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    freq=np.linspace(0, 1, 16)/8
+
+    ufmodel = UncertainFlorisModel(
+        sample_inputs_fixture.core,
+        wd_sample_points=[-3, 0, 3],
+        wd_std=3
+    )
+    pfmodel_input = copy.deepcopy(ufmodel)
+    ufmodel.run_no_wake()
+    serial_farm_AEP = ufmodel.get_farm_AEP(freq=freq)
+
+    pfmodel = ParallelFlorisModel(
+        fmodel=pfmodel_input,
+        max_workers=2,
+        n_wind_condition_splits=2,
+        interface="multiprocessing",
+        print_timings=False,
+    )
+
+    parallel_farm_AEP = pfmodel.get_farm_AEP(freq=freq, no_wake=True)
+
+    assert np.allclose(parallel_farm_AEP, serial_farm_AEP)


### PR DESCRIPTION
#Add capabilities to parallel_floris_model

This pull request adds *some* capabilities to `ParallelFlorisModel`.  These updates are not comprehensive, a more thorough updating of `ParallelFlorisModel` to provide full functionality of `FlorisModel` is deferred to a future pull request.  The updates included in this PR are those necessary to support capabilities in FLASC's use of parallelized FLORIS runs.  Specifically:

- The set function's inputs are expanded to match the full set in `FlorisModel`
- The method to run without wake (`no_wake = True`) is updated to the correct syntax of underlying `FlorisModel`
- A new test of running without wake is added to confirm correct behavior
- Functions for getting and setting operation model added
- Functions for getting and setting parameters are added

A few remaining open questions:

1. Some `#TODO` in the code mark a question (@misi9170 ) if a re-run of __init__ is necessary / appropriate?
  (UPDATE: we decided to include __init__ to be safe/consistent)
Not doing this:
        3. I believe one more improvement we could make is add default values to max_workers, for example I think something like this code:
        
        ```
         if max_workers is None:
              max_workers = multiprocessing.cpu_count()
        ```
        
        Or maybe this can be out of scope of this PR


## Impacted areas of the software
parallel_floris_model.py
