### PR TITLE
[BUGFIX] Control setpoints and wind data set on `FlorisModel` copied into `ParFlorisModel`

### DIFF
--- a/floris/par_floris_model.py
+++ b/floris/par_floris_model.py
@@ -47,8 +47,19 @@ class ParFlorisModel(FlorisModel):
         """
         # Instantiate the underlying FlorisModel
         if isinstance(configuration, FlorisModel):
-            configuration = configuration.core.as_dict()
-        super().__init__(configuration)
+            configuration_dict = configuration.core.as_dict()
+            super().__init__(configuration_dict)
+            # Copy over any control setpoints, wind data, if not already done.
+            self.set(
+                yaw_angles=configuration.core.farm.yaw_angles,
+                power_setpoints=configuration.core.farm.power_setpoints,
+                awc_modes=configuration.core.farm.awc_modes,
+                awc_amplitudes=configuration.core.farm.awc_amplitudes,
+                awc_frequencies=configuration.core.farm.awc_frequencies,
+                wind_data=configuration.wind_data,
+            )
+        else:
+            super().__init__(configuration)
 
         # Save parallelization parameters
         if interface == "multiprocessing":


### PR DESCRIPTION
One way of instantiating a `ParFlorisModel` is to pass in an instantiated `FlorisModel`. However, as is, if there are any control setpoints (`yaw_angles`, ...) that had already been set on the instantiated `FlorisModel`, they were dropped on instantiation of the `ParFlorisModel`. Similarly, `wind_data` was not copied over correctly. 

A workaround is to only `set()` control setpoints and wind data _after_ instantiating the `ParFlorisModel`; however, this is not immediately obvious to the user. Instead, this PR fixes the bug. In particular, the following code
```python
import numpy as np

from floris import FlorisModel, ParFlorisModel, TimeSeries

fmodel = FlorisModel("inputs/gch.yaml")
fmodel.set(
    layout_x=[0., 0., 0.],
    layout_y=[0., 500., 1000.],
    wind_data=TimeSeries(
        wind_directions=np.array([270.0]),
        wind_speeds=np.array([8.0]),
        turbulence_intensities=np.array([0.06])
    )
)
fmodel.set(yaw_angles=np.array([[20.0, 10.0, 0.0]]))

pfmodel = ParFlorisModel(fmodel)
print(pfmodel.core.farm.yaw_angles)
print(pfmodel.wind_data)
```
produces `[[0. 0. 0.]]` and `None` prior to the bugfix; while producing `[[20. 10.  0.]]` and `<floris.wind_data.TimeSeries object at 0x12f93e9f0>`, as expected, with the fix.
