### PR TITLE
[BUGFIX] Address reference wind height warnings raised unnecessarily

### DIFF
--- a/examples/examples_turbine/003_specify_turbine_power_curve.py
+++ b/examples/examples_turbine/003_specify_turbine_power_curve.py
@@ -51,6 +51,7 @@ fmodel.set(
     wind_speeds=wind_speeds,
     turbulence_intensities=turbulence_intensities,
     turbine_type=[turbine_dict],
+    reference_wind_height=fmodel.reference_wind_height
 )
 fmodel.run()
 

--- a/examples/examples_turbopark/001_compare_turbopark_implementations.py
+++ b/examples/examples_turbopark/001_compare_turbopark_implementations.py
@@ -35,7 +35,10 @@ const_CT_turb = build_cosine_loss_turbine_dict(
 ### Start by visualizing a single turbine in and its wake with the new model
 # Load the new TurboPark implementation and switch to constant CT turbine
 fmodel_new = FlorisModel("../inputs/turboparkgauss_cubature.yaml")
-fmodel_new.set(turbine_type=[const_CT_turb])
+fmodel_new.set(
+    turbine_type=[const_CT_turb],
+    reference_wind_height=fmodel_new.reference_wind_height
+)
 fmodel_new.run()
 u0 = fmodel_new.wind_speeds[0]
 
@@ -94,7 +97,10 @@ ax[2].set_xlim([-2, 2])
 ### Look at the wake profile at a single downstream distance for a range of wind directions
 # Load the original TurboPark implementation and switch to constant CT turbine
 fmodel_orig = FlorisModel("../inputs/turbopark_cubature.yaml")
-fmodel_orig.set(turbine_type=[const_CT_turb])
+fmodel_orig.set(
+    turbine_type=[const_CT_turb],
+    reference_wind_height=fmodel_orig.reference_wind_height
+)
 
 # Set up and solve flows
 wd_array = np.arange(225,315,0.1)

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1542,7 +1542,10 @@ class FlorisModel(LoggingManager):
                 # Set a single one here, then, and return
                 turbine_type = self.core.farm.turbine_definitions[0]
                 turbine_type["operation_model"] = operation_model
-                self.set(turbine_type=[turbine_type])
+                self.set(
+                    turbine_type=[turbine_type],
+                    reference_wind_height=self.reference_wind_height
+                )
                 return
             else:
                 operation_model = [operation_model]*self.core.farm.n_turbines
@@ -1561,7 +1564,10 @@ class FlorisModel(LoggingManager):
             )
             turbine_type_list[tindex]["operation_model"] = operation_model[tindex]
 
-        self.set(turbine_type=turbine_type_list)
+        self.set(
+            turbine_type=turbine_type_list,
+            reference_wind_height=self.reference_wind_height
+        )
 
     def copy(self):
         """Create an independent copy of the current FlorisModel object"""
@@ -1701,6 +1707,16 @@ class FlorisModel(LoggingManager):
             int: Number of turbines.
         """
         return self.core.farm.n_turbines
+
+    @property
+    def reference_wind_height(self):
+        """
+        Reference wind height.
+
+        Returns:
+            float: Reference wind height.
+        """
+        return self.core.flow_field.reference_wind_height
 
     @property
     def turbine_average_velocities(self) -> NDArrayFloat:

--- a/floris/flow_visualization.py
+++ b/floris/flow_visualization.py
@@ -543,7 +543,8 @@ def calculate_horizontal_plane_with_turbines(
                     awc_modes=awc_modes,
                     awc_amplitudes=awc_amplitudes,
                     awc_frequencies=awc_frequencies,
-                    turbine_type=turbine_types_test
+                    turbine_type=turbine_types_test,
+                    reference_wind_height=fmodel_viz.reference_wind_height
                 )
                 fmodel_viz.run()
 

--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -958,7 +958,10 @@ class UncertainFlorisModel(LoggingManager):
                 # Set a single one here, then, and return
                 turbine_type = self.fmodel_unexpanded.core.farm.turbine_definitions[0]
                 turbine_type["operation_model"] = operation_model
-                self.set(turbine_type=[turbine_type])
+                self.set(
+                    turbine_type=[turbine_type],
+                    reference_wind_height=self.reference_wind_height
+                )
                 return
             else:
                 operation_model = [operation_model] * self.fmodel_unexpanded.core.farm.n_turbines
@@ -976,7 +979,10 @@ class UncertainFlorisModel(LoggingManager):
             )
             turbine_type_list[tindex]["operation_model"] = operation_model[tindex]
 
-        self.set(turbine_type=turbine_type_list)
+        self.set(
+            turbine_type=turbine_type_list,
+            reference_wind_height=self.reference_wind_height
+        )
 
     def copy(self):
         """Create an independent copy of the current UncertainFlorisModel object"""
@@ -1094,6 +1100,16 @@ class UncertainFlorisModel(LoggingManager):
             int: Number of turbines in the wind farm.
         """
         return self.fmodel_unexpanded.core.farm.n_turbines
