### PR TITLE
Remove testing for Mac OS for FLORIS v2

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -25,7 +25,7 @@ jobs:
         # 3.5 fails with a bad comparison in TurbineMap unit tests
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         # windows-latest fails in codecov
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
       fail-fast: False
 
     steps:


### PR DESCRIPTION
As suggested by @rafmudaf in #1008 , this PR removes Mac OS tests from the testing matrix for FLORIS v2. This will address failing tests in #1008, as well as previous PRs to v2 (e.g. #734 ).

Assuming this is fine, we can merge this PR ahead of #1008 so that tests pass on that PR prior to merger. I will then increment the version number on v2 and create a v2.5.2 release.
