### PR TITLE
Add versions to optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,17 +42,17 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-    "jupyter-book",
-    "sphinx-book-theme",
-    "sphinx-autodoc-typehints",
-    "sphinxcontrib-autoyaml==1.1.1",
-    "sphinxcontrib.mermaid",
+    "jupyter-book~=1.0",
+    "sphinx-book-theme~=1.0",
+    "sphinx-autodoc-typehints~=2.0",
+    "sphinxcontrib-autoyaml~=1.0",
+    "sphinxcontrib.mermaid~=1.0",
 ]
 develop = [
-    "pytest",
-    "pre-commit",
-    "ruff",
-    "isort"
+    "pytest~=8.0",
+    "pre-commit~=4.0",
+    "ruff~=0.7",
+    "isort~=5.0"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This small pull request does two things:

1) Removes the pin on autoyaml put in place in #1034 now that the issue is resolved (see https://github.com/Jakski/sphinxcontrib-autoyaml/issues/26)

  -- Confirm docs build locally

2) Adds versions to optional dependencies as a partial guard against future major version jumps (wouldn't have helped here but good practice!)

