### PR TITLE
[BUGFIX] `UncertainFlorisModel` not correctly using `ParFlorisModel`

### DIFF
--- a/examples/examples_uncertain/003_uncertain_model_with_parallelization.py
+++ b/examples/examples_uncertain/003_uncertain_model_with_parallelization.py
@@ -13,73 +13,73 @@ from floris import (
 )
 from floris.par_floris_model import ParFlorisModel
 
+if __name__ == "__main__":
+    # Following the refactoring of ParFlorisModel, the UncertainFlorisModel can be
+    # parallelized by passing the ParFlorisModel as the model to be run.  This example
+    # demonstrates the usage and shows that the result obtained from the UncertainFlorisModel
+    # with and without parallelization is the same.  The results are compared to the nominal
+    # results.
 
-# Following the refactoring of ParFlorisModel, the UncertainFlorisModel can be
-# parallelized by passing the ParFlorisModel as the model to be run.  This example
-# demonstrates the usage and shows that the result obtained from the UncertainFlorisModel
-# with and without parallelization is the same.  The results are compared to the nominal
-# results.
+    # Instantiate a FlorisModel and ParallelFlorisModel using the GCH model
+    fmodel = FlorisModel("../inputs/gch.yaml")
+    pfmodel = ParFlorisModel("../inputs/gch.yaml")
 
-# Instantiate a FlorisModel and ParallelFlorisModel using the GCH model
-fmodel = FlorisModel("../inputs/gch.yaml")
-pfmodel = ParFlorisModel("../inputs/gch.yaml")
-
-# Use the above model to declare a serial and parallel UncertainFlorisModel
-ufmodel = UncertainFlorisModel(fmodel)
-pufmodel = UncertainFlorisModel(pfmodel)
+    # Use the above model to declare a serial and parallel UncertainFlorisModel
+    ufmodel = UncertainFlorisModel(fmodel)
+    pufmodel = UncertainFlorisModel(pfmodel)
 
 
-# Define an inflow where wind direction is swept while
-# wind speed and turbulence intensity are held constant
-wind_directions = np.arange(240.0, 300.0, 1.0)
-time_series = TimeSeries(
-    wind_directions=wind_directions,
-    wind_speeds=8.0,
-    turbulence_intensities=0.06,
-)
+    # Define an inflow where wind direction is swept while
+    # wind speed and turbulence intensity are held constant
+    wind_directions = np.arange(240.0, 300.0, 1.0)
+    time_series = TimeSeries(
+        wind_directions=wind_directions,
+        wind_speeds=8.0,
+        turbulence_intensities=0.06,
+    )
 
-# Define a two turbine farm and apply the inflow
-D = 126.0
-layout_x = np.array([0, D * 6])
-layout_y = [0, 0]
+    # Define a two turbine farm and apply the inflow
+    D = 126.0
+    layout_x = np.array([0, D * 6])
+    layout_y = [0, 0]
 
-# Apply to fmodel, ufmodel, and pufmodel
-fmodel.set(
-    layout_x=layout_x,
-    layout_y=layout_y,
-    wind_data=time_series,
-)
+    # Apply to fmodel, ufmodel, and pufmodel
+    fmodel.set(
+        layout_x=layout_x,
+        layout_y=layout_y,
+        wind_data=time_series,
+    )
 
-ufmodel.set(
-    layout_x=layout_x,
-    layout_y=layout_y,
-    wind_data=time_series,
-)
+    ufmodel.set(
+        layout_x=layout_x,
+        layout_y=layout_y,
+        wind_data=time_series,
+    )
 
-pufmodel.set(
-    layout_x=layout_x,
-    layout_y=layout_y,
-    wind_data=time_series,
-)
+    pufmodel.set(
+        layout_x=layout_x,
+        layout_y=layout_y,
+        wind_data=time_series,
+    )
 
-# Run the models
-fmodel.run()
-ufmodel.run()
-pufmodel.run()
+    # Run the models
+    fmodel.run()
+    ufmodel.run()
+    pufmodel.run()
 
-# Collect the farm power results from each model
-farm_powers_nom = fmodel.get_farm_power() / 1e3
-farm_powers_unc = ufmodel.get_farm_power() / 1e3
-farm_powers_punc = pufmodel.get_farm_power() / 1e3
+    # Collect the farm power results from each model
+    farm_powers_nom = fmodel.get_farm_power() / 1e3
+    farm_powers_unc = ufmodel.get_farm_power() / 1e3
+    farm_powers_punc = pufmodel.get_farm_power() / 1e3
 
