### PR TITLE
Widen numpy requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "attrs",
     "pyyaml~=6.0",
     "numexpr~=2.0",
-    "numpy~=2.0",
+    "numpy >=1.20, <3",
     "scipy~=1.1",
     "matplotlib~=3.0",
     "pandas~=2.0",


### PR DESCRIPTION
# Widen numpy requirement

Since raising numpy requirement to 2.0 in the develop branch of FLORIS in #1051 , have noted local FLORIS/FLASC workflows are difficult with main FLORIS supporting 1.0 and develop supporting 2.0.  Each virtual environment needs a little manual editing to come to a workable state when working with develop branches.

This made me think a gentler transition allows both 1 and 2 for one version iteration (or at least on develop) and that's what this PR does.

Notes:

1. The branch does not put in an open-ended >, such that the problem identified in https://github.com/NREL/floris/issues/1030#issuecomment-2538806480 is repeated
2. I confirm tests pass with numpy 1.20 reinstalled since #1051 doesn't change the code 
3. The softer requirement for one version might be gentler for users, allowing the upgrade to numpy 2 while not requiring it immediately



