### PR TITLE
[BUGFIX] Allow empty arrays in export as dict

### DIFF
--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -108,6 +108,7 @@ def _attr_floris_filter(inst: Attribute, value: Any) -> bool:
         return False
     if isinstance(value, np.ndarray):
         if value.size == 0:
+            raise ValueError("aaa")
             return False
     return True
 

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -106,10 +106,16 @@ def _attr_floris_filter(inst: Attribute, value: Any) -> bool:
         return False
     if value is None:
         return False
-    if isinstance(value, np.ndarray):
-        if value.size == 0:
-            raise ValueError("aaa")
-            return False
+
+    # This is removed to support initializing FLORIS with default values:
+    # - defaults added in https://github.com/NREL/floris/pull/1040
+    # - bug fix in https://github.com/NREL/floris/pull/1061
+    # When Core is exported to a dict in _reinitialize, this filter removes empty arrays.
+    # For init with defaults, this results in FlowField losing the wind speed, wind direction and TI
+    # arrays if they weren't provided in the .set function.
+    # if isinstance(value, np.ndarray):
+    #     if value.size == 0:
+    #         return False
     return True
 
 def iter_validator(iter_type, item_types: Union[Any, Tuple[Any]]) -> Callable:


### PR DESCRIPTION
# Bug fix: Allow empty arrays in export as dict

In #1040, functionality was added to support initializing the `FlorisModel` from a default configuration. I intentionally left the wind speed, wind direction, and turbulence intensity inputs as empty arrays instead of some default numeric value so that the `FlorisModel.run()` function would fail with an error requiring the user to set these inputs themselves. However, if FLORIS is initialized and some parameters set but not the wind speed, wind direction, and TI, then these arrays are dropped during the `FlorisModel.set()` routine.

Details:
1. `FlorisModel.set()` calls `FlorisModel._reinitialize()`
2. `FlorisModel._reinitialize()` exports `FlorisModel.Core` to a dictionary with `as_dict` from the `FromDictMixin` class
    - Note `Core` inherits from `BaseClass` which inherits from `FromDictMixin`
3. `FromDictMixin.as_dict()` calls `attr.asdict` with the `_attr_floris_filter` filter
4. `_attr_floris_filter` filters out the following conditions from the export:
    - The attribute is not initialized when the object is created (`field(init=False`)
    - The attribute's value is `None`
    - The length is 0 when the attribute is a `np.array`
5. The last condition above removes arrays that are set to empty during the default init
6. `FlorisModel._reinitialize()` calls `Core.from_dict()`, but the empty arrays have been removed
7. `FlowField` requires wind speed, wind direction and turbulence intensity inputs, so there's an error

This pull request removes the last condition in `_attr_floris_filter`. While the complete impact of this is difficult to assess, all the tests pass and the examples run without change. Also, I added an error within the last condition to check if it's used at all in the examples, and it was not called (see Test Results).

## Related issue
No open issue, but introduced in #1040 and spotted in https://github.com/WISDEM/Ard/pull/47

## Test results, if applicable
Before removing it, I added an error in the `_attr_floris_filter` condition to check whether any examples execute this branch.
- Examples job (passing): https://github.com/rafmudaf/floris/actions/runs/13187479394
- Test job (failing, as expected): https://github.com/rafmudaf/floris/actions/runs/13187479398