+
+    @property
+    def reference_wind_height(self):
+        """
+        Reference wind height.
+
+        Returns:
+            float: Reference wind height.
+        """
+        return self.fmodel_unexpanded.core.flow_field.reference_wind_height
 
     @property
     def core(self):

--- a/tests/floris_model_integration_test.py
+++ b/tests/floris_model_integration_test.py
@@ -720,6 +720,8 @@ def test_set_operation_model():
     fmodel.set_operation_model("simple-derating")
     assert fmodel.get_operation_model() == "simple-derating"
 
+    reference_wind_height = fmodel.reference_wind_height
+
     # Check multiple turbine types works
     fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
     fmodel.set_operation_model(["simple-derating", "cosine-loss"])
@@ -727,26 +729,26 @@ def test_set_operation_model():
 
     # Check that setting a single turbine type, and then altering the operation model works
     fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
-    fmodel.set(turbine_type=["nrel_5MW"])
+    fmodel.set(turbine_type=["nrel_5MW"], reference_wind_height=reference_wind_height)
     fmodel.set_operation_model("simple-derating")
     assert fmodel.get_operation_model() == "simple-derating"
 
     # Check that setting over mutliple turbine types works
-    fmodel.set(turbine_type=["nrel_5MW", "iea_15MW"])
+    fmodel.set(turbine_type=["nrel_5MW", "iea_15MW"], reference_wind_height=reference_wind_height)
     fmodel.set_operation_model("simple-derating")
     assert fmodel.get_operation_model() == "simple-derating"
     fmodel.set_operation_model(["simple-derating", "cosine-loss"])
     assert fmodel.get_operation_model() == ["simple-derating", "cosine-loss"]
 
     # Check setting over single turbine type; then updating layout works
-    fmodel.set(turbine_type=["nrel_5MW"])
+    fmodel.set(turbine_type=["nrel_5MW"], reference_wind_height=reference_wind_height)
     fmodel.set_operation_model("simple-derating")
     fmodel.set(layout_x=[0, 0, 0], layout_y=[0, 1000, 2000])
     assert fmodel.get_operation_model() == "simple-derating"
 
     # Check that setting for multiple turbine types and then updating layout breaks
     fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
-    fmodel.set(turbine_type=["nrel_5MW"])
+    fmodel.set(turbine_type=["nrel_5MW"], reference_wind_height=reference_wind_height)
     fmodel.set_operation_model(["simple-derating", "cosine-loss"])
     assert fmodel.get_operation_model() == ["simple-derating", "cosine-loss"]
     with pytest.raises(ValueError):
@@ -754,7 +756,7 @@ def test_set_operation_model():
 
     # Check one more variation
     fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
-    fmodel.set(turbine_type=["nrel_5MW", "iea_15MW"])
+    fmodel.set(turbine_type=["nrel_5MW", "iea_15MW"], reference_wind_height=reference_wind_height)
     fmodel.set_operation_model("simple-derating")
     fmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
     with pytest.raises(ValueError):