-# Compare the results
-fig, ax = plt.subplots()
-ax.plot(wind_directions, farm_powers_nom.flatten(), 'k-', label="Nominal power")
-ax.plot(wind_directions, farm_powers_unc.flatten(), 'bs-', label="Uncertain power")
-ax.plot(wind_directions, farm_powers_punc.flatten(), 'r.--', label="Parallel uncertain power")
-ax.grid(True)
-ax.legend()
-ax.set_xlabel("Wind Direction (deg)")
-ax.set_ylabel("Power (kW)")
+    # Compare the results
+    fig, ax = plt.subplots()
+    ax.plot(wind_directions, farm_powers_nom.flatten(), 'k-', label="Nominal power")
+    ax.plot(wind_directions, farm_powers_unc.flatten(), 'bs-', label="Uncertain power")
+    ax.plot(wind_directions, farm_powers_punc.flatten(), 'r.--', label="Parallel uncertain power")
+    ax.grid(True)
+    ax.legend()
+    ax.set_xlabel("Wind Direction (deg)")
+    ax.set_ylabel("Power (kW)")
 
-plt.show()
+    plt.show()

--- a/examples/examples_uncertain/003_uncertain_model_with_parallelization.py
+++ b/examples/examples_uncertain/003_uncertain_model_with_parallelization.py
@@ -13,6 +13,7 @@ from floris import (
 )
 from floris.par_floris_model import ParFlorisModel
 
+
 if __name__ == "__main__":
     # Following the refactoring of ParFlorisModel, the UncertainFlorisModel can be
     # parallelized by passing the ParFlorisModel as the model to be run.  This example

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1576,7 +1576,12 @@ class FlorisModel(LoggingManager):
         )
 
     def copy(self):
