### PR TITLE
Convert angles from deg to rad fewer times

### DIFF
--- a/floris/core/turbine/controller_dependent_operation_model.py
+++ b/floris/core/turbine/controller_dependent_operation_model.py
@@ -520,6 +520,7 @@ class ControllerDependentTurbine(BaseOperationModel):
 
             # Yawed case
             mu = np.arccos(cosd(gamma) * cosd(tilt))
+            pitch_in_plus_beta = np.deg2rad(pitch_in + beta)
             data = (
                 sigma,
                 cd,
@@ -530,7 +531,7 @@ class ControllerDependentTurbine(BaseOperationModel):
                 np.cos(mu),
                 np.sin(mu),
                 x,
-                np.deg2rad(pitch_in) + np.deg2rad(beta),
+                pitch_in_plus_beta,
                 mu,
             )
             x0 = 0.1
@@ -547,7 +548,7 @@ class ControllerDependentTurbine(BaseOperationModel):
                 np.cos(mu),
                 np.sin(mu),
                 x,
-                np.deg2rad(pitch_in) + np.deg2rad(beta),
+                pitch_in_plus_beta,
                 mu,
                 ct,
             )
@@ -564,7 +565,7 @@ class ControllerDependentTurbine(BaseOperationModel):
                 np.cos(mu),
                 np.sin(mu),
                 x,
-                np.deg2rad(pitch_in) + np.deg2rad(beta),
+                pitch_in_plus_beta,
                 mu,
             )
             x0 = 0.1
@@ -581,7 +582,7 @@ class ControllerDependentTurbine(BaseOperationModel):
                 np.cos(mu),
                 np.sin(mu),
                 x,
-                np.deg2rad(pitch_in) + np.deg2rad(beta),
+                pitch_in_plus_beta,
                 mu,
                 ct,
             )
@@ -628,7 +629,7 @@ class ControllerDependentTurbine(BaseOperationModel):
             omega_rpm = omega_rated * 30 / np.pi
             tsr = omega_rated * R / (u)
 
-            pitch_in = np.deg2rad(x)
+            pitch_in_plus_beta = np.deg2rad(x + beta)
             torque_nm = np.interp(
                 omega_rpm, omega_lut_torque * 30 / np.pi, torque_lut_omega
             )
@@ -645,7 +646,7 @@ class ControllerDependentTurbine(BaseOperationModel):
                 np.cos(mu),
                 np.sin(mu),
                 tsr,
-                (pitch_in) + np.deg2rad(beta),
+                pitch_in_plus_beta,
                 mu,
             )
             x0 = 0.1
@@ -662,7 +663,7 @@ class ControllerDependentTurbine(BaseOperationModel):
                 np.cos(mu),
                 np.sin(mu),
                 tsr,
-                (pitch_in) + np.deg2rad(beta),
+                pitch_in_plus_beta,
                 mu,
                 ct,
             )
@@ -679,7 +680,7 @@ class ControllerDependentTurbine(BaseOperationModel):
                 np.cos(mu),
                 np.sin(mu),
                 tsr,
-                (pitch_in) + np.deg2rad(beta),
+                pitch_in_plus_beta,
                 mu,
             )
             x0 = 0.1
@@ -696,7 +697,7 @@ class ControllerDependentTurbine(BaseOperationModel):
                 np.cos(mu),
                 np.sin(mu),
                 tsr,
-                (pitch_in) + np.deg2rad(beta),
+                pitch_in_plus_beta,
                 mu,
                 ct,
             )