--- a/tests/uncertain_floris_model_integration_test.py
+++ b/tests/uncertain_floris_model_integration_test.py
@@ -410,9 +410,14 @@ def test_get_operation_model():
 
 
 def test_set_operation_model():
+    # Define a reference wind height for cases when there are changes to
+    # turbine_type
+
     ufmodel = UncertainFlorisModel(configuration=YAML_INPUT)
     ufmodel.set_operation_model("simple-derating")
     assert ufmodel.get_operation_model() == "simple-derating"
+
+    reference_wind_height = ufmodel.reference_wind_height
 
     # Check multiple turbine types works
     ufmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
@@ -424,26 +429,26 @@ def test_set_operation_model():
 
     # Check that setting a single turbine type, and then altering the operation model works
     ufmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
-    ufmodel.set(turbine_type=["nrel_5MW"])
+    ufmodel.set(turbine_type=["nrel_5MW"], reference_wind_height=reference_wind_height)
     ufmodel.set_operation_model("simple-derating")
     assert ufmodel.get_operation_model() == "simple-derating"
 
     # Check that setting over mutliple turbine types works
-    ufmodel.set(turbine_type=["nrel_5MW", "iea_15MW"])
+    ufmodel.set(turbine_type=["nrel_5MW", "iea_15MW"], reference_wind_height=reference_wind_height)
     ufmodel.set_operation_model("simple-derating")
     assert ufmodel.get_operation_model() == "simple-derating"
     ufmodel.set_operation_model(["simple-derating", "cosine-loss"])
     assert ufmodel.get_operation_model() == ["simple-derating", "cosine-loss"]
 
     # Check setting over single turbine type; then updating layout works
-    ufmodel.set(turbine_type=["nrel_5MW"])
+    ufmodel.set(turbine_type=["nrel_5MW"], reference_wind_height=reference_wind_height)
     ufmodel.set_operation_model("simple-derating")
     ufmodel.set(layout_x=[0, 0, 0], layout_y=[0, 1000, 2000])
     assert ufmodel.get_operation_model() == "simple-derating"
 
     # Check that setting for multiple turbine types and then updating layout breaks
     ufmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
-    ufmodel.set(turbine_type=["nrel_5MW"])
+    ufmodel.set(turbine_type=["nrel_5MW"], reference_wind_height=reference_wind_height)
     ufmodel.set_operation_model(["simple-derating", "cosine-loss"])
     assert ufmodel.get_operation_model() == ["simple-derating", "cosine-loss"]
     with pytest.raises(ValueError):
@@ -451,7 +456,7 @@ def test_set_operation_model():
 
     # Check one more variation
     ufmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
-    ufmodel.set(turbine_type=["nrel_5MW", "iea_15MW"])
+    ufmodel.set(turbine_type=["nrel_5MW", "iea_15MW"], reference_wind_height=reference_wind_height)
     ufmodel.set_operation_model("simple-derating")
     ufmodel.set(layout_x=[0, 0], layout_y=[0, 1000])
     with pytest.raises(ValueError):


### PR DESCRIPTION
#1000 introduced a warning that is raised when `turbine_type` is set without setting the `reference_wind_height`, to let users know that the reference wind height had not been updated. This was pointed out by @cfrontin and also something I ran into recently while working on other aspects of the FLORIS code.

While this works as intended, the warning is now raised in some places (particularly `set_operation_model`) where the `turbine_type` is set implicitly (without direct input from the user). This pull request addresses the unnecessary warning raised by explicitly setting the `reference_wind_height` (to be the same as it was) when `set_operation_model` is called.

I've also updated some examples to add the reference wind height when the turbine model is set, as well as the `calculate_horizontal_plane_with_turbines()` function (which also implicitly sets the `turbine_type`). The following examples are updated:
- examples_turbopark/001_...py
- examples_turbine/003_...py
Note that examples_turbine/001_check_turbine.py also raises the warning; however, in that case, the warning is raised appropriately, and the `assign_hub_height_to_ref_height()` method is then called to "correct" the problem. I therefore left this example as is.

In making the fixes, I also have created a `@property` for the `reference_wind_height` at the `FlorisModel` level to make it easy for users to access.
