### PR TITLE
[BUGFIX] Prevent unnecessary warning being raised in yaw optimization procedures

### DIFF
--- a/floris/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/optimization/yaw_optimization/yaw_optimization_base.py
@@ -231,6 +231,7 @@ class YawOptimization(LoggingManager):
 
         # Initialize subset variables as full set
         self.fmodel_subset = copy.deepcopy(self.fmodel)
+        self.fmodel_subset._wind_data = None # Accessing private attribute!
         n_findex_subset = copy.deepcopy(self.fmodel.core.flow_field.n_findex)
         minimum_yaw_angle_subset = copy.deepcopy(self.minimum_yaw_angle)
         maximum_yaw_angle_subset = copy.deepcopy(self.maximum_yaw_angle)


### PR DESCRIPTION
FLORIS [v4.2.1](https://github.com/nreL/floris/releases/v4.2.1) included a fix/enhancement #1031 for the yaw optimization routine. As part of that fix, I changed `self.fmodel_subset = self.fmodel.copy()` to a `self.fmodel_subset = copy.deepcopy(self.fmodel)` at [this line of yaw_optimization_base.py](https://github.com/NREL/floris/blob/v4.2.1/floris/optimization/yaw_optimization/yaw_optimization_base.py#L233). I did this to ensure that control setpoints were carried over to the `fmodel_subset` attribute. While this worked, it also copied over the `wind_data` stored at `self.fmodel._wind_data`.

In itself, that is not really a problem. However, in the yaw optimization routine, the `wind_directions`, `wind_speeds`, and `turbulence_intensities` are `set()` on `self.fmodel_subset`, see [here](https://github.com/NREL/floris/blob/v4.2.1/floris/optimization/yaw_optimization/yaw_optimization_base.py#L358-L364). This overrides the stored `_wind_data`, which again is not an issue, except that it raises a warning because of [these lines on the `FlorisModel` class](https://github.com/NREL/floris/blob/v4.2.1/floris/floris_model.py#L210-L212). The repeated printout of this warning each time `YawOptimization._calculate_farm_power()` is called is tedious and disconcerting. This is pointed out by @ @MiguelMarante in [#1016](https://github.com/NREL/floris/discussions/1016#discussioncomment-11482947)

To see this, one may run example 001_opt_yaw_single_ws.py in examples/examples_control_optimization/, and see the following printout
![image](https://github.com/user-attachments/assets/29529730-014e-4156-8808-18605f205ea8)
where previously, on v4.2 before #1031 was enacted, the printout was
![image](https://github.com/user-attachments/assets/878f8163-fc03-46ce-89ff-313c2c9f024e)
(Note that the warning raised is once after the yaw optimization procedure is complete, but this is due to [this line in the example](https://github.com/NREL/floris/blob/v4.2.1/examples/examples_control_optimization/001_opt_yaw_single_ws.py#L72) and is the kind of situation the warning was intended for.)

To resolve this, I see a range of possible fixes:
1. (currently implemented on this branch): Simply set `self.fmodel_subset._wind_data = None` after the `self.fmodel_subset = copy.deepcopy(self.fmodel)` statement on `YawOptimization`. This works well, because it sets the unused `._wind_data` to `None` and the warning is then not raised. However, it accesses a private attribute, and is therefore pretty clearly a "hacky" solution.

2. Create a method on `FlorisModel`, perhaps called `reset_wind_data()`, that sets the private attribute to `None`, and then call this method after the `self.fmodel_subset = copy.deepcopy(self.fmodel)` statement on `YawOptimization`. However, it should be noted that although this seems similar to [`reset_operation()`](https://github.com/NREL/floris/blob/v4.2.1/floris/floris_model.py#L475), all it would do is override the `_wind_data` attribute with `None`. This is arguably a bit dangerous, because the `wind_speeds`, `wind_directions`, and `turbulence_intensities` that were set by the originally-passed `WindData` object would _not_ be dropped (as intended), so the name and purpose of the method isn't very clear.

3. Simply remove the warning raised in [`FlorisModel`](https://github.com/NREL/floris/blob/v4.2.1/floris/floris_model.py#L210-L212). I'm not sure how useful this warning is in any circumstance; however, there may be some unintended consequences in situations for which the warning was originally intended.

4. A more thorough fix would be to allow `wind_data`, along with other arguments to `FlorisModel.set()`, to be explicitly removed. This is discussed in #974.

@rafmudaf , @paulf81 , I'd like to hear your input on this. We actually originally did not store the `wind_data` on the `FlorisModel` at all, which would also have avoided this issue, but it was added in #849 (along with the warning) to make post-processing methods more straightforward. Looking back at #849, perhaps option (3.) above is not so bad; perhaps I was a little too liberal with my raising of warnings.
