### PR TITLE
Update numpy req to 2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ the conversation in [GitHub Discussions](https://github.com/NREL/floris/discussi
 
 ```{note}
 Support for python version 3.8 will be dropped in FLORIS v4.3. See {ref}`installation` for details.
+
+FLORIS v4.3 will also move to requiring `numpy` version 2. See the [numpy documentation for details](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html).
 ```
 
 ## Quick Start

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,9 @@ and sandboxed environment. The simplest way to get started with virtual environm
 [conda](https://docs.conda.io/en/latest/miniconda.html).
 
 ```{warning}
-Support for python version 3.8 will be dropped in FLORIS v4.3.
+Support for python version 3.8 will be dropped in FLORIS v4.3. 
+
+FLORIS v4.3 will also require `numpy` version 2. See the [numpy documentation for details](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html).
 ```
 
 Installing into a Python environment that contains a previous version of FLORIS may cause conflicts.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ and sandboxed environment. The simplest way to get started with virtual environm
 [conda](https://docs.conda.io/en/latest/miniconda.html).
 
 ```{warning}
-Support for python version 3.8 will be dropped in FLORIS v4.3. 
+Support for python version 3.8 will be dropped in FLORIS v4.3.
 
 FLORIS v4.3 will also require `numpy` version 2. See the [numpy documentation for details](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html).
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "attrs",
     "pyyaml~=6.0",
     "numexpr~=2.0",
-    "numpy~=1.20",
+    "numpy~=2.0",
     "scipy~=1.1",
     "matplotlib~=3.0",
     "pandas~=2.0",


### PR DESCRIPTION
# Update numpy req to 2

Testing an update based on #1030 where the numpy requirement is pushed up to compatiable version of 2.0.  

An alternative approach would be to span version 1 and 2 using > and < operators, but I understand this to be non-preferred in semantic versioning, since testing would only apply to newer major version, and so the previous major version is not truly supported.

Using this PR also to check if having the requirement at ~=2.0 raises any incompatibilities.

## Related issue
#1030 
