### PR TITLE
Added run_solver flag to sample_flow_at_points and sample_ti_at_points

### DIFF
--- a/floris/core/core.py
+++ b/floris/core/core.py
@@ -264,8 +264,6 @@ class Core(BaseClass):
         else:
             full_flow_sequential_solver(self.farm, self.flow_field, field_grid, self.wake)
 
-        return self.flow_field.u_sorted[:,:,0,0] # Remove turbine grid dimensions
-
     def solve_for_velocity_deficit_profiles(
         self,
         direction: str,
@@ -319,7 +317,8 @@ class Core(BaseClass):
         y = np.squeeze(y, axis=0) + y_start
         z = np.squeeze(z, axis=0) + reference_height
 
-        u = self.solve_for_points(x.flatten(), y.flatten(), z.flatten())
+        self.solve_for_points(x.flatten(), y.flatten(), z.flatten())
+        u = self.flow_field.u_sorted[:, :, 0, 0]
         u = np.reshape(u[0, :], (n_lines, resolution))
         velocity_deficit = (homogeneous_wind_speed - u) / homogeneous_wind_speed
 

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1368,7 +1368,7 @@ class FlorisModel(LoggingManager):
 
         return df
 
-    def sample_flow_at_points(self, x: NDArrayFloat, y: NDArrayFloat, z: NDArrayFloat):
+    def sample_flow_at_points(self, x: NDArrayFloat, y: NDArrayFloat, z: NDArrayFloat, run_solver: bool = True):
         """
         Extract the wind speed at points in the flow.
 
@@ -1376,6 +1376,7 @@ class FlorisModel(LoggingManager):
             x (1DArrayFloat | list): x-locations of points where flow is desired.
             y (1DArrayFloat | list): y-locations of points where flow is desired.
             z (1DArrayFloat | list): z-locations of points where flow is desired.
+            run_solver (bool): If `True` (default), run the solver. This is useful when this function is used in combination with `sample_ti_at_points`.
 
         Returns:
             3DArrayFloat containing wind speed with dimensions
@@ -1386,9 +1387,13 @@ class FlorisModel(LoggingManager):
         if not len(x) == len(y) == len(z):
             raise ValueError("x, y, and z must be the same size")
 
-        return self.core.solve_for_points(x, y, z)
+        if run_solver:
+            self.core.solve_for_points(x, y, z)
 
-    def sample_ti_at_points(self, x: NDArrayFloat, y: NDArrayFloat, z: NDArrayFloat):
+        # Remove grid dimensions and return sorted wind speed field.
+        return self.core.flow_field.u_sorted[:, :, 0, 0]
+
+    def sample_ti_at_points(self, x: NDArrayFloat, y: NDArrayFloat, z: NDArrayFloat, run_solver: bool = True):
         """
         Extract the turbulence intensity at points in the flow.
 
@@ -1396,13 +1401,14 @@ class FlorisModel(LoggingManager):
             x (1DArrayFloat | list): x-locations of points where TI is desired.
             y (1DArrayFloat | list): y-locations of points where TI is desired.
             z (1DArrayFloat | list): z-locations of points where TI is desired.
+            run_solver (bool): If `True` (default), run the solver. This is useful when this function is used in combination with `sample_flow_at_points`.
 
         Returns:
             3DArrayFloat containing turbulence intensity with dimensions
             (# of findex, # of sample points)
         """
-
-        self.sample_flow_at_points(x, y, z) # Solve, but ignore returned velocities
+        if run_solver:
+            self.core.solve_for_points(x, y, z)
 
         # Remove grid dimensions and return sorted TI field
         return self.core.flow_field.turbulence_intensity_field_sorted[:, :, 0, 0]

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1368,7 +1368,11 @@ class FlorisModel(LoggingManager):
 
         return df
 
-    def sample_flow_at_points(self, x: NDArrayFloat, y: NDArrayFloat, z: NDArrayFloat, run_solver: bool = True):
+    def sample_flow_at_points(self,
+                              x: NDArrayFloat,
+                              y: NDArrayFloat,
+                              z: NDArrayFloat,
+                              run_solver: bool = True):
         """
         Extract the wind speed at points in the flow.
 
@@ -1376,7 +1380,7 @@ class FlorisModel(LoggingManager):
             x (1DArrayFloat | list): x-locations of points where flow is desired.
             y (1DArrayFloat | list): y-locations of points where flow is desired.
             z (1DArrayFloat | list): z-locations of points where flow is desired.
-            run_solver (bool): If `True` (default), run the solver. This is useful when this function is used in combination with `sample_ti_at_points`.
+            run_solver (bool): If `True` (default), run the solver.
 
         Returns:
             3DArrayFloat containing wind speed with dimensions
@@ -1393,7 +1397,11 @@ class FlorisModel(LoggingManager):
         # Remove grid dimensions and return sorted wind speed field.
         return self.core.flow_field.u_sorted[:, :, 0, 0]
 
-    def sample_ti_at_points(self, x: NDArrayFloat, y: NDArrayFloat, z: NDArrayFloat, run_solver: bool = True):
+    def sample_ti_at_points(self,
+                            x: NDArrayFloat,
+                            y: NDArrayFloat,
+                            z: NDArrayFloat,
+                            run_solver: bool = True):
         """
         Extract the turbulence intensity at points in the flow.
 
@@ -1401,7 +1409,7 @@ class FlorisModel(LoggingManager):
             x (1DArrayFloat | list): x-locations of points where TI is desired.
             y (1DArrayFloat | list): y-locations of points where TI is desired.
             z (1DArrayFloat | list): z-locations of points where TI is desired.
-            run_solver (bool): If `True` (default), run the solver. This is useful when this function is used in combination with `sample_flow_at_points`.
+            run_solver (bool): If `True` (default), run the solver.
 
         Returns:
             3DArrayFloat containing turbulence intensity with dimensions


### PR DESCRIPTION
# Added `run_solver` flag to `sample_flow_at_points` and `sample_ti_at_points`

The functions `sample_flow_at_points` and `sample_ti_at_points` are fine when used independently. However, if the user needs both the wind speed and TI field for the same grid, then the solver is called twice. I've added a flag to prevent that.

## Related issue

None.

## Impacted areas of the software

- `FlorisModel`
- `Core`

## Additional supporting information


## Test results, if applicable


<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md (appears twice in README.md)
    - [ ] pyproject.toml
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/FLORIS repository
-->
