### PR TITLE
Support initializing FLORIS with default values

### DIFF
--- a/docs/advanced_concepts.ipynb
+++ b/docs/advanced_concepts.ipynb
@@ -96,15 +96,92 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## FLORIS as a library\n",
+    "\n",
+    "FLORIS is commonly used as a library in other software packages.\n",
+    "In cases where the calling-code will create inputs for FLORIS rather than require them from the\n",
+    "user, it can be helpful to initialize the FLORIS model with default inputs and then\n",
+    "change them in code.\n",
+    "In this case, the following workflow is recommended."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import floris\n",
+    "\n",
+    "# Initialize FLORIS with defaults\n",
+    "fmodel = floris.FlorisModel(\"defaults\")\n",
+    "\n",
+    "# Within the calling-code's setup step, update FLORIS as needed\n",
+    "fmodel.set(\n",
+    "    wind_directions=[i for i in range(10)],\n",
+    "    wind_speeds=[5 + i for i in range(10)],\n",
+    "    turbulence_intensities=[i for i in range(10)],\n",
+    "    # turbine_library_path=\"path/to/turbine_library\",   # Shown here for reference\n",
+    "    # turbine_type=[\"my_turbine\"]\n",
+    ")\n",
+    "\n",
+    "# Within the calling code's computation, run FLORIS\n",
+    "fmodel.run()"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "Alternatively, the calling-code can import the FLORIS default inputs as a Python dictionary\n",
+    "and modify them directly before initializing the FLORIS model.\n",
+    "This is especially helpful when the calling-code will modify a parameter that isn't\n",
+    "supported by the `FlorisModel.set(...)` command.\n",
+    "In particular, the wake model parameters are not directly accessible, so these can be updated\n",
+    "externally, as shown below.\n",
+    "Note that the `FlorisModel.get_defaults()` function returns a deep copy of the default inputs,\n",
+    "so these can be modified directly without side effects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import floris\n",
+    "\n",
+    "# Retrieve the default parameters\n",
+    "fdefaults = floris.FlorisModel.get_defaults()\n",
+    "\n",
+    "# Update wake model parameters\n",
+    "fdefaults[\"wake\"][\"model_strings\"][\"velocity_model\"] = \"jensen\"\n",
+    "fdefaults[\"wake\"][\"wake_velocity_parameters\"][\"jensen\"][\"we\"] = 0.05\n",
+    "\n",
+    "# Initialize FLORIS with modified parameters\n",
+    "fmodel = floris.FlorisModel(configuration=fdefaults)\n",
+    "\n",
+    "# Within the calling-code's setup step, update FLORIS as needed\n",
+    "fmodel.set(\n",
+    "    wind_directions=[i for i in range(10)],\n",
+    "    wind_speeds=[5 + i for i in range(10)],\n",
+    "    turbulence_intensities=[i for i in range(10)],\n",
+    "    # turbine_library_path=\"path/to/turbine_library\",   # Shown here for reference\n",
+    "    # turbine_type=[\"my_turbine\"]\n",
+    ")\n",
+    "\n",
+    "# Within the calling code's computation, run FLORIS\n",
+    "fmodel.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/floris/default_inputs.py
+++ b/floris/default_inputs.py
@@ -1,0 +1,131 @@
+
+default_inputs = {
+    "name": "FLORIS defaults",
+    "description": "Gauss-Curl hybrid model (GCH), 1 turbine, 8 m/s, 270 deg, 10% TI",
+    "floris_version": "v4",
+
+    "logging": {
+        "console": {
+            "enable": "true",
+            "level": "WARNING"
+        },
+        "file": {
+            "enable": "false",
+            "level": "WARNING"
+        },
+    },
+
+    "solver": {
+        "type": "turbine_grid",
+        "turbine_grid_points": 3
+    },
+
+    "farm": {
+        "layout_x": [0.0],
+        "layout_y": [0.0],
+        "turbine_type": ["nrel_5MW"]
+    },
+
+    "flow_field": {
+        "air_density": 1.225,
+        "reference_wind_height": -1,
+        "turbulence_intensities": [0.06],
+        "wind_directions": [270.0],
+        "wind_shear": 0.12,
+        "wind_speeds": [8.0],
+        "wind_veer": 0.0,
+        "multidim_conditions": {
+            "Tp": 2.5,
+            "Hs": 3.01
+        }
+    },
+
+    "wake": {
+        "model_strings": {
+            "velocity_model": "gauss",
+            "deflection_model": "gauss",
+            "combination_model": "sosfs",
+            "turbulence_model": "crespo_hernandez",
+        },
+
+        "enable_secondary_steering": True,
+        "enable_yaw_added_recovery": True,
+        "enable_active_wake_mixing": False,
+        "enable_transverse_velocities": True,
+
+        "wake_deflection_parameters": {
+            "gauss": {
+                "ad": 0.0,
+                "alpha": 0.58,
+                "bd": 0.0,
+                "beta": 0.077,
+                "dm": 1.0,
+                "ka": 0.38,
+                "kb": 0.004
+            },
+            "jimenez": {
+                "ad": 0.0,
+                "bd": 0.0,
+                "kd": 0.05,
+            },
+            "empirical_gauss": {
+                "horizontal_deflection_gain_D": 3.0,
+                "vertical_deflection_gain_D": -1,
+                "deflection_rate": 22,
+                "mixing_gain_deflection": 0.0,
+                "yaw_added_mixing_gain": 0.0
+            },
+        },
+
+        "wake_velocity_parameters": {
+            "gauss": {
+                "alpha": 0.58,
+                "beta": 0.077,
+                "ka": 0.38,
+                "kb": 0.004
+            },
+            "jensen": {
+                "we": 0.05,
+            },
+            "cc": {
+                "a_s": 0.179367259,
+                "b_s": 0.0118889215,
+                "c_s1": 0.0563691592,
+                "c_s2": 0.13290157,
+                "a_f": 3.11,
+                "b_f": -0.68,
+                "c_f": 2.41,
+                "alpha_mod": 1.0
+            },
+            "turbopark": {
+                "A": 0.04,
+                "sigma_max_rel": 4.0
+            },
+            "turboparkgauss": {
+                "A": 0.04,
+                "include_mirror_wake": True
+            },
+            "empirical_gauss": {
+                "wake_expansion_rates": [0.023, 0.008],
+                "breakpoints_D": [10],
+                "sigma_0_D": 0.28,
+                "smoothing_length_D": 2.0,
+                "mixing_gain_velocity": 2.0,
+                "awc_wake_exp": 1.2,
+                "awc_wake_denominator": 400
+            },
+        },
+
+        "wake_turbulence_parameters": {
+            "crespo_hernandez": {
+                "initial": 0.1,
+                "constant": 0.5,
+                "ai": 0.8,
+                "downstream": -0.32
+            },
+            "wake_induced_mixing": {
+                "atmospheric_ti_gain": 0.0
+            }
+        },
+    }
+}

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -25,6 +25,7 @@ from floris.core.turbine.turbine import (
     thrust_coefficient,
 )
 from floris.cut_plane import CutPlane
