### PR TITLE
[BUGFIX] Specify resolution in scipy yaw optimization regression test

### DIFF
--- a/tests/reg_tests/yaw_optimization_regression_test.py
+++ b/tests/reg_tests/yaw_optimization_regression_test.py
@@ -183,4 +183,5 @@ def test_scipy_yaw_opt(sample_inputs_fixture):
         print(baseline_scipy.to_string())
         print(df_opt.to_string())
 
-    pd.testing.assert_frame_equal(df_opt, baseline_scipy)
+    # Only require matching up until 2 decimal places
+    pd.testing.assert_frame_equal(df_opt, baseline_scipy, check_exact=False, rtol=1e-5, atol=1e-2)


### PR DESCRIPTION
Recent PRs #1126 , #1129 , #1134 #1135 have had the `test_scripy_yaw_opt` [fail](https://github.com/NREL/floris/actions/runs/16893988771) for python versions 3.11, 3.12, and 3.13. It appears there is some minor numeric change in the outcome of the scipy optimization. This PR simply adds a resolution to the regression test to specify that the values only need to match to a relative tolerance of 1x10^-5 and an absolute tolerance of 0.01. For optimal yaw angles, a difference at the third decimal place is inconsequential.

I've already made a fix for this on #1126 and #1129, but I decided to fix it in a standalone PR. Once this is merged, I will back merge develop into those branches.