### PR TITLE
Update docs to note the upcoming end of support for python 3.9

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,8 @@ of a wind farm or extending FLORIS to include your own wake model, please join
 the conversation in [GitHub Discussions](https://github.com/NREL/floris/discussions/)!
 
 ```{note}
-Support for python version 3.8 was dropped in FLORIS v4.3. See {ref}`installation` for details. FLORIS v4.3 also made the move to requiring `numpy` version 2. See the [numpy documentation for details](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html).
+Support for python version 3.8 was dropped in FLORIS v4.3, and support for python version 3.9 will end in the latter half of 2025.
+See {ref}`installation` for details. FLORIS v4.3 also made the move to requiring `numpy` version 2. See the [numpy documentation for details](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html).
 ```
 
 ## Quick Start

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,10 @@ and sandboxed environment. The simplest way to get started with virtual environm
 Support for python version 3.8 was dropped in FLORIS v4.3. See {ref}`installation` for details. FLORIS v4.3 also made the move to requiring `numpy` version 2. See the [numpy documentation for details](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html).
 ```
 
+```{warning}
+Support for python version 3.9 will end in the latter half of 2025 as it reaches [end-of-life](https://devguide.python.org/versions/).
+```
+
 Installing into a Python environment that contains a previous version of FLORIS may cause conflicts.
 If you intend to use [pyOptSparse](https://mdolab-pyoptsparse.readthedocs-hosted.com/en/latest/)
 with FLORIS, it is recommended to install that package first before installing FLORIS.


### PR DESCRIPTION
As described in https://github.com/NREL/floris/pull/953#issuecomment-2714568167 and https://github.com/NREL/floris/issues/951#issuecomment-2714573015, this is the first of two PRs that will eventually end support of python 3.9. This PR does not drop support itself, but adds notes to the documentation to let users now that dropping support of python 3.9 is on its way.

I intend to open a second pull request shortly that actually drops python 3.9 support, and that should remain open until we are ready to drop support.