### PR TITLE
Add get_param and set_param to UncertainFlorisModel

### DIFF
--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import (
+    Any,
+    List,
+    Optional,
+)
 
 import numpy as np
 
@@ -717,6 +722,40 @@ class UncertainFlorisModel(LoggingManager):
         weights = gaussian_values / np.sum(gaussian_values)
 
         return weights
+
+    def get_param(
+        self,
+        param: List[str],
+        param_idx: Optional[int] = None
+    ) -> Any:
+        """Get a parameter in underlying FlorisModel object.
+
+        Args:
+            param (List[str]): A list of keys to traverse the FlorisModel dictionary.
+            param_idx (Optional[int], optional): The index to get the value at. Defaults to None.
+
+        Returns:
+            Any: The value of the parameter.
+        """
+        return self.fmodel_unexpanded.get_param(param, param_idx)
+
+    def set_param(
+        self,
+        param: List[str],
+        value: Any,
+        param_idx: Optional[int] = None
+    ):
+        """Set a parameter in underlying FlorisModel object.
+
+        Args:
+            param (List[str]): A list of keys to traverse the FlorisModel dictionary.
+            value (Any): The value to set.
+            param_idx (Optional[int], optional): The index to set the value at. Defaults to None.
+        """
+        self.fmodel_unexpanded.set_param(param, value, param_idx)
+        self._set_uncertain()
+
+
 
     def copy(self):
         """Create an independent copy of the current UncertainFlorisModel object"""

--- a/tests/uncertain_floris_model_integration_test.py
+++ b/tests/uncertain_floris_model_integration_test.py
@@ -298,3 +298,11 @@ def test_approx_floris_model():
     power = afmodel.get_farm_power()
     np.testing.assert_almost_equal(power[0], power[1])
     assert not np.allclose(power[2], power[3])
+
+def test_get_and_set_param():
+    ufmodel = UncertainFlorisModel(configuration=YAML_INPUT)
+
+    # Test getting and setting a wake parameter on UncertainFlorisModel
+    ufmodel.set_param(['wake', 'wake_velocity_parameters', 'gauss', 'alpha'], 0.1)
+    alpha = ufmodel.get_param(['wake', 'wake_velocity_parameters', 'gauss', 'alpha'])
+    assert alpha == 0.1


### PR DESCRIPTION
# Add get_param and set_param to UncertainFlorisModel

`UncertainFlorisModel` is missing the member functions available in `FlorisModel` for getting and setting model parameters.  This pull request adds them in, buy accessing the method within the underlying `FlorisModel` and includes a new test of the feature.


## Impacted areas of the software
uncertain_floris_model.py
