### PR TITLE
Remove support for python 3.8

### DIFF
--- a/.github/workflows/check-working-examples.yaml
+++ b/.github/workflows/check-working-examples.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest] #, macos-latest, windows-latest]
       fail-fast: False
 

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest] #, macos-latest, windows-latest]
       fail-fast: False
     env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "floris"
 version = "4.2.1"
 description = "A controls-oriented engineering wake model."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Rafael Mudafort", email = "rafael.mudafort@nrel.gov" },
     { name = "Paul Fleming", email = "paul.fleming@nrel.gov" },
@@ -21,9 +21,11 @@ classifiers = [
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy"
 ]


### PR DESCRIPTION
Python 3.8 is now [at end-of-life](https://test-devguide.readthedocs.io/en/latest/versions/). We intend that FLORIS support only active versions of python. [FLORIS v4.2](https://github.com/NREL/floris/releases/tag/v4.2.1) is the last minor version of FLORIS that supports version 3.8.

This pull request sets the required version of python at 3.9, and updates the testing matrices (#1019) to reflect that 3.8 is no longer supported. The testing matrix is now

| workflow | 3.8 | 3.9 | 3.10 | 3.11 | 3.12 | 3.13 |
| --------- | --- | --- | --- | --- | --- | --- |
| [check-working-examples](https://github.com/NREL/floris/blob/main/.github/workflows/check-working-examples.yaml) | :heavy_minus_sign: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |  :heavy_check_mark: |
| [continuous-integration-workflow](https://github.com/NREL/floris/blob/main/.github/workflows/continuous-integration-workflow.yaml) | :heavy_minus_sign:  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
| [deploy-pages](https://github.com/NREL/floris/blob/main/.github/workflows/deploy-pages.yaml)|  |  |  |  |  | :heavy_check_mark:   |
| [quality-metrics-workflow](https://github.com/NREL/floris/blob/main/.github/workflows/quality-metrics-workflow.yaml) |  |  | |  |  | :heavy_check_mark:  |