### PR TITLE
[BUGFIX] Reenable legend plotting on WindRose

### DIFF
--- a/floris/wind_data.py
+++ b/floris/wind_data.py
@@ -779,8 +779,12 @@ class WindRose(WindDataBase):
                 )
 
         # Configure the plot
-        ax.figure.colorbar(sm_ws, ax=ax, **legend_kwargs)
-        ax.figure.tight_layout()
+        try:
+           ax.figure.colorbar(sm_ws, ax=ax, **legend_kwargs)
+           ax.figure.tight_layout()
+        except TypeError:
+           ax.legend(reversed(rects), ws_bins, **legend_kwargs)
+           ax.figure.get_children()[-1].remove() # Remove the empty colorbar
         ax.set_theta_direction(-1)
         ax.set_theta_offset(np.pi / 2.0)
         ax.set_theta_zero_location("N")
@@ -1822,8 +1826,12 @@ class WindTIRose(WindDataBase):
                 )
 
         # Configure the plot
-        ax.figure.colorbar(sm_wv, ax=ax, **legend_kwargs)
-        ax.figure.tight_layout()
+        try:
+            ax.figure.colorbar(sm_wv, ax=ax, **legend_kwargs)
+            ax.figure.tight_layout()
+        except TypeError:
+            ax.legend(reversed(rects), var_bins, **legend_kwargs)
+            ax.figure.get_children()[-1].remove() # Remove the empty colorbar
         ax.set_theta_direction(-1)
         ax.set_theta_offset(np.pi / 2.0)
         ax.set_theta_zero_location("N")


### PR DESCRIPTION
As discussed in #1023 , #969 introduced a breaking change to the `.plot()` method on `WindRose` and `WindTIRose` (this was also noted in #969's discussion at the time).

This PR uses a `try`/`except` structure to first try plotting with a colorbar, as introduced in #969, but reverts to the original legend plot if the colorbar plotting fails.

To test this functionality, try using `"title"` instead of `"label"` as one of the keys to the `legend_kwargs` argument to `WindRose.plot()` (for instance, [here](https://github.com/NREL/floris/blob/de37a374cff6e67808d4d2c716c8cf70751c60b2/examples/examples_wind_data/001_wind_data_comparisons.py#L67)).
