### PR TITLE
Allow yaw optimization with disabled turbines

### DIFF
--- a/examples/examples_control_optimization/008_optimize_yaw_with_disabled_turbines.py
+++ b/examples/examples_control_optimization/008_optimize_yaw_with_disabled_turbines.py
@@ -11,11 +11,21 @@ from floris import FlorisModel
 from floris.optimization.yaw_optimization.yaw_optimizer_geometric import YawOptimizationGeometric
 from floris.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 
+
 # Load a 3-turbine model
 fmodel = FlorisModel("../inputs/gch.yaml")
 
 # Set wind conditions to be the same for two cases
 fmodel.set(wind_directions=[270.]*2, wind_speeds=[8.]*2, turbulence_intensities=[.06]*2)
+
+# First run the case where all turbines are active and print results
+yaw_opt = YawOptimizationSR(fmodel)
+df_opt = yaw_opt.optimize()
+print("Serial Refine optimized yaw angles (all turbines active) [deg]:\n", df_opt.yaw_angles_opt)
+
+yaw_opt = YawOptimizationGeometric(fmodel)
+df_opt = yaw_opt.optimize()
+print("\nGeometric optimized yaw angles (all turbines active) [deg]:\n", df_opt.yaw_angles_opt)
 
 # Disable turbines (different pattern for each of the two cases)
 # First case: disable the middle turbine
