### PR TITLE
Fix docs

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.13"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.13"
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -2,10 +2,10 @@ name: deploy-pages
 
 on:
   push:
-    branches:
-    - develop
-    paths:
-    - docs/**
+    # branches:
+    # - develop
+    # paths:
+    # - docs/**
 
 # This job installs dependencies, builds the book, and pushes it to `gh-pages`
 jobs:
@@ -50,8 +50,8 @@ jobs:
         jupyter-book build .
 
     # Push the book's HTML to github-pages
-    - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/_build/html
+    # - name: GitHub Pages action
+    #   uses: peaceiris/actions-gh-pages@v3.6.1
+    #   with:
+    #     github_token: ${{ secrets.GITHUB_TOKEN }}
+    #     publish_dir: ./docs/_build/html

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -2,10 +2,10 @@ name: deploy-pages
 
 on:
   push:
-    # branches:
-    # - develop
-    # paths:
-    # - docs/**
+    branches:
+    - develop
+    paths:
+    - docs/**
 
 # This job installs dependencies, builds the book, and pushes it to `gh-pages`
 jobs:
@@ -50,8 +50,8 @@ jobs:
         jupyter-book build .
 
     # Push the book's HTML to github-pages
-    # - name: GitHub Pages action
-    #   uses: peaceiris/actions-gh-pages@v3.6.1
-    #   with:
-    #     github_token: ${{ secrets.GITHUB_TOKEN }}
-    #     publish_dir: ./docs/_build/html
+    - name: GitHub Pages action
+      uses: peaceiris/actions-gh-pages@v3.6.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/_build/html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ docs = [
     "jupyter-book",
     "sphinx-book-theme",
     "sphinx-autodoc-typehints",
-    "sphinxcontrib-autoyaml",
+    "sphinxcontrib-autoyaml==1.1.1",
     "sphinxcontrib.mermaid",
 ]
 develop = [

--- a/tests/wind_data_integration_test.py
+++ b/tests/wind_data_integration_test.py
@@ -893,6 +893,7 @@ def test_wind_ti_rose_aggregate():
     np.testing.assert_allclose(wind_rose.wind_speeds, wind_rose_2.wind_speeds)
     np.testing.assert_allclose(wind_rose.turbulence_intensities, wind_rose_2.turbulence_intensities)
 
+    wind_rose_2 = copy.deepcopy(wind_rose)
     wind_rose_2.downsample(ti_step=0.04, inplace=True)
     np.testing.assert_allclose(
         wind_rose_aggregate.turbulence_intensities, wind_rose_2.turbulence_intensities


### PR DESCRIPTION
# Fix docs

Recently the documentation failed to build:

https://github.com/NREL/floris/actions/runs/11938591041

I believe I've traced the issue to the recent version bump of autoyaml to 1.1.2.  Locally at least, pinning to 1.1.1 resolves the issue.  I've also posted a question as an issue here:

https://github.com/Jakski/sphinxcontrib-autoyaml/issues/26

I think the PR should fix it in github actions as well.  Then also:

- ~I set back python to 3.10 for building docs as this has worked in the past~
- Fix a minor test issue that came up in the course of this.