--- a/floris/layout_visualization.py
+++ b/floris/layout_visualization.py
@@ -238,8 +238,8 @@ def plot_turbine_rotors(
     for i in range(fmodel.layout_x.size):        
         x_0 = fmodel.layout_x[i] + sin_yaw_R[i]
         x_1 = fmodel.layout_x[i] - sin_yaw_R[i]
-        y_0 = fmodel.layout_y[i] - cos_yaw_R
-        y_1 = fmodel.layout_y[i] + cos_yaw_R
+        y_0 = fmodel.layout_y[i] - cos_yaw_R[i]
+        y_1 = fmodel.layout_y[i] + cos_yaw_R[i]
         ax.plot([x_0, x_1], [y_0, y_1], color=color)
 
     return ax

--- a/floris/layout_visualization.py
+++ b/floris/layout_visualization.py
@@ -232,12 +232,15 @@ def plot_turbine_rotors(
         yaw_angles = yaw_angles[0, :]
 
     rotor_diameters = fmodel.core.farm.rotor_diameters.flatten()
+    yaw_rad = np.deg2rad(yaw)
+    sin_yaw_R = np.sin(yaw_rad) * R
+    cos_yaw_R = np.cos(yaw_rad) * R
     for x, y, yaw, d in zip(fmodel.layout_x, fmodel.layout_y, yaw_angles, rotor_diameters):
         R = d / 2.0
-        x_0 = x + np.sin(np.deg2rad(yaw)) * R
-        x_1 = x - np.sin(np.deg2rad(yaw)) * R
-        y_0 = y - np.cos(np.deg2rad(yaw)) * R
-        y_1 = y + np.cos(np.deg2rad(yaw)) * R
+        x_0 = x + sin_yaw_R
+        x_1 = x - sin_yaw_R
+        y_0 = y - cos_yaw_R
+        y_1 = y + cos_yaw_R
         ax.plot([x_0, x_1], [y_0, y_1], color=color)
 
     return ax

--- a/floris/layout_visualization.py
+++ b/floris/layout_visualization.py
@@ -231,16 +231,15 @@ def plot_turbine_rotors(
     if yaw_angles.ndim == 2:
         yaw_angles = yaw_angles[0, :]
 
-    rotor_diameters = fmodel.core.farm.rotor_diameters.flatten()
-    yaw_rad = np.deg2rad(yaw)
-    sin_yaw_R = np.sin(yaw_rad) * R
-    cos_yaw_R = np.cos(yaw_rad) * R
-    for x, y, yaw, d in zip(fmodel.layout_x, fmodel.layout_y, yaw_angles, rotor_diameters):
-        R = d / 2.0
-        x_0 = x + sin_yaw_R
-        x_1 = x - sin_yaw_R
-        y_0 = y - cos_yaw_R
-        y_1 = y + cos_yaw_R
+    rotor_radius = 0.5 * fmodel.core.farm.rotor_diameters.ravel()
+    yaw_rad = np.deg2rad(yaw_angles)
+    sin_yaw_R = np.sin(yaw_rad) * rotor_radius
+    cos_yaw_R = np.cos(yaw_rad) * rotor_radius
+    for i in range(fmodel.layout_x.size):        
+        x_0 = fmodel.layout_x[i] + sin_yaw_R[i]
+        x_1 = fmodel.layout_x[i] - sin_yaw_R[i]
+        y_0 = fmodel.layout_y[i] - cos_yaw_R
+        y_1 = fmodel.layout_y[i] + cos_yaw_R
         ax.plot([x_0, x_1], [y_0, y_1], color=color)
 
     return ax

--- a/floris/layout_visualization.py
+++ b/floris/layout_visualization.py
@@ -235,7 +235,7 @@ def plot_turbine_rotors(
     yaw_rad = np.deg2rad(yaw_angles)
     sin_yaw_R = np.sin(yaw_rad) * rotor_radius
     cos_yaw_R = np.cos(yaw_rad) * rotor_radius
-    for i in range(fmodel.layout_x.size):        
+    for i in range(fmodel.layout_x.size):
         x_0 = fmodel.layout_x[i] + sin_yaw_R[i]
         x_1 = fmodel.layout_x[i] - sin_yaw_R[i]
         y_0 = fmodel.layout_y[i] - cos_yaw_R[i]


### PR DESCRIPTION
# Convert angles from deg to rad fewer times

Convert angles from deg to rad once and re-use the result.

## Related issue

None

## Impacted areas of the software

`plot_turbine_rotors` and `controller_dependent_operation_model`.

## Additional supporting information


## Test results, if applicable

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md (appears twice in README.md)
    - [ ] pyproject.toml
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
