### PR TITLE
Fix bug in version 2 when wind direction uncertainty and heterogeneity are both used

### DIFF
--- a/floris/tools/floris_interface.py
+++ b/floris/tools/floris_interface.py
@@ -862,12 +862,14 @@ class FlorisInterface(LoggerBase):
                 }
 
             mean_farm_power = 0.0
-            wd_orig = self.floris.farm.wind_map.input_direction[0]
+            wd_orig = self.floris.farm.wind_map.input_direction
 
             yaw_angles = self.get_yaw_angles()
 
             for i_wd, delta_wd in enumerate(unc_pmfs["wd_unc"]):
-                self.reinitialize_flow_field(wind_direction=wd_orig + delta_wd)
+                self.reinitialize_flow_field(
+                    wind_direction=[wd + delta_wd for wd in wd_orig]
+                )
 
                 for i_yaw, delta_yaw in enumerate(unc_pmfs["yaw_unc"]):
                     mean_farm_power = mean_farm_power + unc_pmfs["wd_unc_pmf"][
@@ -1041,12 +1043,14 @@ class FlorisInterface(LoggerBase):
                 }
 
             mean_farm_power = np.zeros(len(self.floris.farm.turbines))
-            wd_orig = self.floris.farm.wind_map.input_direction[0]
+            wd_orig = self.floris.farm.wind_map.input_direction
 
             yaw_angles = self.get_yaw_angles()
 
             for i_wd, delta_wd in enumerate(unc_pmfs["wd_unc"]):
-                self.reinitialize_flow_field(wind_direction=wd_orig + delta_wd)
+                self.reinitialize_flow_field(
+                    wind_direction=[wd + delta_wd for wd in wd_orig]
+                )
 
                 for i_yaw, delta_yaw in enumerate(unc_pmfs["yaw_unc"]):
                     self.calculate_wake(


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Fix bug when wind direction uncertainty and heterogeneity are both used
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
FLORIS version 2 did not account for joint wind direction uncertainty and heterogeneity properly, as noted in https://github.com/NREL/floris/discussions/1074. Essentially, it was applying perturbations about the first turbine's wind direction instead of about all turbines' wind directions. This PR fixes the issue.

## Related issue
https://github.com/NREL/floris/discussions/1074

## Impacted areas of the software
`floris.tools.floris_interface`

## Test results, if applicable
I did a quick check by adding `print(fi.get_turbine_power(include_unc=True))` to `examples/heterogenous_flow/demo_het_dir.py` after both `fi.calculate_wake()` calls.

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md (appears twice in README.md)
    - [ ] pyproject.toml
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
