### PR TITLE
Add flow visualization to wake steering example

### DIFF
--- a/examples/examples_control_optimization/001_opt_yaw_single_ws.py
+++ b/examples/examples_control_optimization/001_opt_yaw_single_ws.py
@@ -9,6 +9,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from floris import FlorisModel, TimeSeries
+import floris.flow_visualization as flowviz
+import floris.layout_visualization as layoutviz
 from floris.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 
 
@@ -62,5 +64,28 @@ ax.set_ylabel('Power (W)')
 ax.set_xlabel('Wind Direction (deg)')
 ax.legend()
 ax.grid(True)
+
+# Visualize results for a single wind direction (270 deg) and wind speed (8 m/s)
+fig, axarr = plt.subplots(2, 1, figsize=(10, 5), sharex=False)
+ax = axarr[0] # Baseline aligned operation
+fmodel.reset_operation()
+fmodel.set(wind_directions=[270.0], wind_speeds=[8.0], turbulence_intensities=[0.06])
+fmodel.run()
+horizontal_plane = fmodel.calculate_horizontal_plane(height=90.0)
+flowviz.visualize_cut_plane(horizontal_plane, ax=ax)
+layoutviz.plot_turbine_rotors(fmodel, ax=ax)
+ax.set_title("Turbines aligned")
+
+ax = axarr[1] # Optimized yaw angles
+optimal_yaw_angles = (
+    df_opt[(df_opt["wind_direction"] == 270.0) & (df_opt["wind_speed"] == 8.0)]
+    .yaw_angles_opt.values[0]
+).reshape(1,-1)
+fmodel.set(yaw_angles=optimal_yaw_angles)
+fmodel.run()
+horizontal_plane = fmodel.calculate_horizontal_plane(height=90.0)
+flowviz.visualize_cut_plane(horizontal_plane, ax=ax)
+layoutviz.plot_turbine_rotors(fmodel, ax=ax, yaw_angles=optimal_yaw_angles)
+ax.set_title("Optimized yaw angles")
 
 plt.show()

--- a/examples/examples_control_optimization/001_opt_yaw_single_ws.py
+++ b/examples/examples_control_optimization/001_opt_yaw_single_ws.py
@@ -8,9 +8,9 @@ Use the serial-refine method to optimize the yaw angles for a 3-turbine wind far
 import matplotlib.pyplot as plt
 import numpy as np
 
-from floris import FlorisModel, TimeSeries
 import floris.flow_visualization as flowviz
 import floris.layout_visualization as layoutviz
+from floris import FlorisModel, TimeSeries
 from floris.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 
 


### PR DESCRIPTION
It seems that none of the wake steering examples currently include any flow visualizations to demonstrate the deflection of the wake. This small PR makes a change to examples_control_optimization/001_opt_yaw_single_ws.py to add such visualization.

There _is_ flow visualization under yaw misalignment in examples_visualizations/001_layout_visualizations.py, but this is not a very intuitive place to go look for that example and is also included in a figure with a lot of other things going on.

A new figure is now generated by 001_opt_yaw_single_ws.py:

![yaw_optimization](https://github.com/user-attachments/assets/a2ebb78f-b80e-4631-bdea-a5af2203c94c)
