### PR TITLE
[BUGFIX] Correct grid coordinates for ngrid=1

### DIFF
--- a/floris/simulation/flow_field.py
+++ b/floris/simulation/flow_field.py
@@ -100,16 +100,20 @@ class FlowField:
             pt = turbine.rloc * turbine.rotor_radius
 
             xt = [coord.x1 for coord in self.turbine_map.coords]
-            yt = np.linspace(
-                x2 - pt,
-                x2 + pt,
-                ngrid,
-            )
-            zt = np.linspace(
-                x3 - pt,
-                x3 + pt,
-                ngrid,
-            )
+            if ngrid == 1:
+                yt = [x2]
+                zt = [x3]
+            else:
+                yt = np.linspace(
+                    x2 - pt,
+                    x2 + pt,
+                    ngrid,
+                )
+                zt = np.linspace(
+                    x3 - pt,
+                    x3 + pt,
+                    ngrid,
+                )
 
             x_grid[i] = xt[i]
             y_grid[i] = yt


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# [BUGFIX] Correct grid coordinates for ngrid=1
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
When `ngrid=1` was chosen, np.linspace would just return the starting value of -1 * pt which would not place the point at the center of the rotor. With this fix the center of the rotor is chosen.

## Related issue
<!--
If one exists, link to a related GitHub Issue.
-->
#1004 

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests.
-->
The generation of the y and z coordinates for each of the turbines is affected in cases where `ngrid=1` is chosen.

## Additional supporting information
<!--
Add any other context about the problem here.
-->
See #1004 

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->
Locally all existing tests run without issues. The example case of #1004 now works as expected.

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] floris/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