@@ -23,11 +33,16 @@ fmodel.set(wind_directions=[270.]*2, wind_speeds=[8.]*2, turbulence_intensities=
 fmodel.set_operation_model('mixed')
 fmodel.set(disable_turbines=np.array([[False, True, False], [True, False, False]]))
 
-# Run optimizations and print results
+# Rerun optimizations and print results
 yaw_opt = YawOptimizationSR(fmodel)
 df_opt = yaw_opt.optimize()
-print("Serial Refine optimized yaw angles [deg]:\n", df_opt.yaw_angles_opt)
+print(
+    "\nSerial Refine optimized yaw angles (some turbines disabled) [deg]:\n",
+    df_opt.yaw_angles_opt
+)
+# Note that disabled turbines may not have a zero yaw angle, because a disabled turbine's
+# yaw angle does not affect the total power output.
 
 yaw_opt = YawOptimizationGeometric(fmodel)
 df_opt = yaw_opt.optimize()
-print("\nGeometric optimized yaw angles [deg]:\n", df_opt.yaw_angles_opt)
+print("\nGeometric optimized yaw angles (some turbines disabled) [deg]:\n", df_opt.yaw_angles_opt)

--- a/examples/examples_control_optimization/008_optimize_yaw_with_disabled_turbines.py
+++ b/examples/examples_control_optimization/008_optimize_yaw_with_disabled_turbines.py
@@ -40,8 +40,8 @@ print(
     "\nSerial Refine optimized yaw angles (some turbines disabled) [deg]:\n",
     df_opt.yaw_angles_opt
 )
-# Note that disabled turbines may not have a zero yaw angle, because a disabled turbine's
-# yaw angle does not affect the total power output.
+# Note that disabled turbines are assigned a zero yaw angle, but their yaw angle is arbitrary as it
+# does not affect the total power output.
 
 yaw_opt = YawOptimizationGeometric(fmodel)
 df_opt = yaw_opt.optimize()

--- a/examples/examples_control_optimization/008_optimize_yaw_with_disabled_turbines.py
+++ b/examples/examples_control_optimization/008_optimize_yaw_with_disabled_turbines.py
@@ -1,0 +1,33 @@
+"""Example: Optimizing yaw angles with disabled turbines
+
+This example demonstrates how to optimize yaw angles in FLORIS, when some turbines are disabled.
+The example optimization is run using both YawOptimizerSR and YawOptimizerGeometric, the two
+yaw optimizers that support disabling turbines.
+"""
+
+import numpy as np
+
+from floris import FlorisModel
+from floris.optimization.yaw_optimization.yaw_optimizer_geometric import YawOptimizationGeometric
+from floris.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
+
+# Load a 3-turbine model
+fmodel = FlorisModel("../inputs/gch.yaml")
+
+# Set wind conditions to be the same for two cases
+fmodel.set(wind_directions=[270.]*2, wind_speeds=[8.]*2, turbulence_intensities=[.06]*2)
+
+# Disable turbines (different pattern for each of the two cases)
+# First case: disable the middle turbine
+# Second case: disable the front turbine
+fmodel.set_operation_model('mixed')
+fmodel.set(disable_turbines=np.array([[False, True, False], [True, False, False]]))
+
+# Run optimizations and print results
+yaw_opt = YawOptimizationSR(fmodel)
+df_opt = yaw_opt.optimize()
+print("Serial Refine optimized yaw angles [deg]:\n", df_opt.yaw_angles_opt)
+
+yaw_opt = YawOptimizationGeometric(fmodel)
+df_opt = yaw_opt.optimize()
+print("\nGeometric optimized yaw angles [deg]:\n", df_opt.yaw_angles_opt)

--- a/floris/core/turbine/operation_models.py
+++ b/floris/core/turbine/operation_models.py
@@ -382,22 +382,22 @@ class SimpleDeratingTurbine(BaseOperationModel):
 @define
 class MixedOperationTurbine(BaseOperationModel):
 
+    @staticmethod
     def power(
         yaw_angles: NDArrayFloat,
         power_setpoints: NDArrayFloat,
         **kwargs
     ):
-        # Yaw angles mask all yaw_angles not equal to zero
-        yaw_angles_mask = yaw_angles != 0.0
-        power_setpoints_mask = power_setpoints < POWER_SETPOINT_DEFAULT
-        neither_mask = np.logical_not(yaw_angles_mask) & np.logical_not(power_setpoints_mask)
-
-        if (power_setpoints_mask & yaw_angles_mask).any():
-            raise ValueError((
-                "Power setpoints and yaw angles are incompatible."
-                "If yaw_angles entry is nonzero, power_setpoints must be greater than"
-                " or equal to {0}.".format(POWER_SETPOINT_DEFAULT)
-            ))
+        (
+            yaw_angles,
+            power_setpoints,
+            yaw_angles_mask,
+            power_setpoints_mask,
+            neither_mask
+        ) = MixedOperationTurbine._handle_mixed_operation_setpoints(
+            yaw_angles=yaw_angles,
+            power_setpoints=power_setpoints
+        )
 
         powers = np.zeros_like(power_setpoints)
         powers[yaw_angles_mask] += CosineLossTurbine.power(
@@ -414,21 +414,22 @@ class MixedOperationTurbine(BaseOperationModel):
 
         return powers
 
+    @staticmethod
     def thrust_coefficient(
         yaw_angles: NDArrayFloat,
         power_setpoints: NDArrayFloat,
         **kwargs
     ):
-        yaw_angles_mask = yaw_angles != 0.0
-        power_setpoints_mask = power_setpoints < POWER_SETPOINT_DEFAULT
-        neither_mask = np.logical_not(yaw_angles_mask) & np.logical_not(power_setpoints_mask)
-
-        if (power_setpoints_mask & yaw_angles_mask).any():
-            raise ValueError((
-                "Power setpoints and yaw angles are incompatible."
-                "If yaw_angles entry is nonzero, power_setpoints must be greater than"
-                " or equal to {0}.".format(POWER_SETPOINT_DEFAULT)
-            ))
+        (
+            yaw_angles,
+            power_setpoints,
+            yaw_angles_mask,
+            power_setpoints_mask,
+            neither_mask
+        ) = MixedOperationTurbine._handle_mixed_operation_setpoints(
+            yaw_angles=yaw_angles,
+            power_setpoints=power_setpoints
+        )
 
         thrust_coefficients = np.zeros_like(power_setpoints)
         thrust_coefficients[yaw_angles_mask] += CosineLossTurbine.thrust_coefficient(
@@ -445,21 +446,22 @@ class MixedOperationTurbine(BaseOperationModel):
 
         return thrust_coefficients
 
+    @staticmethod
     def axial_induction(
         yaw_angles: NDArrayFloat,
         power_setpoints: NDArrayFloat,
         **kwargs
     ):
-        yaw_angles_mask = yaw_angles != 0.0
-        power_setpoints_mask = power_setpoints < POWER_SETPOINT_DEFAULT
-        neither_mask = np.logical_not(yaw_angles_mask) & np.logical_not(power_setpoints_mask)
-
-        if (power_setpoints_mask & yaw_angles_mask).any():
-            raise ValueError((
-                "Power setpoints and yaw angles are incompatible."
-                "If yaw_angles entry is nonzero, power_setpoints must be greater than"
-                " or equal to {0}.".format(POWER_SETPOINT_DEFAULT)
-            ))
+        (
+            yaw_angles,
+            power_setpoints,
+            yaw_angles_mask,
+            power_setpoints_mask,
+            neither_mask
+        ) = MixedOperationTurbine._handle_mixed_operation_setpoints(
+            yaw_angles=yaw_angles,
+            power_setpoints=power_setpoints
+        )
 
         axial_inductions = np.zeros_like(power_setpoints)
         axial_inductions[yaw_angles_mask] += CosineLossTurbine.axial_induction(
@@ -475,6 +477,34 @@ class MixedOperationTurbine(BaseOperationModel):
         )[neither_mask]
 
         return axial_inductions
+
+    @staticmethod
+    def _handle_mixed_operation_setpoints(
+        yaw_angles: NDArrayFloat,
+        power_setpoints: NDArrayFloat,
+    ):
+        """
+        Check for incompatible yaw angles and power setpoints and raise an error if found.
+        Return masks and updated setpoints.
+        """
+        # If any turbines are disabled, set their yaw angles to zero
+        yaw_angles[power_setpoints <= POWER_SETPOINT_DISABLED] = 0.0
+        
+        # Create masks for whether yaw angles and power setpoints are set
+        yaw_angles_mask = yaw_angles != 0.0
+        power_setpoints_mask = power_setpoints < POWER_SETPOINT_DEFAULT
+        neither_mask = np.logical_not(yaw_angles_mask) & np.logical_not(power_setpoints_mask)
+
+        # Check for incompatibility and raise error if found.
+        if (power_setpoints_mask & yaw_angles_mask).any():
+            raise ValueError((
+                "Power setpoints and yaw angles are incompatible."
+                "If yaw_angles entry is nonzero, power_setpoints must be greater than"
+                " or equal to {0}.".format(POWER_SETPOINT_DEFAULT)
+            ))
+        
+        # Return updated setpoints as well as masks
+        return yaw_angles, power_setpoints, yaw_angles_mask, power_setpoints_mask, neither_mask
 
 @define
 class AWCTurbine(BaseOperationModel):

--- a/floris/core/turbine/operation_models.py
+++ b/floris/core/turbine/operation_models.py
@@ -489,7 +489,7 @@ class MixedOperationTurbine(BaseOperationModel):
         """
         # If any turbines are disabled, set their yaw angles to zero
         yaw_angles[power_setpoints <= POWER_SETPOINT_DISABLED] = 0.0
-        
+
         # Create masks for whether yaw angles and power setpoints are set
         yaw_angles_mask = yaw_angles != 0.0
         power_setpoints_mask = power_setpoints < POWER_SETPOINT_DEFAULT
@@ -502,7 +502,7 @@ class MixedOperationTurbine(BaseOperationModel):
                 "If yaw_angles entry is nonzero, power_setpoints must be greater than"
                 " or equal to {0}.".format(POWER_SETPOINT_DEFAULT)
             ))
-        
+
         # Return updated setpoints as well as masks
         return yaw_angles, power_setpoints, yaw_angles_mask, power_setpoints_mask, neither_mask
 

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -453,10 +453,7 @@ class FlorisModel(LoggingManager):
         # previous setting
         if not (_yaw_angles == 0).all():
             self.core.farm.set_yaw_angles(_yaw_angles)
-        if not (
-            (_power_setpoints == POWER_SETPOINT_DEFAULT)
-            | (_power_setpoints == POWER_SETPOINT_DISABLED)
-        ).all():
+        if not (_power_setpoints == POWER_SETPOINT_DEFAULT).all():
             self.core.farm.set_power_setpoints(_power_setpoints)
         if _awc_modes is not None:
             self.core.farm.set_awc_modes(_awc_modes)

--- a/floris/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/optimization/yaw_optimization/yaw_optimization_base.py
@@ -5,6 +5,7 @@ from time import perf_counter as timerpc
 import numpy as np
 import pandas as pd
 
+from floris.core.turbine.operation_models import POWER_SETPOINT_DISABLED
 from floris.logging_manager import LoggingManager
 
 from .yaw_optimization_tools import derive_downstream_turbines
@@ -130,6 +131,11 @@ class YawOptimization(LoggingManager):
         # Set optimization bounds
         self.minimum_yaw_angle = self._unpack_variable(minimum_yaw_angle)
         self.maximum_yaw_angle = self._unpack_variable(maximum_yaw_angle)
+
+        # Limit yaw angles to zero for disabled turbines
+        active_turbines = fmodel.core.farm.power_setpoints > POWER_SETPOINT_DISABLED
+        self.minimum_yaw_angle[~active_turbines] = 0.0
+        self.maximum_yaw_angle[~active_turbines] = 0.0
 
         # Set initial condition for optimization
         if x0 is not None:

--- a/floris/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/optimization/yaw_optimization/yaw_optimization_base.py
@@ -99,7 +99,7 @@ class YawOptimization(LoggingManager):
         """
 
         # Save turbine object to self
-        self.fmodel = fmodel.copy()
+        self.fmodel = copy.deepcopy(fmodel)
         self.nturbs = len(self.fmodel.layout_x)
 
         # # Check floris options
@@ -224,7 +224,7 @@ class YawOptimization(LoggingManager):
         self.turbs_to_opt = (self.maximum_yaw_angle - self.minimum_yaw_angle >= 0.001)
 
         # Initialize subset variables as full set
-        self.fmodel_subset = self.fmodel.copy()
+        self.fmodel_subset = copy.deepcopy(self.fmodel)
         n_findex_subset = copy.deepcopy(self.fmodel.core.flow_field.n_findex)
         minimum_yaw_angle_subset = copy.deepcopy(self.minimum_yaw_angle)
         maximum_yaw_angle_subset = copy.deepcopy(self.maximum_yaw_angle)
@@ -301,6 +301,7 @@ class YawOptimization(LoggingManager):
             ti_array=None,
             turbine_weights=None,
             heterogeneous_speed_multipliers=None,
+            power_setpoints=None,
         ):
         """
         Calculate the wind farm power production assuming the predefined
@@ -353,6 +354,7 @@ class YawOptimization(LoggingManager):
             wind_speeds=ws_array,
             turbulence_intensities=ti_array,
             yaw_angles=yaw_angles,
+            power_setpoints=power_setpoints,
         )
         fmodel_subset.run()
         turbine_power = fmodel_subset.get_turbine_powers()

--- a/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
+++ b/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
@@ -1,6 +1,7 @@
 
 import numpy as np
 
+from floris.core.turbine.operation_models import POWER_SETPOINT_DISABLED
 from floris.utilities import rotate_coordinates_rel_west
 
 from .yaw_optimization_base import YawOptimization
@@ -46,10 +47,11 @@ class YawOptimizationGeometric(YawOptimization):
         # Loop through every WD individually. WS ignored!
         wd_array = self.fmodel_subset.core.flow_field.wind_directions
 
+        active_turbines = self.fmodel_subset.core.farm.power_setpoints > POWER_SETPOINT_DISABLED
         for nwdi, wd in enumerate(wd_array):
-            self._yaw_angles_opt_subset[nwdi, :] = geometric_yaw(
-                self.fmodel_subset.layout_x,
-                self.fmodel_subset.layout_y,
+            self._yaw_angles_opt_subset[nwdi, active_turbines[nwdi]] = geometric_yaw(
+                self.fmodel_subset.layout_x[active_turbines[nwdi]],
+                self.fmodel_subset.layout_y[active_turbines[nwdi]],
                 wd,
                 self.fmodel.core.farm.turbine_definitions[0]["rotor_diameter"],
                 top_left_yaw_upper=self.maximum_yaw_angle[0, 0],

--- a/floris/optimization/yaw_optimization/yaw_optimizer_scipy.py
+++ b/floris/optimization/yaw_optimization/yaw_optimizer_scipy.py
@@ -30,6 +30,12 @@ class YawOptimizationScipy(YawOptimization):
         Instantiate YawOptimizationScipy object with a FlorisModel object
         and assign parameter values.
         """
+        valid_op_models = ["cosine-loss"]
+        if fmodel.get_operation_model() not in valid_op_models:
+            raise ValueError(
+                "YawOptimizationScipy is currently limited to the following operation models: "
+                + ", ".join(valid_op_models)
+            )
         if opt_options is None:
             # Default SciPy parameters
             opt_options = {

--- a/floris/optimization/yaw_optimization/yaw_optimizer_sr.py
+++ b/floris/optimization/yaw_optimization/yaw_optimizer_sr.py
@@ -93,6 +93,7 @@ class YawOptimizationSR(YawOptimization, LoggingManager):
         wd_array_subset = self.fmodel_subset.core.flow_field.wind_directions
         ws_array_subset = self.fmodel_subset.core.flow_field.wind_speeds
         ti_array_subset = self.fmodel_subset.core.flow_field.turbulence_intensities
+        power_setpoints_subset = self.fmodel_subset.core.farm.power_setpoints
         turbine_weights_subset = self._turbine_weights_subset
 
         # Reformat yaw_angles_subset, if necessary
@@ -108,6 +109,7 @@ class YawOptimizationSR(YawOptimization, LoggingManager):
             wd_array_subset = np.tile(wd_array_subset, Ny)
             ws_array_subset = np.tile(ws_array_subset, Ny)
             ti_array_subset = np.tile(ti_array_subset, Ny)
+            power_setpoints_subset = np.tile(power_setpoints_subset, (Ny, 1))
             turbine_weights_subset = np.tile(turbine_weights_subset, (Ny, 1))
 
         # Initialize empty matrix for floris farm power outputs
@@ -143,6 +145,7 @@ class YawOptimizationSR(YawOptimization, LoggingManager):
                 ti_array=ti_array_subset[~idx],
                 turbine_weights=turbine_weights_subset[~idx, :],
                 yaw_angles=yaw_angles_subset[~idx, :],
+                power_setpoints=power_setpoints_subset[~idx, :],
                 heterogeneous_speed_multipliers=het_sm
             )
             self.time_spent_in_floris += (timerpc() - start_time)

--- a/floris/optimization/yaw_optimization/yaw_optimizer_sr.py
+++ b/floris/optimization/yaw_optimization/yaw_optimizer_sr.py
@@ -145,8 +145,8 @@ class YawOptimizationSR(YawOptimization, LoggingManager):
                 ti_array=ti_array_subset[~idx],
                 turbine_weights=turbine_weights_subset[~idx, :],
                 yaw_angles=yaw_angles_subset[~idx, :],
+                heterogeneous_speed_multipliers=het_sm,
                 power_setpoints=power_setpoints_subset[~idx, :],
-                heterogeneous_speed_multipliers=het_sm
             )
             self.time_spent_in_floris += (timerpc() - start_time)
 

--- a/tests/floris_model_integration_test.py
+++ b/tests/floris_model_integration_test.py
@@ -10,7 +10,7 @@ from floris import (
     TimeSeries,
     WindRose,
 )
-from floris.core.turbine.operation_models import POWER_SETPOINT_DEFAULT
+from floris.core.turbine.operation_models import POWER_SETPOINT_DEFAULT, POWER_SETPOINT_DISABLED
 
 
 TEST_DATA = Path(__file__).resolve().parent / "data"
@@ -44,7 +44,24 @@ def test_assign_setpoints():
 
     # power_setpoints and disable_turbines (disable_turbines overrides power_setpoints)
     fmodel.set(power_setpoints=[[1e6, 2e6]], disable_turbines=[[True, False]])
-    assert np.allclose(fmodel.core.farm.power_setpoints, np.array([[0.001, 2e6]]))
+    assert np.allclose(fmodel.core.farm.power_setpoints, np.array([[POWER_SETPOINT_DISABLED, 2e6]]))
+
+    # Setting sequentially is equivalent to setting together
+    fmodel.reset_operation()
+    fmodel.set(disable_turbines=[[True, False]])
+    fmodel.set(yaw_angles=[[0, 30]])
+    assert np.allclose(
+        fmodel.core.farm.power_setpoints,
+        np.array([[POWER_SETPOINT_DISABLED, POWER_SETPOINT_DEFAULT]])
+    )
+    assert np.allclose(fmodel.core.farm.yaw_angles, np.array([[0, 30]]))
+
+    fmodel.set(disable_turbines=[[True, False]], yaw_angles=[[0, 30]])
+    assert np.allclose(
+        fmodel.core.farm.power_setpoints,
+        np.array([[POWER_SETPOINT_DISABLED, POWER_SETPOINT_DEFAULT]])
+    )
+    assert np.allclose(fmodel.core.farm.yaw_angles, np.array([[0, 30]]))
 
 def test_set_run():
     """

--- a/tests/geometric_yaw_unit_test.py
+++ b/tests/geometric_yaw_unit_test.py
@@ -1,0 +1,103 @@
+
+import numpy as np
+import pandas as pd
+
+from floris import FlorisModel
+from floris.optimization.yaw_optimization.yaw_optimizer_geometric import YawOptimizationGeometric
+
+
+DEBUG = False
+VELOCITY_MODEL = "gauss"
+DEFLECTION_MODEL = "gauss"
+
+# Inputs for basic yaw optimizations
+WIND_DIRECTIONS = [0.0, 90.0, 180.0, 270.0]
+WIND_SPEEDS = [8.0] * 4
+TURBULENCE_INTENSITIES = [0.06] * 4
+LAYOUT_X = [0.0, 600.0, 1200.0]
+LAYOUT_Y = [0.0, 0.0, 0.0]
+MAXIMUM_YAW_ANGLE = 25.0
+
+def test_basic_optimization(sample_inputs_fixture):
+    """
+    The Serial Refine (SR) method optimizes yaw angles based on a sequential, iterative yaw
+    optimization scheme. This test checks basic properties of the optimization result.
+    """
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    fmodel = FlorisModel(sample_inputs_fixture.core)
+
+    fmodel.set(
+        layout_x=LAYOUT_X,
+        layout_y=LAYOUT_Y,
+        wind_directions=WIND_DIRECTIONS,
+        wind_speeds=WIND_SPEEDS,
+        turbulence_intensities=TURBULENCE_INTENSITIES
+    )
+    fmodel.set_operation_model("cosine-loss")
+
+    yaw_opt = YawOptimizationGeometric(fmodel, minimum_yaw_angle=0.0, maximum_yaw_angle=MAXIMUM_YAW_ANGLE)
+    df_opt = yaw_opt.optimize()
+
+    # Unaligned conditions
+    assert np.allclose(df_opt.loc[0, "yaw_angles_opt"], 0.0)
+    assert np.allclose(df_opt.loc[2, "yaw_angles_opt"], 0.0)
+
+    # Check aligned conditions
+    # Check maximum and minimum are respected
+    assert (df_opt.loc[1, "yaw_angles_opt"] <= MAXIMUM_YAW_ANGLE).all()
+    assert (df_opt.loc[3, "yaw_angles_opt"] <= MAXIMUM_YAW_ANGLE).all()
+    assert (df_opt.loc[1, "yaw_angles_opt"] >= 0.0).all()
+    assert (df_opt.loc[3, "yaw_angles_opt"] >= 0.0).all()
+
+    # Check 90.0 and 270.0 are symmetric
+    assert np.allclose(df_opt.loc[1, "yaw_angles_opt"], np.flip(df_opt.loc[3, "yaw_angles_opt"]))
+
+    # Check last turbine's angles are zero at 270.0
+    assert np.allclose(df_opt.loc[3, "yaw_angles_opt"][-1], 0.0)
+
+    # YawOptimizationGeometric does not compute farm powers
+
+def test_disabled_turbines(sample_inputs_fixture):
+    """
+    Tests SR when some turbines are disabled and checks that the results are equivalent to removing
+    those turbines from the wind farm. Need a tight layout to ensure that the front-to-back distance
+    is not too large.
+    """
+
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    fmodel = FlorisModel(sample_inputs_fixture.core)
+
+    fmodel.set(
+        layout_x=LAYOUT_X,
+        layout_y=LAYOUT_Y,
+        wind_directions=WIND_DIRECTIONS,
+        wind_speeds=WIND_SPEEDS,
+        turbulence_intensities=TURBULENCE_INTENSITIES
+    )
+    fmodel.set_operation_model("mixed")
+
+    # Disable the middle turbine in all wind conditions, run optimization, and extract results
+    fmodel.set(disable_turbines=[[False, True, False]]*4)
+    yaw_opt = YawOptimizationGeometric(fmodel, minimum_yaw_angle=0.0, maximum_yaw_angle=MAXIMUM_YAW_ANGLE)
+    df_opt = yaw_opt.optimize()
+    yaw_angles_opt_disabled = df_opt.loc[3, "yaw_angles_opt"]
+
+    # Set up a new wind farm with the middle turbine removed
+    fmodel = FlorisModel(sample_inputs_fixture.core)
+    fmodel.set(
+        layout_x=np.array(LAYOUT_X)[[0, 2]],
+        layout_y=np.array(LAYOUT_Y)[[0, 2]],
+        wind_directions=WIND_DIRECTIONS,
+        wind_speeds=WIND_SPEEDS,
+        turbulence_intensities=TURBULENCE_INTENSITIES
+    )
+    fmodel.set_operation_model("cosine-loss")
+    yaw_opt = YawOptimizationGeometric(fmodel, minimum_yaw_angle=0.0, maximum_yaw_angle=MAXIMUM_YAW_ANGLE)
+    df_opt = yaw_opt.optimize()
+    yaw_angles_opt_removed = df_opt.loc[3, "yaw_angles_opt"]
+
+    assert np.allclose(yaw_angles_opt_disabled[[0, 2]], yaw_angles_opt_removed)

--- a/tests/geometric_yaw_unit_test.py
+++ b/tests/geometric_yaw_unit_test.py
@@ -37,7 +37,11 @@ def test_basic_optimization(sample_inputs_fixture):
     )
     fmodel.set_operation_model("cosine-loss")
 
-    yaw_opt = YawOptimizationGeometric(fmodel, minimum_yaw_angle=0.0, maximum_yaw_angle=MAXIMUM_YAW_ANGLE)
+    yaw_opt = YawOptimizationGeometric(
+        fmodel,
+        minimum_yaw_angle=0.0,
+        maximum_yaw_angle=MAXIMUM_YAW_ANGLE
+    )
     df_opt = yaw_opt.optimize()
 
     # Unaligned conditions
@@ -82,7 +86,11 @@ def test_disabled_turbines(sample_inputs_fixture):
 
     # Disable the middle turbine in all wind conditions, run optimization, and extract results
     fmodel.set(disable_turbines=[[False, True, False]]*4)
-    yaw_opt = YawOptimizationGeometric(fmodel, minimum_yaw_angle=0.0, maximum_yaw_angle=MAXIMUM_YAW_ANGLE)
+    yaw_opt = YawOptimizationGeometric(
+        fmodel,
+        minimum_yaw_angle=0.0,
+        maximum_yaw_angle=MAXIMUM_YAW_ANGLE
+    )
     df_opt = yaw_opt.optimize()
     yaw_angles_opt_disabled = df_opt.loc[3, "yaw_angles_opt"]
 
@@ -96,7 +104,11 @@ def test_disabled_turbines(sample_inputs_fixture):
         turbulence_intensities=TURBULENCE_INTENSITIES
     )
     fmodel.set_operation_model("cosine-loss")
-    yaw_opt = YawOptimizationGeometric(fmodel, minimum_yaw_angle=0.0, maximum_yaw_angle=MAXIMUM_YAW_ANGLE)
+    yaw_opt = YawOptimizationGeometric(
+        fmodel,
+        minimum_yaw_angle=0.0,
+        maximum_yaw_angle=MAXIMUM_YAW_ANGLE
+    )
     df_opt = yaw_opt.optimize()
     yaw_angles_opt_removed = df_opt.loc[3, "yaw_angles_opt"]
 

--- a/tests/serial_refine_unit_test.py
+++ b/tests/serial_refine_unit_test.py
@@ -1,0 +1,107 @@
+
+import numpy as np
+import pandas as pd
+
+from floris import FlorisModel
+from floris.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
+
+
+DEBUG = False
+VELOCITY_MODEL = "gauss"
+DEFLECTION_MODEL = "gauss"
+
+# Inputs for basic yaw optimizations
+WIND_DIRECTIONS = [0.0, 90.0, 180.0, 270.0]
+WIND_SPEEDS = [8.0] * 4
+TURBULENCE_INTENSITIES = [0.06] * 4
+LAYOUT_X = [0.0, 600.0, 1200.0]
+LAYOUT_Y = [0.0, 0.0, 0.0]
+MAXIMUM_YAW_ANGLE = 25.0
+
+def test_basic_optimization(sample_inputs_fixture):
+    """
+    The Serial Refine (SR) method optimizes yaw angles based on a sequential, iterative yaw
+    optimization scheme. This test checks basic properties of the optimization result.
+    """
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    fmodel = FlorisModel(sample_inputs_fixture.core)
+
+    fmodel.set(
+        layout_x=LAYOUT_X,
+        layout_y=LAYOUT_Y,
+        wind_directions=WIND_DIRECTIONS,
+        wind_speeds=WIND_SPEEDS,
+        turbulence_intensities=TURBULENCE_INTENSITIES
+    )
+    fmodel.set_operation_model("cosine-loss")
+
+    yaw_opt = YawOptimizationSR(fmodel, minimum_yaw_angle=0.0, maximum_yaw_angle=MAXIMUM_YAW_ANGLE)
+    df_opt = yaw_opt.optimize()
+
+    # Unaligned conditions
+    assert np.allclose(df_opt.loc[0, "yaw_angles_opt"], 0.0)
+    assert np.allclose(df_opt.loc[2, "yaw_angles_opt"], 0.0)
+
+    # Check aligned conditions
+    # Check maximum and minimum are respected
+    assert (df_opt.loc[1, "yaw_angles_opt"] <= MAXIMUM_YAW_ANGLE).all()
+    assert (df_opt.loc[3, "yaw_angles_opt"] <= MAXIMUM_YAW_ANGLE).all()
+    assert (df_opt.loc[1, "yaw_angles_opt"] >= 0.0).all()
+    assert (df_opt.loc[3, "yaw_angles_opt"] >= 0.0).all()
+
+    # Check 90.0 and 270.0 are symmetric
+    assert np.allclose(df_opt.loc[1, "yaw_angles_opt"], np.flip(df_opt.loc[3, "yaw_angles_opt"]))
+
+    # Check last turbine's angles are zero at 270.0
+    assert np.allclose(df_opt.loc[3, "yaw_angles_opt"][-1], 0.0)
+
+    # Check that optimizer reports a power improvement
+    assert (df_opt["farm_power_opt"] >= df_opt["farm_power_baseline"]).all()
+
+def test_disabled_turbines(sample_inputs_fixture):
+    """
+    Tests SR when some turbines are disabled and checks that the results are equivalent to removing
+    those turbines from the wind farm. Need a tight layout to ensure that the front-to-back distance
+    is not too large.
+    """
+
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    fmodel = FlorisModel(sample_inputs_fixture.core)
+
+    fmodel.set(
+        layout_x=LAYOUT_X,
+        layout_y=LAYOUT_Y,
+        wind_directions=WIND_DIRECTIONS,
+        wind_speeds=WIND_SPEEDS,
+        turbulence_intensities=TURBULENCE_INTENSITIES
+    )
+    fmodel.set_operation_model("mixed")
+
+    # Disable the middle turbine in all wind conditions, run optimization, and extract results
+    fmodel.set(disable_turbines=[[False, True, False]]*4)
+    yaw_opt = YawOptimizationSR(fmodel, minimum_yaw_angle=0.0, maximum_yaw_angle=MAXIMUM_YAW_ANGLE)
+    df_opt = yaw_opt.optimize()
+    yaw_angles_opt_disabled = df_opt.loc[3, "yaw_angles_opt"]
+    farm_power_opt_disabled = df_opt.loc[3, "farm_power_opt"]
+
+    # Set up a new wind farm with the middle turbine removed
+    fmodel = FlorisModel(sample_inputs_fixture.core)
+    fmodel.set(
+        layout_x=np.array(LAYOUT_X)[[0, 2]],
+        layout_y=np.array(LAYOUT_Y)[[0, 2]],
+        wind_directions=WIND_DIRECTIONS,
+        wind_speeds=WIND_SPEEDS,
+        turbulence_intensities=TURBULENCE_INTENSITIES
+    )
+    fmodel.set_operation_model("cosine-loss")
+    yaw_opt = YawOptimizationSR(fmodel, minimum_yaw_angle=0.0, maximum_yaw_angle=MAXIMUM_YAW_ANGLE)
+    df_opt = yaw_opt.optimize()
+    yaw_angles_opt_removed = df_opt.loc[3, "yaw_angles_opt"]
+    farm_power_opt_removed = df_opt.loc[3, "farm_power_opt"]
+
+    assert np.allclose(yaw_angles_opt_disabled[[0, 2]], yaw_angles_opt_removed)
+    assert np.allclose(farm_power_opt_disabled, farm_power_opt_removed)


### PR DESCRIPTION
In #1016, @MiguelMarante raised the issue that the Serial Refine yaw optimizer ignores that some turbines are disabled. I converted this to an issue in #1022 . 

This pull request enables that behavior, both for the Serial Refine routine as well as the Geometric yaw optimizer. Note that yaw optimization using Scipy is still not supported for the `"mixed-operation"` model (I looked into enabling this as well, but this will take more time and is not the priority).

### Affected areas of the code
In making the necessary changes to the yaw optimization routines, I also had to make the following changes:
- floris/floris_model.py: `FlorisModel.set()` was incorrectly treating lower power setpoints as though they were the default, which caused them to be ignored and reset when `set()` is called again. This was introduced in #823 by an erroneous commit of mine, a00bff8. This bug meant that calling `set(disabled_turbines=[...])` followed by any other `set()` call would _drop_ the information about disabling turbines.
- floris/core/turbine/operation_models.py: Clean up of the `MixedOperationModel` to work better with yaw optimization.

I've also added a new example, examples/examples_control_optimization/008_....py, which is based heavily on @MiguelMarante 's example script in #1016.

### Notes
In the yaw optimization routines, the solution involves passing `power_setpoints` through from the users `fmodel` to the `fmodel_subset` attributes on the yaw optimization routines. While this works fine, it is yet another example of where control setpoints have to be piped through various pieces of the FLORIS code. To enable other setpoints to be used while optimizing yaw, this process will have to be repeated. We could consider moving to some sort of high-level data structure (possible just a dictionary) for the control setpoints, so that they can be lumped together and passed through the FLORIS code more readily.

### Results
Running the new example produces (removing the progress output from Serial Refine):
```
Serial Refine optimized yaw angles (all turbines active) [deg]:
 0    [25.0, 22.65625, 0.0]
1    [25.0, 22.65625, 0.0]
Name: yaw_angles_opt, dtype: object

Geometric optimized yaw angles (all turbines active) [deg]:
 0    [19.9952335557674, 19.9952335557674, 0.0]
1    [19.9952335557674, 19.9952335557674, 0.0]
Name: yaw_angles_opt, dtype: object

Serial Refine optimized yaw angles (some turbines disabled) [deg]:
 0    [20.3125, 0.0, 0.0]
1      [0.0, 25.0, 0.0]
Name: yaw_angles_opt, dtype: object

Geometric optimized yaw angles (some turbines disabled) [deg]:
 0    [14.990467111534794, 0.0, 0.0]
1      [0.0, 19.9952335557674, 0.0]
```
which is in line with expectations, see #1022.

