### PR TITLE
Set ref wind height to -1 for turboparkgauss.yaml

### DIFF
--- a/examples/inputs/turboparkgauss.yaml
+++ b/examples/inputs/turboparkgauss.yaml
@@ -29,7 +29,7 @@ farm:
 
 flow_field:
   air_density: 1.225
-  reference_wind_height: 90.0
+  reference_wind_height: -1
   turbulence_intensities:
   - 0.06
   wind_directions:


### PR DESCRIPTION
# Set ref wind height to -1 for turboparkgauss.yaml

Doing some other work I noticed that among the example inputs turboparkgauss.yaml uses 90.0 instead of -1.  This isn't really a bug, but since we often use these example inputs as starters for other turbine models, probably nice if they all use the more generic option.  I think this is the only case of this (the multiple turbine input correctly specifies the height since there isn't a single height).