### PR TITLE
[BUGFIX] Fix incorrect implementation in geometric yaw optimization

### DIFF
--- a/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
+++ b/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
@@ -188,11 +188,6 @@ def _process_layout(
     dx = x_dists.min(axis=1)
     dy = y_dists[range(len(turbine_x)), x_dists.argmin(axis=1)]
 
-    # Handle last turbine downstream
-    furthest_ds_turb_idx = np.where(dx == np.inf)[0]
-    dx[furthest_ds_turb_idx] = 0.
-    dy[furthest_ds_turb_idx] = 0.
-
     return dx/rotor_diameter, dy/rotor_diameter
 
 
@@ -219,7 +214,7 @@ def _get_yaw_angles(
     |.......................................
     ________________________________________
 
-    x and y: dx and dy to the nearest downstream turbine in rotor diameteters with
+    x and y: dx and dy to the nearest downstream turbine in rotor diameters with
         turbines rotated so wind is coming left to right
     left_x: where we start the trapezoid. Should be left as 0.
     top_left_y: trapezoid top left coord
@@ -236,20 +231,17 @@ def _get_yaw_angles(
     bottom_right_yaw_lower: yaw angle associated with bottom right point
     """
 
-    if x <= 0:
+    dx = (x-left_x)/(right_x-left_x)
+    if dx >= 1.0:
         return 0.0
-    else:
-        dx = (x-left_x)/(right_x-left_x)
-        if dx >= 1.0:
-            return 0.0
-        edge_y = top_left_y + (top_right_y-top_left_y)*dx
-        if abs(y) > edge_y:
-            return 0.0
-        elif y >= -0.01: # Tolerance to handle numerical issues
-            top_yaw = top_left_yaw_upper + (top_right_yaw_upper-top_left_yaw_upper)*dx
-            bottom_yaw = bottom_left_yaw_upper + (bottom_right_yaw_upper-bottom_left_yaw_upper)*dx
-            return bottom_yaw + (top_yaw-bottom_yaw)*abs(y)/edge_y
-        elif y < -0.01:
-            top_yaw = top_left_yaw_lower + (top_right_yaw_lower-top_left_yaw_lower)*dx
-            bottom_yaw = bottom_left_yaw_lower + (bottom_right_yaw_lower-bottom_left_yaw_lower)*dx
-            return bottom_yaw + (top_yaw-bottom_yaw)*abs(y)/edge_y
+    edge_y = top_left_y + (top_right_y-top_left_y)*dx
+    if abs(y) > edge_y:
+        return 0.0
+    elif y >= -0.01: # Tolerance to handle numerical issues
+        top_yaw = top_left_yaw_upper + (top_right_yaw_upper-top_left_yaw_upper)*dx
+        bottom_yaw = bottom_left_yaw_upper + (bottom_right_yaw_upper-bottom_left_yaw_upper)*dx
+        return bottom_yaw + (top_yaw-bottom_yaw)*abs(y)/edge_y
+    elif y < -0.01:
+        top_yaw = top_left_yaw_lower + (top_right_yaw_lower-top_left_yaw_lower)*dx
+        bottom_yaw = bottom_left_yaw_lower + (bottom_right_yaw_lower-bottom_left_yaw_lower)*dx
+        return bottom_yaw + (top_yaw-bottom_yaw)*abs(y)/edge_y

--- a/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
+++ b/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
@@ -144,7 +144,7 @@ def _process_layout(
 ):
     """
     returns the distance from each turbine to the nearest downstream waked turbine
-    normalized by the rotor diameter. Right now "waked" is determind by a Jensen-like
+    normalized by the rotor diameter. Right now "waked" is determined by a Jensen-like
     wake spread, but this could/should be modified to be the same as the trapezoid rule
     used to determine the yaw angles.
 
@@ -181,7 +181,7 @@ def _process_layout(
     x_dists[x_dists <= 0.] = np.inf
 
     # Check within Jensen model spread
-    in_Jensen_wake = (abs(y_dists) < spread * x_dists + rotor_diameter/1.0)
+    in_Jensen_wake = (abs(y_dists) < spread * x_dists + rotor_diameter/2.0)
     x_dists[~in_Jensen_wake] = np.inf
 
     # Get minimums (and arguments to select the correct y values also)

--- a/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
+++ b/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
@@ -14,7 +14,7 @@ class YawOptimizationGeometric(YawOptimization):
     used to provide a rough estimate of optimal yaw angles based purely on the
     wind farm geometry. Main use case is for coupled layout and yaw optimization.
 
-    See Stanely et al. (2023) for details: https://wes.copernicus.org/articles/8/1341/2023/
+    See Stanley et al. (2023) for details: https://wes.copernicus.org/articles/8/1341/2023/
     """
 
     def __init__(
@@ -153,31 +153,12 @@ def _process_layout(
     rotor_diameter: turbine rotor diameter (float)
     spread=0.1: Jensen alpha wake spread value
     """
-    len(turbine_x)
-
-    # # Intialize storage
-    # dx = np.zeros(nturbs) + 1E10
-    # dy = np.zeros(nturbs)
-
-    # for waking_index in range(nturbs):
-    #     for waked_index in range(nturbs):
-    #         if turbine_x[waked_index] > turbine_x[waking_index]:
-    #             r = spread*(turbine_x[waked_index]-turbine_x[waking_index]) + rotor_diameter/2.0
-    #             if abs(turbine_y[waked_index]-turbine_y[waking_index]) < (r+rotor_diameter/2.0):
-    #                 if (turbine_x[waked_index] - turbine_x[waking_index]) < dx[waking_index]:
-    #                     dx[waking_index] = turbine_x[waked_index] - turbine_x[waking_index]
-    #                     dy[waking_index] = turbine_y[waked_index]- turbine_y[waking_index]
-    #     if dx[waking_index] == 1E10:
-    #         dx[waking_index] = 0.0
-
-    # dx_ = dx
-    # dy_ = dy
 
     # Compute distances
     x_dists = turbine_x.reshape(-1,1).T - turbine_x.reshape(-1,1)
     y_dists = turbine_y.reshape(-1,1).T - turbine_y.reshape(-1,1)
 
-    # Any turbines upstream or at the turbine location are ineligble
+    # Any turbines upstream or at the turbine location are ineligible
     x_dists[x_dists <= 0.] = np.inf
 
     # Check within Jensen model spread

--- a/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
+++ b/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
@@ -181,7 +181,7 @@ def _process_layout(
     x_dists[x_dists <= 0.] = np.inf
 
     # Check within Jensen model spread
-    in_Jensen_wake = (abs(y_dists) < spread * x_dists + rotor_diameter)
+    in_Jensen_wake = (abs(y_dists) < spread * x_dists + rotor_diameter/1.0)
     x_dists[~in_Jensen_wake] = np.inf
 
     # Get minimums (and arguments to select the correct y values also)

--- a/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
+++ b/floris/optimization/yaw_optimization/yaw_optimizer_geometric.py
@@ -85,23 +85,30 @@ def geometric_yaw(
     bottom_right_yaw_lower=0.0,
 ):
     """
-    turbine_x: unrotated x turbine coords
-    turbine_y: unrotated y turbine coords
-    wind_direction: float, degrees
-    rotor_diameter: float
-    left_x: where we start the trapezoid. Should be left as 0.
-    top_left_y: trapezoid top left coord
-    right_x: where to stop the trapezoid downstream.
-        Max coord after which the upstream turbine won't yaw.
-    top_right_y: trapezoid top right coord
-    top_left_yaw_upper: yaw angle associated with top left point (upper trapezoid)
-    top_right_yaw_upper: yaw angle associated with top right point
-    bottom_left_yaw_upper: yaw angle associated with bottom left point
-    bottom_right_yaw_upper: yaw angle associated with bottom right point
-    top_left_yaw_lower: yaw angle associated with top left point (lower trapezoid)
-    top_right_yaw_lower: yaw angle associated with top right point
-    bottom_left_yaw_lower: yaw angle associated with bottom left point
-    bottom_right_yaw_lower: yaw angle associated with bottom right point
+    Main function to compute geometric yaw angles based on wind farm layout for a single wind
+    direction.
+
+    Arguments:
+        turbine_x: unrotated x turbine coords
+        turbine_y: unrotated y turbine coords
+        wind_direction: float, degrees
+        rotor_diameter: float
+        left_x: where we start the trapezoid. Should be left as 0.
+        top_left_y: trapezoid top left coord
+        right_x: where to stop the trapezoid downstream.
+            Max coord after which the upstream turbine won't yaw.
+        top_right_y: trapezoid top right coord
+        top_left_yaw_upper: yaw angle associated with top left point (upper trapezoid)
+        top_right_yaw_upper: yaw angle associated with top right point
+        bottom_left_yaw_upper: yaw angle associated with bottom left point
+        bottom_right_yaw_upper: yaw angle associated with bottom right point
+        top_left_yaw_lower: yaw angle associated with top left point (lower trapezoid)
+        top_right_yaw_lower: yaw angle associated with top right point
+        bottom_left_yaw_lower: yaw angle associated with bottom left point
+        bottom_right_yaw_lower: yaw angle associated with bottom right point
+
+    Returns:
+        yaw_array: yaw angles for all turbines for the present wind direction.
     """
 
     nturbs = len(turbine_x)
@@ -143,15 +150,20 @@ def _process_layout(
     spread=0.1
 ):
     """
-    returns the distance from each turbine to the nearest downstream waked turbine
+    Returns the distance from each turbine to the nearest downstream waked turbine
     normalized by the rotor diameter. Right now "waked" is determined by a Jensen-like
     wake spread, but this could/should be modified to be the same as the trapezoid rule
     used to determine the yaw angles.
 
-    turbine_x: turbine x coords (rotated)
-    turbine_y: turbine y coords (rotated)
-    rotor_diameter: turbine rotor diameter (float)
-    spread=0.1: Jensen alpha wake spread value
+    Arguments:
+        turbine_x: turbine x coords (rotated)
+        turbine_y: turbine y coords (rotated)
+        rotor_diameter: turbine rotor diameter (float)
+        spread=0.1: Jensen alpha wake spread value
+
+    Returns:
+        dx: distance to nearest downstream turbine in rotor diameters for all turbines
+        dy: lateral distance to nearest downstream turbine in rotor diameters for all turbines
     """
 
     # Compute distances
@@ -189,27 +201,30 @@ def _get_yaw_angles(
     bottom_right_yaw_lower
 ):
     """
-    _______2,5___________________________4,6
-    |.......................................
-    |......1,7...........................3,8
-    |.......................................
-    ________________________________________
+    For a given turbine, return the geometric yaw angle based on its position relative to the
+    nearest downstream turbine.
 
-    x and y: dx and dy to the nearest downstream turbine in rotor diameters with
+    Arguments:
+        x: downstream distance to the nearest downstream turbine in rotor diameters with
         turbines rotated so wind is coming left to right
-    left_x: where we start the trapezoid. Should be left as 0.
-    top_left_y: trapezoid top left coord
-    right_x: where to stop the trapezoid downstream.
-        Max coord after which the upstream turbine won't yaw.
-    top_right_y: trapezoid top right coord
-    top_left_yaw_upper: yaw angle associated with top left point (upper trapezoid)
-    top_right_yaw_upper: yaw angle associated with top right point
-    bottom_left_yaw_upper: yaw angle associated with bottom left point
-    bottom_right_yaw_upper: yaw angle associated with bottom right point
-    top_left_yaw_lower: yaw angle associated with top left point (lower trapezoid)
-    top_right_yaw_lower: yaw angle associated with top right point
-    bottom_left_yaw_lower: yaw angle associated with bottom left point
-    bottom_right_yaw_lower: yaw angle associated with bottom right point
+        y: lateral distance to the nearest downstream turbine in rotor diameters with
+        turbines rotated so wind is coming left to right
+        left_x: where we start the trapezoid. Should be left as 0.
+        top_left_y: trapezoid top left coord
+        right_x: where to stop the trapezoid downstream.
+            Max coord after which the upstream turbine won't yaw.
+        top_right_y: trapezoid top right coord
+        top_left_yaw_upper: yaw angle associated with top left point (upper trapezoid)
+        top_right_yaw_upper: yaw angle associated with top right point
+        bottom_left_yaw_upper: yaw angle associated with bottom left point
+        bottom_right_yaw_upper: yaw angle associated with bottom right point
+        top_left_yaw_lower: yaw angle associated with top left point (lower trapezoid)
+        top_right_yaw_lower: yaw angle associated with top right point
+        bottom_left_yaw_lower: yaw angle associated with bottom left point
+        bottom_right_yaw_lower: yaw angle associated with bottom right point
+
+    Returns:
+        (yaw angle): float, geometric yaw angle for the given turbine
     """
 
     dx = (x-left_x)/(right_x-left_x)

--- a/tests/geometric_yaw_unit_test.py
+++ b/tests/geometric_yaw_unit_test.py
@@ -64,6 +64,8 @@ def test_basic_optimization(sample_inputs_fixture):
     # Check last turbine's angles are zero at 270.0
     assert np.allclose(df_opt.loc[3, "yaw_angles_opt"][-1], 0.0)
 
+    # YawOptimizationGeometric does not compute farm powers
+
 def test_disabled_turbines(sample_inputs_fixture):
     """
     Tests SR when some turbines are disabled and checks that the results are equivalent to removing

--- a/tests/geometric_yaw_unit_test.py
+++ b/tests/geometric_yaw_unit_test.py
@@ -135,7 +135,7 @@ def test_process_layout():
         rotor_diameter=1.0,
         spread=0.5
     )
-    assert dx[0] == 0.0 # Distance to downstream turbine, which is outside the wake
+    assert dx[0] == np.inf # Distance to downstream turbine, which is outside the wake
 
     # Test effect of rotor diameter
     dx, dy, = _process_layout(
@@ -144,7 +144,7 @@ def test_process_layout():
         rotor_diameter=100.0,
         spread=0.5
     )
-    assert dx[0] > 0.0 # This turbine is now inside the wake
+    assert dx[0] != np.inf # This turbine is now inside the wake
 
     dx, dy = _process_layout(
         turbine_x=np.array([0.0, 1000.0]),
@@ -152,4 +152,4 @@ def test_process_layout():
         rotor_diameter=100.0,
         spread=0.5
     )
-    assert dx[0] == 0.0 # This turbine is now outside the wake
+    assert dx[0] == np.inf # This turbine is now outside the wake

--- a/tests/geometric_yaw_unit_test.py
+++ b/tests/geometric_yaw_unit_test.py
@@ -61,7 +61,20 @@ def test_basic_optimization(sample_inputs_fixture):
     # Check last turbine's angles are zero at 270.0
     assert np.allclose(df_opt.loc[3, "yaw_angles_opt"][-1], 0.0)
 
-    # YawOptimizationGeometric does not compute farm powers
+    # Check the critical angle where a turbine comes just outside of the Jensen wake
+    # (based on trial and error with defaults)
+    fmodel.set(
+        wind_directions=[282.0],
+        wind_speeds=WIND_SPEEDS[0:1],
+        turbulence_intensities=TURBULENCE_INTENSITIES[0:1]
+    )
+    yaw_opt = YawOptimizationGeometric(
+        fmodel,
+        minimum_yaw_angle=0.0,
+        maximum_yaw_angle=MAXIMUM_YAW_ANGLE
+    )
+    df_opt = yaw_opt.optimize()
+    assert np.allclose(df_opt.yaw_angles_opt.values[0], 0.0)
 
 def test_disabled_turbines(sample_inputs_fixture):
     """

--- a/tests/geometric_yaw_unit_test.py
+++ b/tests/geometric_yaw_unit_test.py
@@ -3,7 +3,10 @@ import numpy as np
 import pandas as pd
 
 from floris import FlorisModel
-from floris.optimization.yaw_optimization.yaw_optimizer_geometric import YawOptimizationGeometric
+from floris.optimization.yaw_optimization.yaw_optimizer_geometric import (
+    _process_layout,
+    YawOptimizationGeometric,
+)
 
 
 DEBUG = False
@@ -61,21 +64,6 @@ def test_basic_optimization(sample_inputs_fixture):
     # Check last turbine's angles are zero at 270.0
     assert np.allclose(df_opt.loc[3, "yaw_angles_opt"][-1], 0.0)
 
-    # Check the critical angle where a turbine comes just outside of the Jensen wake
-    # (based on trial and error with defaults)
-    fmodel.set(
-        wind_directions=[282.0],
-        wind_speeds=WIND_SPEEDS[0:1],
-        turbulence_intensities=TURBULENCE_INTENSITIES[0:1]
-    )
-    yaw_opt = YawOptimizationGeometric(
-        fmodel,
-        minimum_yaw_angle=0.0,
-        maximum_yaw_angle=MAXIMUM_YAW_ANGLE
-    )
-    df_opt = yaw_opt.optimize()
-    assert np.allclose(df_opt.yaw_angles_opt.values[0], 0.0)
-
 def test_disabled_turbines(sample_inputs_fixture):
     """
     Tests SR when some turbines are disabled and checks that the results are equivalent to removing
@@ -126,3 +114,40 @@ def test_disabled_turbines(sample_inputs_fixture):
     yaw_angles_opt_removed = df_opt.loc[3, "yaw_angles_opt"]
 
     assert np.allclose(yaw_angles_opt_disabled[[0, 2]], yaw_angles_opt_removed)
+
+def test_process_layout():
+
+    # Test inside Jensen-like wake
+    dx, dy = _process_layout(
+        turbine_x=np.array([0.0, 1000.0]),
+        turbine_y=np.array([0.0, 499.0]),
+        rotor_diameter=1.0,
+        spread=0.5
+    )
+    assert dx[0] == 1000.0 # Distance to downstream turbine, which is inside the wake
+
+    # Test outside Jensen-like wake
+    dx, dy, = _process_layout(
+        turbine_x=np.array([0.0, 1000.0]),
+        turbine_y=np.array([0.0, 501.0]),
+        rotor_diameter=1.0,
+        spread=0.5
+    )
+    assert dx[0] == 0.0 # Distance to downstream turbine, which is outside the wake
+
+    # Test effect of rotor diameter
+    dx, dy, = _process_layout(
+        turbine_x=np.array([0.0, 1000.0]),
+        turbine_y=np.array([0.0, 549.0]),
+        rotor_diameter=100.0,
+        spread=0.5
+    )
+    assert dx[0] > 0.0 # This turbine is now inside the wake
+
+    dx, dy = _process_layout(
+        turbine_x=np.array([0.0, 1000.0]),
+        turbine_y=np.array([0.0, 551.0]),
+        rotor_diameter=100.0,
+        spread=0.5
+    )
+    assert dx[0] == 0.0 # This turbine is now outside the wake


### PR DESCRIPTION
Addresses bug flagged in #1138 by adding appropriate `/2.0` divisor and adds a test for the `_process_layout()` function. 

The updated implementation passes the new tests; the old version (without the `/2.0`) fails the test.


I also made a couple of updates to use `np.inf` rather than `0.` as an indicator of "far downstream" turbines. I checked that this does not affect outputs of regression tests and examples, and it simplifies the code somewhat and (in my opinion) makes the method clearer. Affected code: `_process_layout()` and `_get_yaw_angles()`. As these are both "hidden" functions, I'm comfortable that we can change their behavior without considering this a breaking change.

Note that all existing tests still pass (see tests/geometric_yaw_unit_test.py and tests/reg_tests/yaw_optimization_regression_test.py). Also, no change appears in examples/examples_control_optimization/006_compare_yaw_optimizers.py