+from floris.default_inputs import default_inputs
 from floris.logging_manager import LoggingManager
 from floris.type_dec import (
     floris_array_converter,
@@ -63,7 +64,15 @@ class FlorisModel(LoggingManager):
                 - **logging**: See `floris.simulation.core.Core` for more details.
     """
 
+    @staticmethod
+    def get_defaults() -> dict:
+        return copy.deepcopy(default_inputs)
+
     def __init__(self, configuration: dict | str | Path):
+
+        if configuration == "defaults":
+            configuration = FlorisModel.get_defaults()
+
         self.configuration = configuration
 
         if isinstance(self.configuration, (str, Path)):

--- a/tests/floris_model_integration_test.py
+++ b/tests/floris_model_integration_test.py
@@ -17,6 +17,24 @@ TEST_DATA = Path(__file__).resolve().parent / "data"
 YAML_INPUT = TEST_DATA / "input_full.yaml"
 
 
+def test_default_init():
+    # Test getting the default dict
+    defaults = FlorisModel.get_defaults()
+    fmodel1 = FlorisModel(defaults)
+    assert isinstance(fmodel1, FlorisModel)
+
+    # Test that there are no side effects from changing the default dict
+    defaults2 = FlorisModel.get_defaults()
+    defaults2["farm"]["layout_x"] = [0, 1000]
+    defaults2["farm"]["layout_y"] = [0, 0]
+    fmodel2 = FlorisModel(defaults2)
+    assert fmodel2.core.as_dict() != FlorisModel(defaults).core.as_dict()
+
+    # Test using the "default" string
+    # This checks that the init works and that the default dictionary hasn't changed
+    fmodel3 = FlorisModel("defaults")
+    assert fmodel1.core.as_dict() == fmodel3.core.as_dict()
+
 def test_read_yaml():
     fmodel = FlorisModel(configuration=YAML_INPUT)
     assert isinstance(fmodel, FlorisModel)
@@ -487,7 +505,6 @@ def test_expected_farm_value_regression():
 
     expected_farm_value = fmodel.get_expected_farm_value()
     assert np.allclose(expected_farm_value,75108001.05154414 , atol=1e-1)
-
 
 def test_get_farm_avp(caplog):
     fmodel = FlorisModel(configuration=YAML_INPUT)


### PR DESCRIPTION
# Add an option to initialize FLORIS with default options for use as a library

When used as a library in third-party software, the calling-code typically must carry along a version of the FLORIS input files or require them as user input in order to initialize FLORIS. Often, the inputs are immediately changed by the calling-code such as in an optimization routine. This pattern leads to unnecessary complexity when integrating FLORIS in third-party software, and it could be avoided by providing an option to initialize FLORIS with default data with the understanding that much of it will be overwritten. See https://github.com/NREL/floris/discussions/1037.

This pull request modifies the initialization method of `FlorisModel` to load some set of default values when `configuration="defaults"`. Additionally, a method to retrieve the default inputs as a Python dictionary is provided so that it can be retrieved and modified prior to initialization from the calling code. This is required, for example, if the calling code will change a value that isn't supported in `FlorisModel.set(...)` such as the wake model parameters. I've also added a documentation block in the Advanced Concepts section.

## Design considerations

### Another input file
I considered setting defaults through the `attrs.field` function, but decided against this since it would spread the set of default parameters over many source code files. Instead, they're all contained in one file, `floris/default_inputs.py`. It hurts my heart to add yet another input file to the FLORIS repository, and I apologize in advance to any future developer who has to update these 💔.

### What are good defaults?
I chose the GCH example input file as the defaults. Is that reasonable?

### Guessable
Is this confusing to users who use FLORIS directly rather than through another tool? If so, how can it be made more explicit?