### PR TITLE
Test on all supported Python versions

### DIFF
--- a/.github/workflows/check-working-examples.yaml
+++ b/.github/workflows/check-working-examples.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest] #, macos-latest, windows-latest]
       fail-fast: False
 

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest] #, macos-latest, windows-latest]
       fail-fast: False
     env:

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.13"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/quality-metrics-workflow.yaml
+++ b/.github/workflows/quality-metrics-workflow.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.13"]
         os: [ubuntu-latest]
       fail-fast: False
 


### PR DESCRIPTION
In the [Python project configuration](https://github.com/NREL/floris/blob/main/setup.py#L13), FLORIS supports Python versions `>=3.8.0`. However, the automated checks through GitHub Actions are testing inconsistent and incomplete versions, as shown below.

| workflow | 3.8 | 3.9 | 3.10 | 3.11 | 3.12 | 3.13 |
| --------- | --- | --- | --- | --- | --- | --- |
| [check-working-examples](https://github.com/NREL/floris/blob/main/.github/workflows/check-working-examples.yaml) |  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |  |  |
| [continuous-integration-workflow](https://github.com/NREL/floris/blob/main/.github/workflows/continuous-integration-workflow.yaml) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |  |  |
| [deploy-pages](https://github.com/NREL/floris/blob/main/.github/workflows/deploy-pages.yaml)|  |  | :heavy_check_mark: |  |  |  |
| [quality-metrics-workflow](https://github.com/NREL/floris/blob/main/.github/workflows/quality-metrics-workflow.yaml) |  |  | :heavy_check_mark: |  |  |  |

This pull request updates these workflows to support Python v3.13 and moves the pages build and speed checks to 3.13. The version changes are captured below.

| workflow | 3.8 | 3.9 | 3.10 | 3.11 | 3.12 | 3.13 |
| --------- | --- | --- | --- | --- | --- | --- |
| [check-working-examples](https://github.com/NREL/floris/blob/main/.github/workflows/check-working-examples.yaml) | :heavy_plus_sign: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_plus_sign: | :heavy_plus_sign: |
| [continuous-integration-workflow](https://github.com/NREL/floris/blob/main/.github/workflows/continuous-integration-workflow.yaml) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_plus_sign: | :heavy_plus_sign: |
| [deploy-pages](https://github.com/NREL/floris/blob/main/.github/workflows/deploy-pages.yaml)|  |  | :heavy_minus_sign: |  |  | :heavy_plus_sign:  |
| [quality-metrics-workflow](https://github.com/NREL/floris/blob/main/.github/workflows/quality-metrics-workflow.yaml) |  |  | :heavy_minus_sign: |  |  | :heavy_plus_sign:  |

For context, testing on all supported versions helps to catch backward compatibility errors such as the lack of importing `annotations` when we use the pipe (`|`) for type hinting.