-        """Create an independent copy of the current FlorisModel object"""
+        """Create an independent copy of the current FlorisModel object
+
+        When creating the copy, this method uses self.__class__(), rather than FlorisModel()
+        directly, so that subclasses of FlorisModel can inherit this method and return
+        instantiations of their own class, rather than the FlorisModel class.
+        """
         return self.__class__(self.core.as_dict(), **self.secondary_init_kwargs)
 
     def get_param(
@@ -1665,8 +1670,8 @@ class FlorisModel(LoggingManager):
     @property
     def secondary_init_kwargs(self):
         """
-        FlorisModel takes only the configuration argument. This method is a placeholder
-        for children of FlorisModel.
+        FlorisModel takes only the configuration argument. This method is a placeholder for
+        subclasses of FlorisModel.
         """
         return {}
 

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1577,7 +1577,7 @@ class FlorisModel(LoggingManager):
 
     def copy(self):
         """Create an independent copy of the current FlorisModel object"""
-        return FlorisModel(self.core.as_dict())
+        return self.__class__(self.core.as_dict(), **self.secondary_init_kwargs)
 
     def get_param(
         self,
@@ -1616,7 +1616,7 @@ class FlorisModel(LoggingManager):
         """
         fm_dict_mod = self.core.as_dict()
         nested_set(fm_dict_mod, param, value, param_idx)
-        self.__init__(fm_dict_mod)
+        self.__init__(fm_dict_mod, **self.secondary_init_kwargs)
 
     def get_turbine_layout(self, z=False):
         """
@@ -1661,6 +1661,14 @@ class FlorisModel(LoggingManager):
         self.show_config(full=True)
 
     ### Properties
+
+    @property
+    def secondary_init_kwargs(self):
+        """
+        FlorisModel takes only the configuration argument. This method is a placeholder
+        for children of FlorisModel.
+        """
+        return {}
 
     @property
     def layout_x(self):

--- a/floris/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/optimization/yaw_optimization/yaw_optimization_base.py
@@ -231,7 +231,10 @@ class YawOptimization(LoggingManager):
 
         # Initialize subset variables as full set
         self.fmodel_subset = copy.deepcopy(self.fmodel)
-        self.fmodel_subset._wind_data = None # Accessing private attribute!
+        if hasattr(self.fmodel_subset, "_wind_data"): # Normal FlorisModel
+            self.fmodel_subset._wind_data = None # Accessing private attribute!
+        elif hasattr(self.fmodel_subset, "fmodel_expanded"): # UncertainFlorisModel
+            self.fmodel_subset.fmodel_unexpanded._wind_data = None
         n_findex_subset = copy.deepcopy(self.fmodel.core.flow_field.n_findex)
         minimum_yaw_angle_subset = copy.deepcopy(self.minimum_yaw_angle)
         maximum_yaw_angle_subset = copy.deepcopy(self.maximum_yaw_angle)

--- a/floris/optimization/yaw_optimization/yaw_optimization_base.py
+++ b/floris/optimization/yaw_optimization/yaw_optimization_base.py
@@ -231,10 +231,10 @@ class YawOptimization(LoggingManager):
 
         # Initialize subset variables as full set
         self.fmodel_subset = copy.deepcopy(self.fmodel)
-        if hasattr(self.fmodel_subset, "_wind_data"): # Normal FlorisModel
+        if hasattr(self.fmodel_subset, "_wind_data"): # Normal FlorisModel, ParFlorisModel
             self.fmodel_subset._wind_data = None # Accessing private attribute!
         elif hasattr(self.fmodel_subset, "fmodel_expanded"): # UncertainFlorisModel
-            self.fmodel_subset.fmodel_unexpanded._wind_data = None
+            self.fmodel_subset.fmodel_unexpanded._wind_data = None # Accessing private attribute!
         n_findex_subset = copy.deepcopy(self.fmodel.core.flow_field.n_findex)
         minimum_yaw_angle_subset = copy.deepcopy(self.minimum_yaw_angle)
         maximum_yaw_angle_subset = copy.deepcopy(self.maximum_yaw_angle)

--- a/floris/par_floris_model.py
+++ b/floris/par_floris_model.py
@@ -232,17 +232,6 @@ class ParFlorisModel(FlorisModel):
 
         return sampled_wind_speeds
 
-    def copy(self):
-        """Create an independent copy of the current ParFlorisModel object"""
-        return ParFlorisModel(
-            configuration=self.core.as_dict(),
-            interface=self.interface,
-            max_workers=self.max_workers,
-            n_wind_condition_splits=self.n_wind_condition_splits,
-            return_turbine_powers_only=self.return_turbine_powers_only,
-            print_timings=self.print_timings,
-        )
-
     def _preprocessing(self):
         """
         Prepare the input arguments for parallel execution.
@@ -360,6 +349,19 @@ class ParFlorisModel(FlorisModel):
             return self._stored_turbine_powers
         else:
             return super()._get_turbine_powers()
+
+    @property
+    def secondary_init_kwargs(self):
+        """
+        ParFlorisModel secondary keyword arguments (after configuration).
+        """
+        return {
+            "interface": self.interface,
+            "max_workers": self.max_workers,
+            "n_wind_condition_splits": self.n_wind_condition_splits,
+            "return_turbine_powers_only": self.return_turbine_powers_only,
+            "print_timings": self.print_timings
+        }
 
     @property
     def fmodel(self):

--- a/floris/par_floris_model.py
+++ b/floris/par_floris_model.py
@@ -234,7 +234,14 @@ class ParFlorisModel(FlorisModel):
 
     def copy(self):
         """Create an independent copy of the current ParFlorisModel object"""
-        return ParFlorisModel(self.core.as_dict())
+        return ParFlorisModel(
+            configuration=self.core.as_dict(),
+            interface=self.interface,
+            max_workers=self.max_workers,
+            n_wind_condition_splits=self.n_wind_condition_splits,
+            return_turbine_powers_only=self.return_turbine_powers_only,
+            print_timings=self.print_timings,
+        )
 
     def _preprocessing(self):
         """

--- a/floris/par_floris_model.py
+++ b/floris/par_floris_model.py
@@ -232,6 +232,10 @@ class ParFlorisModel(FlorisModel):
 
         return sampled_wind_speeds
 
+    def copy(self):
+        """Create an independent copy of the current ParFlorisModel object"""
+        return ParFlorisModel(self.core.as_dict())
+
     def _preprocessing(self):
         """
         Prepare the input arguments for parallel execution.

--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -987,7 +987,7 @@ class UncertainFlorisModel(LoggingManager):
     def copy(self):
         """Create an independent copy of the current UncertainFlorisModel object"""
         return UncertainFlorisModel(
-            self.fmodel_unexpanded.core.as_dict(),
+            self.fmodel_unexpanded.copy(),
             wd_resolution=self.wd_resolution,
             ws_resolution=self.ws_resolution,
             ti_resolution=self.ti_resolution,

--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -997,16 +997,7 @@ class UncertainFlorisModel(LoggingManager):
         """Create an independent copy of the current UncertainFlorisModel object"""
         return UncertainFlorisModel(
             self.fmodel_unexpanded.copy(),
-            wd_resolution=self.wd_resolution,
-            ws_resolution=self.ws_resolution,
-            ti_resolution=self.ti_resolution,
-            yaw_resolution=self.yaw_resolution,
-            power_setpoint_resolution=self.power_setpoint_resolution,
-            awc_amplitude_resolution=self.awc_amplitude_resolution,
-            wd_std=self.wd_std,
-            wd_sample_points=self.wd_sample_points,
-            fix_yaw_to_nominal_direction=self.fix_yaw_to_nominal_direction,
-            verbose=self.verbose,
+            **self.secondary_init_kwargs,
         )
 
     def get_param(self, param: List[str], param_idx: Optional[int] = None) -> Any:
@@ -1037,8 +1028,26 @@ class UncertainFlorisModel(LoggingManager):
         """
         fm_dict_mod = self.fmodel_unexpanded.core.as_dict()
         nested_set(fm_dict_mod, param, value, param_idx)
-        self.fmodel_unexpanded.__init__(fm_dict_mod)
+        self.fmodel_unexpanded.__init__(fm_dict_mod, **self.fmodel_unexpanded.secondary_init_kwargs)
         self.set()
+
+    @property
+    def secondary_init_kwargs(self):
+        """
+        UncertainFlorisModel secondary keyword arguments (after configuration).
+        """
+        return {
+            "wd_resolution": self.wd_resolution,
+            "ws_resolution": self.ws_resolution,
+            "ti_resolution": self.ti_resolution,
+            "yaw_resolution": self.yaw_resolution,
+            "power_setpoint_resolution": self.power_setpoint_resolution,
+            "awc_amplitude_resolution": self.awc_amplitude_resolution,
+            "wd_std": self.wd_std,
+            "wd_sample_points": self.wd_sample_points,
+            "fix_yaw_to_nominal_direction": self.fix_yaw_to_nominal_direction,
+            "verbose": self.verbose,
+        }
 
     @property
     def layout_x(self):

--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -995,10 +995,7 @@ class UncertainFlorisModel(LoggingManager):
 
     def copy(self):
         """Create an independent copy of the current UncertainFlorisModel object"""
-        return UncertainFlorisModel(
-            self.fmodel_unexpanded.copy(),
-            **self.secondary_init_kwargs,
-        )
+        return self.__class__(self.fmodel_unexpanded.copy(), **self.secondary_init_kwargs)
 
     def get_param(self, param: List[str], param_idx: Optional[int] = None) -> Any:
         """Get a parameter from a FlorisModel object.

--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -109,6 +109,15 @@ class UncertainFlorisModel(LoggingManager):
         # Instantiate the un-expanded FlorisModel
         if isinstance(configuration, (FlorisModel, ParFlorisModel)):
             self.fmodel_unexpanded = configuration.copy()
+            # Copy over any control setpoints, wind data, if not already done.
+            self.fmodel_unexpanded.set(
+                yaw_angles=configuration.core.farm.yaw_angles,
+                power_setpoints=configuration.core.farm.power_setpoints,
+                awc_modes=configuration.core.farm.awc_modes,
+                awc_amplitudes=configuration.core.farm.awc_amplitudes,
+                awc_frequencies=configuration.core.farm.awc_frequencies,
+                wind_data=configuration.wind_data,
+            )
         elif isinstance(configuration, (dict, str, Path)):
             self.fmodel_unexpanded = FlorisModel(configuration)
         else:

--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -1227,3 +1227,18 @@ class ApproxFlorisModel(UncertainFlorisModel):
         self.yaw_resolution = yaw_resolution
         self.power_setpoint_resolution = power_setpoint_resolution
         self.awc_amplitude_resolution = awc_amplitude_resolution
+
+    @property
+    def secondary_init_kwargs(self):
+        """
+        ApproxFlorisModel secondary keyword arguments (after configuration).
+        """
+        return {
+            "wd_resolution": self.wd_resolution,
+            "ws_resolution": self.ws_resolution,
+            "ti_resolution": self.ti_resolution,
+            "yaw_resolution": self.yaw_resolution,
+            "power_setpoint_resolution": self.power_setpoint_resolution,
+            "awc_amplitude_resolution": self.awc_amplitude_resolution,
+            "verbose": self.verbose,
+        }

--- a/floris/uncertain_floris_model.py
+++ b/floris/uncertain_floris_model.py
@@ -994,7 +994,13 @@ class UncertainFlorisModel(LoggingManager):
         )
 
     def copy(self):
-        """Create an independent copy of the current UncertainFlorisModel object"""
+        """Create an independent copy of the current UncertainFlorisModel object
+
+        When creating the copy, this method uses self.__class__(), rather than
+        UncertainFlorisModel() directly, so that subclasses of UncertainFlorisModel can inherit this
+        method and return instantiations of their own class, rather than the UncertainFlorisModel
+        class.
+        """
         return self.__class__(self.fmodel_unexpanded.copy(), **self.secondary_init_kwargs)
 
     def get_param(self, param: List[str], param_idx: Optional[int] = None) -> Any:

--- a/tests/par_floris_model_unit_test.py
+++ b/tests/par_floris_model_unit_test.py
@@ -321,6 +321,7 @@ def test_copy(sample_inputs_fixture):
     sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
     sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
 
-    pfmodel = ParFlorisModel(sample_inputs_fixture.core)
+    pfmodel = ParFlorisModel(sample_inputs_fixture.core, max_workers=2)
     pfmodel_copy = pfmodel.copy()
     assert isinstance(pfmodel_copy, ParFlorisModel)
+    assert pfmodel_copy.max_workers == 2

--- a/tests/par_floris_model_unit_test.py
+++ b/tests/par_floris_model_unit_test.py
@@ -312,3 +312,15 @@ def test_sample_flow_at_points(sample_inputs_fixture):
         pfmodel = ParFlorisModel(fmodel, max_workers=2, interface=interface)
         ws_test = pfmodel.sample_flow_at_points(x_test, y_test, z_test)
         assert np.allclose(ws_base, ws_test)
+
+def test_copy(sample_inputs_fixture):
+    """
+    Check that the ParFlorisModel copies correctly as a ParFlorisModel.
+    """
+
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    pfmodel = ParFlorisModel(sample_inputs_fixture.core)
+    pfmodel_copy = pfmodel.copy()
+    assert isinstance(pfmodel_copy, ParFlorisModel)

--- a/tests/uncertain_floris_model_integration_test.py
+++ b/tests/uncertain_floris_model_integration_test.py
@@ -271,6 +271,32 @@ def test_get_powers_with_wind_data():
 
     assert np.allclose(farm_power_weighted, ufmodel.get_turbine_powers()[:, :, :-1].sum(axis=2))
 
+def test_AEP_with_wind_data():
+    wind_speeds = np.array([8.0, 10.0])
+    wind_directions = np.array([270.0, 280.0])
+    frequencies = np.array([[0.25, 0.25], [0.1, 0.4]])
+    wind_rose = WindRose(
+        wind_directions=np.unique(wind_directions),
+        wind_speeds=np.unique(wind_speeds),
+        freq_table=frequencies,
+        ti_table=0.06,
+    )
+
+    # Set wind_data on UncertainFlorisModel directly
+    ufmodel = UncertainFlorisModel(configuration=YAML_INPUT)
+    ufmodel.set(wind_data=wind_rose)
+    ufmodel.run()
+    aep_1 = ufmodel.get_farm_AEP()
+
+    # Set wind_data on FlorisModel and then set on UncertainFlorisModel
+    fmodel = FlorisModel(configuration=YAML_INPUT)
+    fmodel.set(wind_data=wind_rose)
+    ufmodel = UncertainFlorisModel(fmodel)
+    ufmodel.run()
+    aep_2 = ufmodel.get_farm_AEP()
+
+    # Check AEPs match
+    assert np.allclose(aep_1, aep_2)
 
 def test_approx_floris_model():
     afmodel = ApproxFlorisModel(configuration=YAML_INPUT, wd_resolution=1.0)

--- a/tests/uncertain_floris_model_integration_test.py
+++ b/tests/uncertain_floris_model_integration_test.py
@@ -466,6 +466,8 @@ def test_parallel_uncertain_model():
 
     ufmodel = UncertainFlorisModel(FlorisModel(configuration=YAML_INPUT))
     pufmodel = UncertainFlorisModel(ParFlorisModel(configuration=YAML_INPUT))
+    assert isinstance(ufmodel.fmodel_expanded, FlorisModel)
+    assert isinstance(pufmodel.fmodel_expanded, ParFlorisModel)
 
     # Run the models and compare outputs
     ufmodel.run()

--- a/tests/uncertain_floris_model_integration_test.py
+++ b/tests/uncertain_floris_model_integration_test.py
@@ -476,3 +476,19 @@ def test_parallel_uncertain_model():
     powers_punc = pufmodel.get_turbine_powers()
 
     assert np.allclose(powers_unc, powers_punc)
+
+def test_copy():
+    """
+    Check that the UncertainFlorisModel copy method works as expected for
+    both FlorisModel and ParFlorisModel.
+    """
+    ufmodel = UncertainFlorisModel(FlorisModel(configuration=YAML_INPUT))
+
+    ufmodel_copy = ufmodel.copy()
+    assert isinstance(ufmodel_copy, UncertainFlorisModel)
+    assert isinstance(ufmodel_copy.fmodel_expanded, FlorisModel)
+
+    pufmodel = UncertainFlorisModel(ParFlorisModel(configuration=YAML_INPUT))
+    pufmodel_copy = pufmodel.copy()
+    assert isinstance(pufmodel_copy, UncertainFlorisModel)
+    assert isinstance(pufmodel_copy.fmodel_expanded, ParFlorisModel)

--- a/tests/uncertain_floris_model_integration_test.py
+++ b/tests/uncertain_floris_model_integration_test.py
@@ -331,6 +331,9 @@ def test_approx_floris_model():
     np.testing.assert_almost_equal(power[0], power[1])
     assert not np.allclose(power[2], power[3])
 
+    # Test copy method
+    assert isinstance(afmodel.copy(), ApproxFlorisModel)
+
 
 def test_expected_farm_power_regression():
     ufmodel = UncertainFlorisModel(


### PR DESCRIPTION
@gogannes pointed out a bug in #1106 that the `UncertainFlorisModel` did not appear to be using parallelization when passed an instantiated `ParFlorisModel` as an input during yaw optimization routines. Looking into this further, I believe that the `UncertainFlorisModel` did not correctly assign the `ParFlorisModel`, and instead (silently) converted it into a `FlorisModel` type object.

At the root of the issue is that the `ParFlorisModel`, which is a child of `FlorisModel`, did not implement it's own `copy()` method; thus, when the `UncertainFlorisModel` calls `ParFlorisModel.copy()`, a `FlorisModel` is returned rather than a `ParFlorisModel`.

This PR corrects this issue by defining `copy()` on `ParFlorisModel`. In doing so, I believe it addresses #1106. 
EDIT: I have now switched to a more refined approach where `copy()` uses a property dictionary `secondary_init_kwargs`. This obviates the need for a `copy()` method on `ParFlorisModel`, and I have removed it again in favor of the `secondary_init_kwargs` approach.

Check list:
- [x] Implement fix for bug
- [x] Update examples if needed (example 009_parallel_models.py was not running correctly, but did not need to be changed; while examples_uncertain/003_uncertain_model_with_parallelization.py was not running correctly and needed a change so that the parallel model runs correctly).
- [x] Add test to check that the `ParFlorisModel` is correctly assigned to the `UncertainFlorisModel` (this new test fails on the develop branch, and only passes with the bug fix included)
- [x] Check that the expected behavior is occurring that, for large problems, `UncertainFlorisModel` running in parallel (using `ParFlorisModel`) is significantly faster than `UncertainFlorisModel` running using `FlorisModel`.


The underlying bug here was the `copy()` method of the FlorisModel object and its variants. This method has some other issues, in particular, it also does not copy over wind data structures and control setpoints #997. We may need to consider revamping how `copy()` works in future.
