### PR TITLE
Update ruff versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - id: mixed-line-ending
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.241
+  rev: v0.9.6
   hooks:
   - id: ruff
 

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1798,7 +1798,7 @@ class FlorisModel(LoggingManager):
                 or general solver settings.
         """
 
-        if not all( type(fm) == FlorisModel for fm in fmodel_list ):
+        if not all( type(fm) is FlorisModel for fm in fmodel_list ):
             raise TypeError(
                 "Incompatible input specified. fmodel_list must be a list of FlorisModel objects."
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ filterwarnings = [
 # Ruff-specific rules (RUF)
 
 [tool.ruff]
-src = ["floris", "tests", "docs"]
+src = ["floris", "tests"]
 line-length = 100
 target-version = "py313"
 
@@ -178,6 +178,7 @@ exclude = [
     "dist",
     "node_modules",
     "venv",
+    "docs",
 ]
 
 # Allow unused variables when underscore-prefixed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ develop = [
     "pytest~=8.0",
     "pytest-benchmark~=5.1",
     "pre-commit~=4.0",
-    "ruff~=0.7",
+    "ruff~=0.9",
     "isort~=5.0"
 ]
 
@@ -141,7 +141,7 @@ filterwarnings = [
 [tool.ruff]
 src = ["floris", "tests"]
 line-length = 100
-target-version = "py310"
+target-version = "py313"
 
 # See https://github.com/charliermarsh/ruff#supported-rules
 # for rules included and matching to prefix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ filterwarnings = [
 # Ruff-specific rules (RUF)
 
 [tool.ruff]
-src = ["floris", "tests"]
+src = ["floris", "tests", "docs"]
 line-length = 100
 target-version = "py313"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,16 +145,16 @@ target-version = "py313"
 
 # See https://github.com/charliermarsh/ruff#supported-rules
 # for rules included and matching to prefix.
-select = ["F", "E", "W", "C4", ] #"T20", "I"
+lint.select = ["F", "E", "W", "C4", ] #"T20", "I"
 # I - isort is not fully implemented in ruff so there is not parity. Consider disabling I.
 
 # F401 unused-import: Ignore until all used isort flags are adopted in ruff
-ignore = ["F401"]
+lint.ignore = ["F401"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 # fixable = ["A", "B", "C", "D", "E", "F"]
-fixable = ["F", "E", "W", "C4"] #"T20", "I"
-unfixable = []
+lint.fixable = ["F", "E", "W", "C4"] #"T20", "I"
+lint.unfixable = []
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -182,9 +182,9 @@ exclude = [
 ]
 
 # Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # F841 unused-variable: ignore since this file uses numexpr and many variables look unused
 "floris/core/wake_deflection/jimenez.py" = ["F841"]
 "floris/core/wake_turbulence/crespo_hernandez.py" = ["F841"]
@@ -199,7 +199,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # import dependencies
 "floris/core/__init__.py" = ["I001"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 known-first-party = ["floris"]
 order-by-type = false


### PR DESCRIPTION
# Update ruff versions

I was getting some nuisance warnings in my VS code I think related to 

https://docs.astral.sh/ruff/editors/migration/

I think bumping the version references to ruff, and ruff precommit action resolved it
