### PR TITLE
Add dependabot dependent version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "pip"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
# Add dependabot dependent version updates

This PR introduces automated updating of dependent versions via github's [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates)

Following basic settings from here:

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

When this file is in github then dependabot should generate PRs we can consider to update dependencies.  This should save us from having to do this manually.

Could consider patching this into main as well.