### PR TITLE
 [BUGFIX] AWC wake mixing factor with mixed awc_modes inputs #1089

### DIFF
--- a/floris/core/wake_velocity/empirical_gauss.py
+++ b/floris/core/wake_velocity/empirical_gauss.py
@@ -294,12 +294,7 @@ def awc_added_wake_mixing(
 ):
 
     # TODO: Add TI in the mix, finetune amplitude/freq effect
-    if (awc_mode_i == "helix").any():
-        return awc_amplitude_i[:,:,0,0]**awc_wake_exp/awc_wake_denominator
-    elif (awc_mode_i == "baseline").any():
-        return 0
-    else:
-        raise NotImplementedError(
-            'Active wake mixing strategies other than the `helix` mode '
-            'have not yet been implemented in FLORIS.'
-        )
+    awc_mixing_factor = np.zeros_like(awc_amplitude_i[:,:,0,0])
+    helix_mask = (awc_mode_i[:,:,0,0] == 'helix')
+    awc_mixing_factor[helix_mask] = awc_amplitude_i[:,:,0,0][helix_mask]**awc_wake_exp/awc_wake_denominator
+    return awc_mixing_factor 


### PR DESCRIPTION
This PR addresses a bug in the mixing factor when using AWC that was identified in issue https://github.com/NREL/floris/issues/1089.