### PR TITLE
Set keepdims to True so that we don't have to add again those dimensions

### DIFF
--- a/floris/core/solver.py
+++ b/floris/core/solver.py
@@ -253,8 +253,9 @@ def sequential_solver(
     flow_field.turbulence_intensity_field_sorted = turbine_turbulence_intensity
     flow_field.turbulence_intensity_field_sorted_avg = np.mean(
         turbine_turbulence_intensity,
-        axis=(2,3)
-    )[:, :, None, None]
+        axis=(2,3),
+        keepdims=True
+    )
 
 
 def full_flow_sequential_solver(
@@ -657,10 +658,9 @@ def cc_solver(
 
         # Calculate wake overlap for wake-added turbulence (WAT)
         area_overlap = 1 - (
-            np.sum(turb_u_wake <= 0.05, axis=(2, 3))
+            np.sum(turb_u_wake <= 0.05, axis=(2, 3), keepdims=True)
             / (grid.grid_resolution * grid.grid_resolution)
         )
-        area_overlap = area_overlap[:, :, None, None]
 
         # Modify wake added turbulence by wake area overlap
         downstream_influence_length = 15 * rotor_diameter_i
@@ -684,8 +684,9 @@ def cc_solver(
     flow_field.turbulence_intensity_field_sorted = turbine_turbulence_intensity
     flow_field.turbulence_intensity_field_sorted_avg = np.mean(
         turbine_turbulence_intensity,
-        axis=(2,3)
-    )[:, :, None, None]
+        axis=(2,3),
+        keepdims=True
+    )
 
 
 def full_flow_cc_solver(
@@ -998,10 +999,8 @@ def turbopark_solver(
                 "and perform a thorough examination of the results."
             )
             for ii in range(i):
-                x_ii = np.mean(grid.x_sorted[:, ii:ii+1], axis=(2, 3))
-                x_ii = x_ii[:, :, None, None]
-                y_ii = np.mean(grid.y_sorted[:, ii:ii+1], axis=(2, 3))
-                y_ii = y_ii[:, :, None, None]
+                x_ii = np.mean(grid.x_sorted[:, ii:ii+1], axis=(2, 3), keepdims=True)
+                y_ii = np.mean(grid.y_sorted[:, ii:ii+1], axis=(2, 3), keepdims=True)
 
                 yaw_ii = farm.yaw_angles_sorted[:, ii:ii+1, None, None]
                 turbulence_intensity_ii = turbine_turbulence_intensity[:, ii:ii+1]
@@ -1079,10 +1078,13 @@ def turbopark_solver(
         # turbines; could use WAT_upstream
         # Calculate wake overlap for wake-added turbulence (WAT)
         area_overlap = (
-            np.sum(velocity_deficit * flow_field.u_initial_sorted > 0.05, axis=(2, 3))
+            np.sum(
+                velocity_deficit * flow_field.u_initial_sorted > 0.05,
+                axis=(2, 3),
+                keepdims=True
+            )
             / (grid.grid_resolution * grid.grid_resolution)
         )
-        area_overlap = area_overlap[:, :, None, None]
 
         # Modify wake added turbulence by wake area overlap
         downstream_influence_length = 15 * rotor_diameter_i
@@ -1106,8 +1108,9 @@ def turbopark_solver(
     flow_field.turbulence_intensity_field_sorted = turbine_turbulence_intensity
     flow_field.turbulence_intensity_field_sorted_avg = np.mean(
         turbine_turbulence_intensity,
-        axis=(2, 3)
-    )[:, :, None, None]
+        axis=(2, 3),
+        keepdims=True
+    )
 
 
 def full_flow_turbopark_solver(

--- a/floris/core/solver.py
+++ b/floris/core/solver.py
@@ -79,12 +79,9 @@ def sequential_solver(
     for i in range(grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(grid.x_sorted[:, i:i+1], axis=(2, 3))
-        x_i = x_i[:, :, None, None]
-        y_i = np.mean(grid.y_sorted[:, i:i+1], axis=(2, 3))
-        y_i = y_i[:, :, None, None]
-        z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3))
-        z_i = z_i[:, :, None, None]
+        x_i = np.mean(grid.x_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        y_i = np.mean(grid.y_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
 
         u_i = flow_field.u_sorted[:, i:i+1]
         v_i = flow_field.v_sorted[:, i:i+1]
@@ -317,12 +314,9 @@ def full_flow_sequential_solver(
     for i in range(flow_field_grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(turbine_grid.x_sorted[:, i:i+1], axis=(2, 3))
-        x_i = x_i[:, :, None, None]
-        y_i = np.mean(turbine_grid.y_sorted[:, i:i+1], axis=(2, 3))
-        y_i = y_i[:, :, None, None]
-        z_i = np.mean(turbine_grid.z_sorted[:, i:i+1], axis=(2, 3))
-        z_i = z_i[:, :, None, None]
+        x_i = np.mean(turbine_grid.x_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        y_i = np.mean(turbine_grid.y_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        z_i = np.mean(turbine_grid.z_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
 
         u_i = turbine_grid_flow_field.u_sorted[:, i:i+1]
         v_i = turbine_grid_flow_field.v_sorted[:, i:i+1]
@@ -487,12 +481,9 @@ def cc_solver(
     for i in range(grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(grid.x_sorted[:, i:i+1], axis=(2, 3))
-        x_i = x_i[:, :, None, None]
-        y_i = np.mean(grid.y_sorted[:, i:i+1], axis=(2, 3))
-        y_i = y_i[:, :, None, None]
-        z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3))
-        z_i = z_i[:, :, None, None]
+        x_i = np.mean(grid.x_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        y_i = np.mean(grid.y_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
 
         rotor_diameter_i = farm.rotor_diameters_sorted[:, i:i+1, None, None]
 
@@ -756,12 +747,9 @@ def full_flow_cc_solver(
     for i in range(flow_field_grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(turbine_grid.x_sorted[:, i:i+1], axis=(2, 3))
-        x_i = x_i[:, :, None, None]
-        y_i = np.mean(turbine_grid.y_sorted[:, i:i+1], axis=(2, 3))
-        y_i = y_i[:, :, None, None]
-        z_i = np.mean(turbine_grid.z_sorted[:, i:i+1], axis=(2, 3))
-        z_i = z_i[:, :, None, None]
+        x_i = np.mean(turbine_grid.x_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        y_i = np.mean(turbine_grid.y_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        z_i = np.mean(turbine_grid.z_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
 
         u_i = turbine_grid_flow_field.u_sorted[:, i:i+1]
         v_i = turbine_grid_flow_field.v_sorted[:, i:i+1]
@@ -923,12 +911,9 @@ def turbopark_solver(
     # Calculate the velocity deficit sequentially from upstream to downstream turbines
     for i in range(grid.n_turbines):
         # Get the current turbine quantities
-        x_i = np.mean(grid.x_sorted[:, i:i+1], axis=(2, 3))
-        x_i = x_i[:, :, None, None]
-        y_i = np.mean(grid.y_sorted[:, i:i+1], axis=(2, 3))
-        y_i = y_i[:, :, None, None]
-        z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3))
-        z_i = z_i[:, :, None, None]
+        x_i = np.mean(grid.x_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        y_i = np.mean(grid.y_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
 
         Cts = thrust_coefficient(
             velocities=flow_field.u_sorted,
@@ -1191,12 +1176,9 @@ def empirical_gauss_solver(
     for i in range(grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(grid.x_sorted[:, i:i+1], axis=(2, 3))
-        x_i = x_i[:, :, None, None]
-        y_i = np.mean(grid.y_sorted[:, i:i+1], axis=(2, 3))
-        y_i = y_i[:, :, None, None]
-        z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3))
-        z_i = z_i[:, :, None, None]
+        x_i = np.mean(grid.x_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        y_i = np.mean(grid.y_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
+        z_i = np.mean(grid.z_sorted[:, i:i+1], axis=(2, 3), keepdims=True)
 
         ct_i = thrust_coefficient(
             velocities=flow_field.u_sorted,
@@ -1414,12 +1396,9 @@ def full_flow_empirical_gauss_solver(
     for i in range(flow_field_grid.n_turbines):
 
         # Get the current turbine quantities
-        x_i = np.mean(turbine_grid.x_sorted[:, i:i+1], axis=(2,3))
-        x_i = x_i[:, :, None, None]
-        y_i = np.mean(turbine_grid.y_sorted[:, i:i+1], axis=(2,3))
-        y_i = y_i[:, :, None, None]
-        z_i = np.mean(turbine_grid.z_sorted[:, i:i+1], axis=(2,3))
-        z_i = z_i[:, :, None, None]
+        x_i = np.mean(turbine_grid.x_sorted[:, i:i+1], axis=(2,3), keepdims=True)
+        y_i = np.mean(turbine_grid.y_sorted[:, i:i+1], axis=(2,3), keepdims=True)
+        z_i = np.mean(turbine_grid.z_sorted[:, i:i+1], axis=(2,3), keepdims=True)
 
         ct_i = thrust_coefficient(
             velocities=turbine_grid_flow_field.u_sorted,

--- a/floris/core/wake_deflection/gauss.py
+++ b/floris/core/wake_deflection/gauss.py
@@ -289,7 +289,7 @@ def wake_added_yaw(
         scale,
     )
 
-    turbine_average_velocity = np.cbrt(np.mean(u_i ** 3, axis=(2, 3)))[:, :, None, None]
+    turbine_average_velocity = np.cbrt(np.mean(u_i ** 3, axis=(2, 3), keepdims=True))
     Gamma_wake_rotation = 0.25 * 2 * pi * D * (aI - aI ** 2) * turbine_average_velocity / TSR
 
     ### compute the spanwise and vertical velocities induced by yaw
@@ -384,7 +384,7 @@ def calculate_transverse_velocity(
         Ct,
         scale,
     )
-    turbine_average_velocity = np.cbrt(np.mean(u_i ** 3, axis=(2,3)))[:, :, None, None]
+    turbine_average_velocity = np.cbrt(np.mean(u_i ** 3, axis=(2,3), keepdims=True))
     Gamma_wake_rotation = 0.25 * 2 * pi * D * (aI - aI ** 2) * turbine_average_velocity / TSR
 
     ### compute the spanwise and vertical velocities induced by yaw

--- a/floris/core/wake_velocity/cumulative_gauss_curl.py
+++ b/floris/core/wake_velocity/cumulative_gauss_curl.py
@@ -84,8 +84,7 @@ class CumulativeGaussCurlVelocityDeficit(BaseModel):
         turbine_yaw = yaw_i
 
         # TODO Should this be cbrt? This is done to match v2
-        turb_avg_vels = np.cbrt(np.mean(u_i ** 3, axis=(2, 3)))
-        turb_avg_vels = turb_avg_vels[:, :, None, None]
+        turb_avg_vels = np.cbrt(np.mean(u_i ** 3, axis=(2, 3), keepdims=True))
 
         delta_x = x - x_i
 

--- a/floris/core/wake_velocity/cumulative_gauss_curl.py
+++ b/floris/core/wake_velocity/cumulative_gauss_curl.py
@@ -99,7 +99,6 @@ class CumulativeGaussCurlVelocityDeficit(BaseModel):
             self.c_s2,
         )
 
-        x_i_loc = np.mean(x_i, axis=(2, 3), keepdims=True)
         y_i_loc = np.mean(y_i, axis=(2, 3), keepdims=True)
         z_i_loc = np.mean(z_i, axis=(2, 3), keepdims=True)
 

--- a/floris/core/wake_velocity/cumulative_gauss_curl.py
+++ b/floris/core/wake_velocity/cumulative_gauss_curl.py
@@ -100,22 +100,17 @@ class CumulativeGaussCurlVelocityDeficit(BaseModel):
             self.c_s2,
         )
 
-        x_i_loc = np.mean(x_i, axis=(2, 3))
-        x_i_loc = x_i_loc[:, :, None, None]
+        x_i_loc = np.mean(x_i, axis=(2, 3), keepdims=True)
+        y_i_loc = np.mean(y_i, axis=(2, 3), keepdims=True)
+        z_i_loc = np.mean(z_i, axis=(2, 3), keepdims=True)
 
-        y_i_loc = np.mean(y_i, axis=(2, 3))
-        y_i_loc = y_i_loc[:, :, None, None]
-
-        z_i_loc = np.mean(z_i, axis=(2, 3))
-        z_i_loc = z_i_loc[:, :, None, None]
-
-        x_coord = np.mean(x, axis=(2, 3))[:, :, None, None]
+        x_coord = np.mean(x, axis=(2, 3), keepdims=True)
 
         y_loc = y
-        y_coord = np.mean(y, axis=(2, 3))[:, :, None, None]
+        y_coord = np.mean(y, axis=(2, 3), keepdims=True)
 
         z_loc = z  # np.mean(z, axis=(3,4))
-        z_coord = np.mean(z, axis=(2, 3))[:, :, None, None]
+        z_coord = np.mean(z, axis=(2, 3), keepdims=True)
 
         sum_lbda = np.zeros_like(u_initial)
 

--- a/floris/wind_data.py
+++ b/floris/wind_data.py
@@ -1587,16 +1587,12 @@ class WindTIRose(WindDataBase):
                 )
             )
             freq_matrix = np.concatenate(
-                (freq_matrix[0, :, :][None, :, :], freq_matrix, freq_matrix[-1, :, :][None, :, :]),
+                (freq_matrix[0:1, :, :], freq_matrix, freq_matrix[-1:, :, :]),
                 axis=0
             )
             if self.value_table is not None:
                 value_matrix = np.concatenate(
-                    (
-                        value_matrix[0, :, :][None, :, :],
-                        value_matrix,
-                        value_matrix[-1, :, :][None, :, :]
-                    ),
+                    (value_matrix[0:1, :, :], value_matrix, value_matrix[-1:, :, :]),
                     axis=0
                 )
 
@@ -1615,15 +1611,11 @@ class WindTIRose(WindDataBase):
 
             # Pad the remaining with the appropriate value
             freq_matrix = np.vstack(
-                (freq_matrix[-1, :, :][None, :, :], freq_matrix, freq_matrix[0, :, :][None, :, :])
+                (freq_matrix[-1:, :, :], freq_matrix, freq_matrix[0:1, :, :])
             )
             if self.value_table is not None:
                 value_matrix = np.vstack(
-                    (
-                        value_matrix[-1, :, :][None, :, :],
-                        value_matrix,
-                        value_matrix[0, :, :][None, :, :],
-                    )
+                    (value_matrix[-1:, :, :], value_matrix, value_matrix[0:1, :, :])
                 )
 
         # Pad out the wind speeds
@@ -1640,11 +1632,7 @@ class WindTIRose(WindDataBase):
         )
         if self.value_table is not None:
             value_matrix = np.concatenate(
-                (
-                    value_matrix[:, 0, :][:, None, :],
-                    value_matrix,
-                    value_matrix[:, -1, :][:, None, :]
-                ),
+                (value_matrix[:, 0:1, :], value_matrix, value_matrix[:, -1:, :]),
                 axis=1
             )
 
@@ -1657,16 +1645,12 @@ class WindTIRose(WindDataBase):
             )
         )
         freq_matrix = np.concatenate(
-            (freq_matrix[:, :, 0][:, :, None], freq_matrix, freq_matrix[:, :, -1][:, :, None]),
+            (freq_matrix[:, :, 0:1], freq_matrix, freq_matrix[:, :, -1:]),
             axis=2
         )
         if self.value_table is not None:
             value_matrix = np.concatenate(
-                (
-                    value_matrix[:, :, 0][:, :, None],
-                    value_matrix,
-                    value_matrix[:, :, -1][:, :, None]
-                ),
+                (value_matrix[:, :, 0:1], value_matrix, value_matrix[:, :, -1:]),
                 axis=2
             )
 


### PR DESCRIPTION
# Set keepdims to True so that we don't have to add again those dimensions

Instead of doing
```python
b = np.mean(a, axis=(2, 3))
b = b[:, :, None, None]
```
do `b = np.mean(a, axis=(2, 3), keepdims=True)`.

## Related issue

None

## Impacted areas of the software

Solver and a couple of Gauss modules.

## Additional supporting information


## Test results, if applicable


<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md (appears twice in README.md)
    - [ ] pyproject.toml
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
