### PR TITLE
Add warnings about dropping support for python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ the conversation in [GitHub Discussions](https://github.com/NREL/floris/discussi
 
 ## Installation
 
-[!WARNING]
+```{warning}
 Support for python version 3.8 will be dropped in FLORIS v4.3. See [Installation documentation](https://nrel.github.io/floris/installation.html#installation) for details.
+```
 
 **If upgrading from a previous version, it is recommended to install FLORIS v4 into a new virtual environment**.
 If you intend to use [pyOptSparse](https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest/) with FLORIS,

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ the conversation in [GitHub Discussions](https://github.com/NREL/floris/discussi
 
 ## Installation
 
-```{warning}
+**WARNING:**
 Support for python version 3.8 will be dropped in FLORIS v4.3. See [Installation documentation](https://nrel.github.io/floris/installation.html#installation) for details.
-```
 
 **If upgrading from a previous version, it is recommended to install FLORIS v4 into a new virtual environment**.
 If you intend to use [pyOptSparse](https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest/) with FLORIS,

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ the conversation in [GitHub Discussions](https://github.com/NREL/floris/discussi
 
 ## Installation
 
+[!WARNING]
+Support for python version 3.8 will be dropped in FLORIS v4.3. See [Installation documentation](https://nrel.github.io/floris/installation.html#installation) for details.
+
 **If upgrading from a previous version, it is recommended to install FLORIS v4 into a new virtual environment**.
 If you intend to use [pyOptSparse](https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest/) with FLORIS,
 it is recommended to install that package first before installing FLORIS.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,10 @@ is highly encouraged. If you are interested in using FLORIS to conduct studies
 of a wind farm or extending FLORIS to include your own wake model, please join
 the conversation in [GitHub Discussions](https://github.com/NREL/floris/discussions/)!
 
+```{note}
+Support for python version 3.8 will be dropped in FLORIS v4.3. See {ref}`installation` for details.
+```
+
 ## Quick Start
 
 FLORIS is a Python package run on the command line typically by providing

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,10 +7,15 @@ The following sections detail how download and install FLORIS for each use case.
 (requirements)=
 ## Requirements
 
-FLORIS is intended to be used with Python 3.8 and up, and it is highly recommended that users
+FLORIS is a python package. FLORIS is intended to work with all [active versions of python](https://devguide.python.org/versions/). Support will drop for python versions once they reach end-of-life.
+It is highly recommended that users
 work within a virtual environment for both working with and working on FLORIS, to maintain a clean
 and sandboxed environment. The simplest way to get started with virtual environments is through
 [conda](https://docs.conda.io/en/latest/miniconda.html).
+
+```{warning}
+Support for python version 3.8 will be dropped in FLORIS v4.3.
+```
 
 Installing into a Python environment that contains a previous version of FLORIS may cause conflicts.
 If you intend to use [pyOptSparse](https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest/)


### PR DESCRIPTION
As discussed in various places, python v3.8 is now at [end-of-life](https://devguide.python.org/versions/) and we will stop supporting it in FLORIS from version 4.3. This PR does not drop the support, but instead adds warnings in the documentation in various places to let users know that FLORIS v4.2 will be the last version to "officially" support python v3.8.