### PR TITLE
[BUGFIX] Warn users if the `turbine_type` is set without setting `reference_wind_height`

### DIFF
--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -175,6 +175,16 @@ class FlorisModel(LoggingManager):
         if layout_y is not None:
             farm_dict["layout_y"] = layout_y
         if turbine_type is not None:
+            if reference_wind_height is None:
+                self.logger.warning(
+                    "turbine_type has been changed without specifying a new "
+                    +"reference_wind_height. reference_wind_height remains {0:.2f} m.".format(
+                        flow_field_dict["reference_wind_height"]
+                    )
+                    +f" Consider calling `{self.__class__.__name__}."
+                    +"assign_hub_height_to_ref_height` to update the reference wind height to the "
+                    +"turbine hub height."
+                )
             farm_dict["turbine_type"] = turbine_type
         if turbine_library_path is not None:
             farm_dict["turbine_library_path"] = turbine_library_path

--- a/tests/floris_model_integration_test.py
+++ b/tests/floris_model_integration_test.py
@@ -789,11 +789,11 @@ def test_reference_wind_height_methods(caplog):
     # Check that if the turbine type is changed, a warning is raised/not raised regarding the
     # reference wind height
     with caplog.at_level(logging.WARNING):
-        fmodel.set(turbine_type=["iea_15mw"])
+        fmodel.set(turbine_type=["iea_15MW"])
     assert caplog.text != "" # Checking not empty
     caplog.clear()
     with caplog.at_level(logging.WARNING):
-        fmodel.set(turbine_type=["iea_15mw"], reference_wind_height=100.0)
+        fmodel.set(turbine_type=["iea_15MW"], reference_wind_height=100.0)
     assert caplog.text == "" # Checking empty
 
     # Check that assigning the reference wind height to the turbine hub height works
@@ -805,6 +805,6 @@ def test_reference_wind_height_methods(caplog):
         fmodel.set(
             layout_x = [0.0, 0.0],
             layout_y = [0.0, 1000.0],
-            turbine_type=["nrel_5mw", "iea_15mw"]
+            turbine_type=["nrel_5MW", "iea_15MW"]
         )
         fmodel.assign_hub_height_to_ref_height() # Shouldn't allow due to multiple turbine types

--- a/tests/floris_model_integration_test.py
+++ b/tests/floris_model_integration_test.py
@@ -782,3 +782,29 @@ def test_set_operation():
     with pytest.raises(ValueError):
         fmodel.set_operation(yaw_angles=np.array([[25.0, 0.0], [25.0, 0.0]]))
         fmodel.run()
+
+def test_reference_wind_height_methods(caplog):
+    fmodel = FlorisModel(configuration=YAML_INPUT)
+
+    # Check that if the turbine type is changed, a warning is raised/not raised regarding the
+    # reference wind height
+    with caplog.at_level(logging.WARNING):
+        fmodel.set(turbine_type=["iea_15mw"])
+    assert caplog.text != "" # Checking not empty
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        fmodel.set(turbine_type=["iea_15mw"], reference_wind_height=100.0)
+    assert caplog.text == "" # Checking empty
+
+    # Check that assigning the reference wind height to the turbine hub height works
+    assert fmodel.core.flow_field.reference_wind_height == 100.0 # Set in line above
+    fmodel.assign_hub_height_to_ref_height()
+    assert fmodel.core.flow_field.reference_wind_height == 150.0 # 150m is HH for IEA 15MW
+
+    with pytest.raises(ValueError):
+        fmodel.set(
+            layout_x = [0.0, 0.0],
+            layout_y = [0.0, 1000.0],
+            turbine_type=["nrel_5mw", "iea_15mw"]
+        )
+        fmodel.assign_hub_height_to_ref_height() # Shouldn't allow due to multiple turbine types


### PR DESCRIPTION
Replaces #809 to address #806. When a `FlorisModel` is instantiated using an input wind file that has a `reference_wind_height: -1`, the hub height of the specified turbine model is used as the reference wind height. However, if the `turbine_type` is subsequently changed, the reference wind height is not updated to match. This PR adds a warning that is raised if `turbine_type` is set without also setting the `reference_wind_height`.

The following script demonstrates this update. Prior to the fix, the following code runs without raising any warnings:
```python
from floris import FlorisModel
#from floris import UncertainFlorisModel as FlorisModel
#from floris import ParFlorisModel as FlorisModel

# Initialization uses NREL 5MW model with 90m hub height
fmodel = FlorisModel("../inputs/gch.yaml")
print(fmodel.core.flow_field.reference_wind_height)

# Changing the turbine type without specifying reference_wind_height
fmodel.set(turbine_type=["iea_15mw"]*len(fmodel.layout_x))
print(fmodel.core.flow_field.reference_wind_height)

# Changing the turbine type and specifying reference_wind_height
fmodel.set(turbine_type=["iea_15mw"]*len(fmodel.layout_x), reference_wind_height=150.2)
print(fmodel.core.flow_field.reference_wind_height)
```
producing 
```
90.0
90.0
150.2
```

After the bugfix, the output is instead:
```
90.0
floris.floris_model.FlorisModel WARNING turbine_type has been changed without specifying a new reference_wind_height. reference_wind_height remains 90.00 m. Consider calling `FlorisModel.assign_hub_height_to_ref_height` to update the reference wind height to the turbine hub height.
90.0
150.2
```

### TODO:
- [x] Implement warning
- [x] Check that warning is also raised for `UncertainFlorisModel` and `ParFlorisModel` (other warnings are also raised due to reinstantiation of the underlying `fmodel_expanded` with `UncertainFlorisModel`, but this is acceptable)
- [x] Add test for raising warning
