### PR TITLE
[BUGFIX] Add bokeh requirement for building docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ docs = [
     "sphinx-autodoc-typehints~=2.0",
     "sphinxcontrib-autoyaml~=1.0",
     "sphinxcontrib.mermaid~=1.0",
+    "bokeh~=3.7",
 ]
 develop = [
     "pytest~=8.0",


### PR DESCRIPTION
Recent [deploy-book actions have failed](https://github.com/NREL/floris/actions/workflows/deploy-pages.yaml) with an error regarding a missing `bokeh` package. This happens in the first code block of [docs/code_quality.ipynb](https://github.com/NREL/floris/blob/87967f34f85d829928d3e05ceee311c1e3104c15/docs/code_quality.ipynb). It's not clear to me quite why this has just started happening (possibly changes in dependencies of dependencies), but I've confirmed that:
- the code block doesn't run for me locally if FLORIS `[docs]` requirements are installed as is into my conda environment
- adding `bokeh` to the conda environment allows the code block to run.

This PR simply adds `bokeh~=3.7` to the list of `[docs]` requirements.