### PR TITLE
[BUGFIX] Dimension update in `LayoutOptimizationBase`

### DIFF
--- a/examples/examples_control_optimization/002_opt_yaw_single_ws_uncertain.py
+++ b/examples/examples_control_optimization/002_opt_yaw_single_ws_uncertain.py
@@ -76,7 +76,7 @@ for tindex in range(3):
         color="r",
         marker="x",
     )
-    ax.set_ylabel("Yaw Offset (deg")
+    ax.set_ylabel("Yaw Offset T{0:03d} (deg)".format(tindex))
     ax.legend()
     ax.grid(True)
 

--- a/floris/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/optimization/yaw_optimization/yaw_optimization_base.py
@@ -260,14 +260,14 @@ class YawOptimization(LoggingManager):
             # Find bounds closest to 0.0 deg
             combined_bounds = np.concatenate(
                 (
-                    np.expand_dims(minimum_yaw_angle_subset, axis=3),
-                    np.expand_dims(maximum_yaw_angle_subset, axis=3)
+                    np.expand_dims(minimum_yaw_angle_subset, axis=2),
+                    np.expand_dims(maximum_yaw_angle_subset, axis=2)
                 ),
-                axis=3
+                axis=2
             )
             # Overwrite all values that are not allowed to be 0.0 with bound value closest to zero
-            ids_closest = np.expand_dims(np.argmin(np.abs(combined_bounds), axis=3), axis=3)
-            yaw_mb = np.squeeze(np.take_along_axis(combined_bounds, ids_closest, axis=3))
+            ids_closest = np.expand_dims(np.argmin(np.abs(combined_bounds), axis=2), axis=2)
+            yaw_mb = np.squeeze(np.take_along_axis(combined_bounds, ids_closest, axis=2), axis=2)
             yaw_angles_template_subset[idx] = yaw_mb[idx]
 
         # Save all subset variables to self

--- a/tests/yaw_optimization_integration_test.py
+++ b/tests/yaw_optimization_integration_test.py
@@ -5,6 +5,7 @@ import pytest
 from floris import FlorisModel
 from floris.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
 
+
 DEBUG = False
 VELOCITY_MODEL = "gauss"
 DEFLECTION_MODEL = "gauss"

--- a/tests/yaw_optimization_integration_test.py
+++ b/tests/yaw_optimization_integration_test.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from floris import FlorisModel
+from floris.optimization.yaw_optimization.yaw_optimizer_sr import YawOptimizationSR
+
+DEBUG = False
+VELOCITY_MODEL = "gauss"
+DEFLECTION_MODEL = "gauss"
+
+def test_yaw_optimization_limits(sample_inputs_fixture):
+    """
+    The Serial Refine (SR) method optimizes yaw angles based on a sequential, iterative yaw
+    optimization scheme. This test compares the optimization results from the SR method for
+    a simple farm with a simple wind rose to stored baseline results.
+    """
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    fmodel = FlorisModel(sample_inputs_fixture.core)
+    wd_array = np.arange(0.0, 360.0, 90.0)
+    ws_array = 8.0 * np.ones_like(wd_array)
+    ti_array = 0.1 * np.ones_like(wd_array)
+
+    D = 126.0 # Rotor diameter for the NREL 5 MW
+    fmodel.set(
+        layout_x=[0.0, 5 * D, 10 * D],
+        layout_y=[0.0, 0.0, 0.0],
+        wind_directions=wd_array,
+        wind_speeds=ws_array,
+        turbulence_intensities=ti_array,
+    )
+
+    # Asymmetric limits
+    yaw_opt = YawOptimizationSR(
+        fmodel,
+        minimum_yaw_angle=-10.0,
+        maximum_yaw_angle=20.0,
+    )
+    yaw_opt.optimize()
+
+    # Strictly positive limits
+    yaw_opt = YawOptimizationSR(
+        fmodel,
+        minimum_yaw_angle=5.0,
+        maximum_yaw_angle=20.0,
+    )
+    yaw_opt.optimize()
+
+    # Strictly negative limits
+    yaw_opt = YawOptimizationSR(
+        fmodel,
+        minimum_yaw_angle=-20.0,
+        maximum_yaw_angle=-5.0,
+    )
+    yaw_opt.optimize()
+
+    # Infeasible limits
+    with pytest.raises(ValueError):
+        yaw_opt = YawOptimizationSR(
+            fmodel,
+            minimum_yaw_angle=20.0,
+            maximum_yaw_angle=5.0,
+        )


### PR DESCRIPTION
As described in #1033 , there was a section of code that was missed in the dimension reduction from 5D to 4D as part of the release of Floris v4. The missed code is very much an edge case, where the _minimum_ yaw angle is set to be a stricly positive number (and vice versa, if the maximum yaw angle is set to be strictly negative).

This PR updates that section of code, and also adds an integration test that tests for these unusual situations.

## Test results, if applicable
- Existing tests pass.
- New tests added (yaw_optimization_integration_test.py) fail without changes to `YawOptimizationBase` (with an "axis out of bounds" error due to indexing a non-existent dimension 3---see screenshot below).
- New tests pass with changes to `YawOptimizationBase`.

## Notes
1. Since this is such an edge bug, I don't think we need to target main and release a patch. This can simply be bundled into the next minor release of FLORIS.
2. I'm also using this PR as an opportunity to fix a typo in the axis labels of one of the yaw optimization examples.


Screenshot of failing integration test prior to fixing dimensions:
![image](https://github.com/user-attachments/assets/90049b79-4c73-4535-a5cc-b52f0bbf6621)
