### PR TITLE
Add parallel solve for `sample_flow_at_points`

### DIFF
--- a/tests/par_floris_model_unit_test.py
+++ b/tests/par_floris_model_unit_test.py
@@ -286,3 +286,29 @@ def test_control_setpoints(sample_inputs_fixture):
 
     assert powers_fmodel.shape == powers_pfmodel.shape
     assert np.allclose(powers_fmodel, powers_pfmodel)
+
+def test_sample_flow_at_points(sample_inputs_fixture):
+
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    fmodel = FlorisModel(sample_inputs_fixture.core)
+
+    wind_speeds = np.array([8.0, 8.0, 9.0])
+    wind_directions = np.array([270.0, 270.0, 270.0])
+    fmodel.set(
+        wind_directions=wind_speeds.flatten(),
+        wind_speeds=wind_directions.flatten(),
+        turbulence_intensities=0.06 * np.ones_like(wind_speeds.flatten()),
+    )
+
+    x_test = np.array([500.0, 750.0, 1000.0, 1250.0, 1500.0])
+    y_test = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+    z_test = np.array([90.0, 90.0, 90.0, 90.0, 90.0])
+
+    ws_base = fmodel.sample_flow_at_points(x_test, y_test, z_test)
+
+    for interface in ["multiprocessing", "pathos", "concurrent"]:
+        pfmodel = ParFlorisModel(fmodel, max_workers=2, interface=interface)
+        ws_test = pfmodel.sample_flow_at_points(x_test, y_test, z_test)
+        assert np.allclose(ws_base, ws_test)


### PR DESCRIPTION
As identified by @Bartdoekemeijer in #1009 , the `ParFlorisModel` did not have a parallelized version of `sample_flow_at_points()`. Instead, this method was simply inherited from `FlorisModel`, so ran in serial. This works, but does not take advantage of parallelization.

This PR address the issue by adding a `sample_flow_at_points()` method to `ParFlorisModel`. This can be checked by using the script that @Bartdoekemeijer provided in #1009:

```python
import numpy as np
from floris import ParFlorisModel

if __name__ == "__main__":
    # Load the parallel floris model and create a 200-turbine farm
    interface = None #"multiprocessing", "pathos", "concurrent"
    fmodel = ParFlorisModel("../inputs/gch.yaml", max_workers=8, print_timings=True, interface=interface)
    n_turbs = 200 # Or try something smaller 
    fmodel.set(
        layout_x=5 * 126.0 * np.arange(n_turbs),
        layout_y=np.zeros(n_turbs),
    )

    # Cover a large grid of findices
    wd_grid, ws_grid = np.meshgrid(
        np.arange(0.0, 360.0, 3.0),
        np.arange(1.0, 30.01, 1.0)
    )
    fmodel.set(
        wind_directions=wd_grid.flatten(),
        wind_speeds=ws_grid.flatten(),
        turbulence_intensities=0.06 * np.ones_like(ws_grid.flatten()),
    )

    # Sample wind speeds at a couple of points in the flow
    wind_speeds_at_points = fmodel.sample_flow_at_points(
        x=[500.0, 750.0, 1000.0, 1250.0, 1500.0],
        y=[  0.0,   0.0,    0.0,    0.0,    0.0],
        z=[ 90.0,  90.0,   90.0,   90.0,   90.0]
    )
    print(wind_speeds_at_points)
```

## Additional supporting information
In adding the `sample_flow_at_points()` method, I realized the main `run()` method had a lot of unnecessarily repeated code, so I've cleaned that up a bit (and added a private method for printing timing output).

## Test results, if applicable
- Existing tests (for main `run()` functionality) pass
- New test added for `sample_flow_at_points` method
- No change to output of examples/009_parallel_models.py
