### PR TITLE
Update floating tilt table for floating IEA 15MW model

### DIFF
--- a/docs/turbine_library.md
+++ b/docs/turbine_library.md
@@ -47,11 +47,12 @@ This fictional turbine model is not currently used in examples.
 
 ## IEA 15MW floating, multidimensional
 
-The same as the multidimensional IEA 15MW turbine model above, but with an additional fictional
-floating platform tilt table. This model is used to demonstrate the floating wind turbine capabilities
+The same as the multidimensional IEA 15MW turbine model above, but with an additional floating
+platform tilt table. This model is used to demonstrate the floating wind turbine capabilities
 in FLORIS. Specified as `"iea_15MW_floating_multi_dim"` in the `turbine_type` field of the FLORIS input
-dictionary. The data for the floating tilt table was generated using OpenFAST with the U-Maine floater
-by Sam Kaufman-Martin, as seen [here](https://github.com/FLOWMAS-EERC/IEA15_FOWT/blob/main/iea_15MW_floating_power-from-fixed.yaml).
+dictionary. The data for the floating tilt table was generated using OpenFAST with the UMaine
+VolturnUS-S Reference Platform by Sam Kaufman-Martin, as seen
+[here](https://github.com/FLOWMAS-EERC/IEA15_FOWT/blob/main/iea_15MW_floating_power-from-fixed.yaml).
 
 This fictional turbine model is used in the following examples:
 - examples/examples_multidim/001_multi_dimensional_cp_ct.py

--- a/docs/turbine_library.md
+++ b/docs/turbine_library.md
@@ -50,7 +50,8 @@ This fictional turbine model is not currently used in examples.
 The same as the multidimensional IEA 15MW turbine model above, but with an additional fictional
 floating platform tilt table. This model is used to demonstrate the floating wind turbine capabilities
 in FLORIS. Specified as `"iea_15MW_floating_multi_dim"` in the `turbine_type` field of the FLORIS input
-dictionary. This data should be treated as fictional and for demonstrative purposes only.
+dictionary. The data for the floating tilt table was generated using OpenFAST with the U-Maine floater
+by Sam Kaufman-Martin, as seen [here](https://github.com/FLOWMAS-EERC/IEA15_FOWT/blob/main/iea_15MW_floating_power-from-fixed.yaml).
 
 This fictional turbine model is used in the following examples:
 - examples/examples_multidim/001_multi_dimensional_cp_ct.py

--- a/floris/turbine_library/iea_15MW_floating_multi_dim_cp_ct.yaml
+++ b/floris/turbine_library/iea_15MW_floating_multi_dim_cp_ct.yaml
@@ -13,23 +13,55 @@ power_thrust_table:
   power_thrust_data_file: 'iea_15MW_multi_dim_Tp_Hs.csv'
 # The floating_tilt_table describes the steady state tilt of the floating platform as a function of
 # wind speed. This is used to adjust the power and thrust coefficients when correct_cp_ct_for_tilt
-# is True. The values specified here should be treated as a fictional example only, and may not
-# represent a real floating platform.
+# is True. Updated values as of FLORIS v4.6, taken from
+# https://github.com/FLOWMAS-EERC/IEA15_FOWT/blob/main/iea_15MW_floating_power-from-fixed.yaml
+# generated using OpenFAST with the U-Maine floater by Sam Kaufman-Martin.
+# The floater model used to generate these values is 
 floating_tilt_table:
   tilt:
-    - 5.747296314800103
-    - 7.2342400188651068
-    - 9.0468701999352397
-    - 9.762182013267733
-    - 8.795649572299896
-    - 8.089078308325314
-    - 7.7229584934943614
+    - 5.406938261
+    - 5.889508311
+    - 6.566875672
+    - 7.339842075
+    - 8.189297064
+    - 9.175639814
+    - 10.20156799
+    - 10.42520318
+    - 9.954627435
+    - 9.266065643
+    - 8.833742574
+    - 8.514576732
+    - 8.268973572
+    - 8.076813462
+    - 7.924809783
+    - 7.803116564
+    - 7.70524892
+    - 7.626825229
+    - 7.564642136
+    - 7.516322963
+    - 7.48004717
+    - 7.45510389
   wind_speed:
-    - 4.0
-    - 6.0
-    - 8.0
-    - 10.0
-    - 12.0
-    - 14.0
-    - 16.0
+    - 3.5
+    - 4.5
+    - 5.5
+    - 6.5
+    - 7.5
+    - 8.5
+    - 9.5
+    - 10.5
+    - 11.5
+    - 12.5
+    - 13.5
+    - 14.5
+    - 15.5
+    - 16.5
+    - 17.5
+    - 18.5
+    - 19.5
+    - 20.5
+    - 21.5
+    - 22.5
+    - 23.5
+    - 24.5
 correct_cp_ct_for_tilt: True

--- a/floris/turbine_library/iea_15MW_floating_multi_dim_cp_ct.yaml
+++ b/floris/turbine_library/iea_15MW_floating_multi_dim_cp_ct.yaml
@@ -16,7 +16,7 @@ power_thrust_table:
 # is True. Updated values as of FLORIS v4.6, taken from
 # https://github.com/FLOWMAS-EERC/IEA15_FOWT/blob/main/iea_15MW_floating_power-from-fixed.yaml
 # generated using OpenFAST with the U-Maine floater by Sam Kaufman-Martin.
-# The floater model used to generate these values is
+# The floater model used to generate these values is the UMaine VolturnUS-S Reference Platform.
 floating_tilt_table:
   tilt:
     - 5.406938261

--- a/floris/turbine_library/iea_15MW_floating_multi_dim_cp_ct.yaml
+++ b/floris/turbine_library/iea_15MW_floating_multi_dim_cp_ct.yaml
@@ -16,7 +16,7 @@ power_thrust_table:
 # is True. Updated values as of FLORIS v4.6, taken from
 # https://github.com/FLOWMAS-EERC/IEA15_FOWT/blob/main/iea_15MW_floating_power-from-fixed.yaml
 # generated using OpenFAST with the U-Maine floater by Sam Kaufman-Martin.
-# The floater model used to generate these values is 
+# The floater model used to generate these values is
 floating_tilt_table:
   tilt:
     - 5.406938261


### PR DESCRIPTION
As indicated in #1142 , which builds off #1125 and #1130, there is currently some ambiguity about the floating tilt table data in floris/turbine_library/iea_15MW_floating_multidim_cp_ct.yaml.

This PR updates the values for the tilt angle of the rotor under various wind speeds using data provided by @samjkmartin in [their repository](https://github.com/FLOWMAS-EERC/IEA15_FOWT) (see in particular [this file](https://github.com/FLOWMAS-EERC/IEA15_FOWT/blob/main/iea_15MW_floating_power-from-fixed.yaml)).

Separately, after some discussion with @dzalkind , it appears that the existing tilt table data is probably reasonably accurate for the [UMaine platform](https://docs.nrel.gov/docs/fy20osti/76773.pdf). This was also confirmed by @mkrause-strath in [this comment](https://github.com/NREL/floris/discussions/1130#discussioncomment-14407315).

None-the-less, the new table from @samjkmartin is at higher wind speed resolution and covers a greater range of wind speeds, and this PR replaces the existing data with the new data.

Comparing the previous data with the data introduced in this PR, I see:
<img width="569" height="435" alt="image" src="https://github.com/user-attachments/assets/43c92a78-1ae1-4611-bd9e-4cfdd91293f0" />
which is within roughly 1 degree across all wind speeds.

A good example to see this (slight) difference in behavior is examples/examples_multidim/001_multidimensional_cp_ct.py. Using the original data, the turbine powers for the 3 findex, 2 turbine case are
```
[[3109.85063666 1233.81430883]
 [4421.65644331 1795.18052591]
 [6027.16461318 2480.53028085]]
```
whereas with the updated values, this becomes
```
[[3115.68688793 1234.25106658]
 [4415.57562618 1799.26442693]
 [6007.59995332 2488.99346906]]
```
which is a difference of less than 1% across all turbines. Note that this particular example does not account for wake deflection due to tilt, which may also slightly change downstream turbines' powers.

@samjkmartin, could you take a look at this and confirm things look correct from your perspective? Also, could you confirm you were running OpenFAST using the UMaine platform for the IEA 15MW in your simulations?

