### PR TITLE
[BUGFIX] Heterogeneous inflows with `ParFlorisModel` [FLORIS v4.5.1]

### DIFF
--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1,3 +1,6 @@
+
+from __future__ import annotations
+
 import copy
 import inspect
 from pathlib import Path

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1,6 +1,3 @@
-
-from __future__ import annotations
-
 import copy
 import inspect
 from pathlib import Path
@@ -140,7 +137,7 @@ class FlorisModel(LoggingManager):
         turbine_type: list | None = None,
         turbine_library_path: str | Path | None = None,
         solver_settings: dict | None = None,
-        heterogeneous_inflow_config=None,
+        heterogeneous_inflow_config: dict | None = None,
         wind_data: type[WindDataBase] | None = None,
         multidim_conditions: dict | None = None,
     ):
@@ -170,7 +167,7 @@ class FlorisModel(LoggingManager):
             turbine_library_path (str | Path | None, optional): Path to the turbine library.
                 Defaults to None.
             solver_settings (dict | None, optional): Solver settings. Defaults to None.
-            heterogeneous_inflow_config (None, optional): heterogeneous inflow configuration.
+            heterogeneous_inflow_config (dict | None, optional): heterogeneous inflow configuration.
                 Defaults to None.
             wind_data (type[WindDataBase] | None, optional): Wind data. Defaults to None.
         """
@@ -396,7 +393,7 @@ class FlorisModel(LoggingManager):
         turbine_type: list | None = None,
         turbine_library_path: str | Path | None = None,
         solver_settings: dict | None = None,
-        heterogeneous_inflow_config=None,
+        heterogeneous_inflow_config: dict | None = None,
         wind_data: type[WindDataBase] | None = None,
         yaw_angles: NDArrayFloat | list[float] | None = None,
         power_setpoints: NDArrayFloat | list[float] | list[float, None] | None = None,
@@ -428,7 +425,7 @@ class FlorisModel(LoggingManager):
             turbine_library_path (str | Path | None, optional): Path to the turbine library.
                 Defaults to None.
             solver_settings (dict | None, optional): Solver settings. Defaults to None.
-            heterogeneous_inflow_config (None, optional): heterogeneous inflow configuration.
+            heterogeneous_inflow_config (dict | None, optional): heterogeneous inflow configuration.
                 Defaults to None.
             wind_data (type[WindDataBase] | None, optional): Wind data. Defaults to None.
             yaw_angles (NDArrayFloat | list[float] | None, optional): Turbine yaw angles.

--- a/floris/par_floris_model.py
+++ b/floris/par_floris_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 from pathlib import Path
 from time import perf_counter as timerpc

--- a/floris/par_floris_model.py
+++ b/floris/par_floris_model.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import copy
 from pathlib import Path
 from time import perf_counter as timerpc
@@ -247,8 +245,8 @@ class ParFlorisModel(FlorisModel):
             self.core.initialize_domain()
             parallel_run_inputs = self._preprocessing()
             parallel_sample_flow_at_points_inputs = [
-                (fmodel_dict, control_setpoints, x, y, z)
-                for fmodel_dict, control_setpoints in parallel_run_inputs
+                (fmodel_dict, set_args, x, y, z)
+                for fmodel_dict, set_args in parallel_run_inputs
             ]
             t1 = timerpc()
             if value == "velocity":
@@ -304,24 +302,36 @@ class ParFlorisModel(FlorisModel):
         for wc_id_split in wind_condition_id_splits:
             # for ws_id_split in wind_speed_id_splits:
             fmodel_dict_split = copy.deepcopy(fmodel_dict)
-            wind_directions = self.core.flow_field.wind_directions[wc_id_split]
-            wind_speeds = self.core.flow_field.wind_speeds[wc_id_split]
-            turbulence_intensities = self.core.flow_field.turbulence_intensities[wc_id_split]
 
-            # Extract and format all control setpoints as a dict that can be unpacked later
-            control_setpoints_subset = {
+            # Extract and format all arguments that are per-findex
+            # (scalar arguments are already broadcast on fmodel_dict_split)
+            set_args_subset = {
+                "wind_directions": self.core.flow_field.wind_directions[wc_id_split],
+                "wind_speeds": self.core.flow_field.wind_speeds[wc_id_split],
+                "turbulence_intensities": self.core.flow_field.turbulence_intensities[wc_id_split],
                 "yaw_angles": self.core.farm.yaw_angles[wc_id_split, :],
                 "power_setpoints": self.core.farm.power_setpoints[wc_id_split, :],
                 "awc_modes": self.core.farm.awc_modes[wc_id_split, :],
                 "awc_amplitudes": self.core.farm.awc_amplitudes[wc_id_split, :],
                 "awc_frequencies": self.core.farm.awc_frequencies[wc_id_split, :],
+                # disable_turbines is not saved on core, but passed through power_setpoints
             }
-            fmodel_dict_split["flow_field"]["wind_directions"] = wind_directions
-            fmodel_dict_split["flow_field"]["wind_speeds"] = wind_speeds
-            fmodel_dict_split["flow_field"]["turbulence_intensities"] = turbulence_intensities
+
+            # Handle heterogeneous_inflow_config
+            if self.core.flow_field.heterogeneous_inflow_config is not None:
+                heterogeneous_inflow_config_subset = {
+                    "x": self.core.flow_field.heterogeneous_inflow_config["x"],
+                    "y": self.core.flow_field.heterogeneous_inflow_config["y"],
+                    "speed_multipliers": self.core.flow_field.heterogeneous_inflow_config\
+                        ["speed_multipliers"][wc_id_split, :]
+                }
+                if "z" in self.core.flow_field.heterogeneous_inflow_config.keys():
+                    heterogeneous_inflow_config_subset["z"] = \
+                        self.core.flow_field.heterogeneous_inflow_config["z"]
+                set_args_subset["heterogeneous_inflow_config"] = heterogeneous_inflow_config_subset
 
             # Prepare lightweight data to pass along
-            multiargs.append((fmodel_dict_split, control_setpoints_subset))
+            multiargs.append((fmodel_dict_split, set_args_subset))
 
         return multiargs
 

--- a/tests/par_floris_model_unit_test.py
+++ b/tests/par_floris_model_unit_test.py
@@ -287,6 +287,37 @@ def test_control_setpoints(sample_inputs_fixture):
     assert powers_fmodel.shape == powers_pfmodel.shape
     assert np.allclose(powers_fmodel, powers_pfmodel)
 
+    # Reset yaw angles and test power setpoints
+    power_setpoints = np.tile(np.array([[1.0e6, 2.0e6, 1.0e12]]), (fmodel.n_findex,1))
+    fmodel.set_operation_model("simple-derating")
+    pfmodel.set_operation_model("simple-derating")
+    fmodel.set(power_setpoints=power_setpoints, yaw_angles=np.zeros_like(yaw_angles))
+    pfmodel.set(power_setpoints=power_setpoints, yaw_angles=np.zeros_like(yaw_angles))
+    fmodel.run()
+    powers_fmodel = fmodel.get_turbine_powers()
+    pfmodel.run()
+    powers_pfmodel = pfmodel.get_turbine_powers()
+
+    assert powers_fmodel.shape == powers_pfmodel.shape
+    assert np.allclose(powers_fmodel, powers_pfmodel)
+
+    # Reset power setpoints and test disable_turbines
+    disable_turbines = np.tile(np.array([[False, True, False]]), (fmodel.n_findex,1))
+    fmodel.set(
+        disable_turbines=disable_turbines,
+        power_setpoints=1e12*np.ones_like(power_setpoints)
+    )
+    pfmodel.set(
+        disable_turbines=disable_turbines,
+        power_setpoints=1e12*np.ones_like(power_setpoints)
+    )
+    fmodel.run()
+    powers_fmodel = fmodel.get_turbine_powers()
+    pfmodel.run()
+    powers_pfmodel = pfmodel.get_turbine_powers()
+    assert powers_fmodel.shape == powers_pfmodel.shape
+    assert np.allclose(powers_fmodel, powers_pfmodel)
+
 def test_sample_flow_at_points(sample_inputs_fixture):
 
     sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
@@ -352,3 +383,65 @@ def test_copy(sample_inputs_fixture):
     pfmodel_copy = pfmodel.copy()
     assert isinstance(pfmodel_copy, ParFlorisModel)
     assert pfmodel_copy.max_workers == 2
+
+def test_heterogeneous_inflow_config(sample_inputs_fixture):
+    """
+    Check that the ParFlorisModel works with heterogeneous_inflow_config set.
+    """
+
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    heterogeneous_inflow_config = {
+        "x": np.array([-200.0, 2000.0, -200.0, 2000.0]),
+        "y": np.array([-200.0, -200.0, 200.0, 200.0]),
+        "speed_multipliers": np.array(
+            [
+                [1.0, 1.1, 1.2, 1.2],
+                [1.1, 1.1, 1.1, 1.1],
+                [1.0, 1.1, 1.2, 1.1],
+            ]
+        ),
+    }
+    wind_directions = np.array([270.0, 270.0, 270.0])
+    wind_speeds = np.array([8.0, 8.0, 9.0])
+    turbulence_intensities = 0.06 * np.ones_like(wind_speeds)
+
+    fmodel = FlorisModel(sample_inputs_fixture.core)
+    pfmodel = ParFlorisModel(
+        sample_inputs_fixture.core,
+        interface="multiprocessing",
+        n_wind_condition_splits=2,
+    )
+
+    # Temporarily, run fmodel without heterogeneous_inflow_config to get baseline
+    fmodel.set(
+        wind_directions=wind_directions,
+        wind_speeds=wind_speeds,
+        turbulence_intensities=turbulence_intensities,
+    )
+    fmodel.run()
+    baseline_powers = fmodel.get_turbine_powers()
+
+    # Set heterogeneous_flow_config cases and run
+    fmodel.set(
+        wind_directions=wind_directions,
+        wind_speeds=wind_speeds,
+        turbulence_intensities=turbulence_intensities,
+        heterogeneous_inflow_config=heterogeneous_inflow_config,
+    )
+    pfmodel.set(
+        wind_directions=wind_directions,
+        wind_speeds=wind_speeds,
+        turbulence_intensities=turbulence_intensities,
+        heterogeneous_inflow_config=heterogeneous_inflow_config,
+    )
+    fmodel.run()
+    pfmodel.run()
+
+    powers_fmodel = fmodel.get_turbine_powers()
+    assert (powers_fmodel != baseline_powers).any()  # Check no overlap to ensure test is valid
+    powers_pfmodel = pfmodel.get_turbine_powers()
+
+    # Confirm that the powers computed using the ParFlorisModel match those from the FlorisModel
+    assert np.allclose(powers_fmodel, powers_pfmodel)

--- a/tests/par_floris_model_unit_test.py
+++ b/tests/par_floris_model_unit_test.py
@@ -264,14 +264,14 @@ def test_wind_data_objects(sample_inputs_fixture):
 
 def test_control_setpoints(sample_inputs_fixture):
     """
-    Check that the ParFlorisModel is compatible with yaw angles.
+    Check that the ParFlorisModel is compatible with control set points.
     """
 
     sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
     sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
 
     fmodel = FlorisModel(sample_inputs_fixture.core)
-    pfmodel = ParFlorisModel(sample_inputs_fixture.core, max_workers=2)
+    pfmodel = ParFlorisModel(sample_inputs_fixture.core, n_wind_condition_splits=2)
 
     # Set yaw angles
     yaw_angles = np.tile(np.array([[10.0, 20.0, 30.0]]), (fmodel.n_findex,1))
@@ -291,8 +291,11 @@ def test_control_setpoints(sample_inputs_fixture):
     power_setpoints = np.tile(np.array([[1.0e6, 2.0e6, 1.0e12]]), (fmodel.n_findex,1))
     fmodel.set_operation_model("simple-derating")
     pfmodel.set_operation_model("simple-derating")
-    fmodel.set(power_setpoints=power_setpoints, yaw_angles=np.zeros_like(yaw_angles))
-    pfmodel.set(power_setpoints=power_setpoints, yaw_angles=np.zeros_like(yaw_angles))
+    fmodel.reset_operation()
+    pfmodel.reset_operation()
+
+    fmodel.set(power_setpoints=power_setpoints)
+    pfmodel.set(power_setpoints=power_setpoints)
     fmodel.run()
     powers_fmodel = fmodel.get_turbine_powers()
     pfmodel.run()
@@ -303,20 +306,43 @@ def test_control_setpoints(sample_inputs_fixture):
 
     # Reset power setpoints and test disable_turbines
     disable_turbines = np.tile(np.array([[False, True, False]]), (fmodel.n_findex,1))
-    fmodel.set(
-        disable_turbines=disable_turbines,
-        power_setpoints=1e12*np.ones_like(power_setpoints)
-    )
-    pfmodel.set(
-        disable_turbines=disable_turbines,
-        power_setpoints=1e12*np.ones_like(power_setpoints)
-    )
+    fmodel.reset_operation()
+    pfmodel.reset_operation()
+
+    fmodel.set(disable_turbines=disable_turbines)
+    pfmodel.set(disable_turbines=disable_turbines)
     fmodel.run()
     powers_fmodel = fmodel.get_turbine_powers()
     pfmodel.run()
     powers_pfmodel = pfmodel.get_turbine_powers()
     assert powers_fmodel.shape == powers_pfmodel.shape
     assert np.allclose(powers_fmodel, powers_pfmodel)
+
+    # Test AWC set points
+    awc_modes = np.tile([["helix", "helix", "baseline"]], (fmodel.n_findex,1))
+    awc_amplitudes = np.tile([[0.0, 2.0, 0.0]], (fmodel.n_findex,1))
+    fmodel.set_operation_model("awc")
+    pfmodel.set_operation_model("awc")
+    fmodel.reset_operation()
+    pfmodel.reset_operation()
+
+    # Run once without AWC as a check
+    fmodel.run()
+    powers_base = fmodel.get_turbine_powers()
+
+    # Now run with AWC
+    fmodel.set(awc_modes=awc_modes, awc_amplitudes=awc_amplitudes)
+    pfmodel.set(awc_modes=awc_modes, awc_amplitudes=awc_amplitudes)
+    fmodel.run()
+    powers_fmodel = fmodel.get_turbine_powers()
+    pfmodel.run()
+    powers_pfmodel = pfmodel.get_turbine_powers()
+    assert powers_fmodel.shape == powers_pfmodel.shape
+    assert np.allclose(powers_fmodel, powers_pfmodel)
+
+    # Confirm that AWC changed the powers from baseline
+    assert np.allclose(powers_base[:, 0], powers_fmodel[:, 0]) # 0 amplitude
+    assert not np.isclose(powers_base[:, 1], powers_fmodel[:, 1]).any() # Helix applied
 
 def test_sample_flow_at_points(sample_inputs_fixture):
 

--- a/tests/par_floris_model_unit_test.py
+++ b/tests/par_floris_model_unit_test.py
@@ -471,3 +471,17 @@ def test_heterogeneous_inflow_config(sample_inputs_fixture):
 
     # Confirm that the powers computed using the ParFlorisModel match those from the FlorisModel
     assert np.allclose(powers_fmodel, powers_pfmodel)
+
+    # Repeat test with z component added
+    heterogeneous_inflow_config["z"] = np.array([0.0, 0.0, 0.0, 1000.0])
+
+    fmodel.set(heterogeneous_inflow_config=heterogeneous_inflow_config, wind_shear=0.0)
+    pfmodel.set(heterogeneous_inflow_config=heterogeneous_inflow_config, wind_shear=0.0)
+    fmodel.run()
+    pfmodel.run()
+
+    powers_fmodel = fmodel.get_turbine_powers()
+    assert (powers_fmodel != baseline_powers).any()  # Check no overlap to ensure test is valid
+    powers_pfmodel = pfmodel.get_turbine_powers()
+    # Confirm that the powers computed using the ParFlorisModel match those from the FlorisModel
+    assert np.allclose(powers_fmodel, powers_pfmodel)


### PR DESCRIPTION
While working on #1152, I realized that the `heterogeneous_inflow_config` is not properly handled on the `ParFlorisModel`. In particular, the `heterogeneous_inflow_config` is not correctly broken down into subsets to pass off to the parallelized `FlorisModel` workers, meaning that all workers may be running the same subset of the `heterogeneous_infow_config` (instead of their correct subset).

This PR fixes the issue; since I consider this to be a fairly critical bug and the develop branch currently have some other changes that would be better to release in a minor version release, I'm directing this PR to main; once (squashed and) merged, I will:
- [x] increment the version number on main
- [x] create a patch release (v4.5.1) pointing at main
- [x] merge main back into develop.

To fix the issue and hopefully avoid future similar issues, I've moved from making changes to the `fmodel_dict` to pass to the parallel workers to explicitly passing information through the keyword arguments to `set()`. This should be done for all future arguments where there are findex dimensions (scalar arguments to `set()`, such as `reference_wind_height` or `wind_shear`, remain as being passed on `fmodel_dict`).

I've added a test for the new capability, as well as adding tests for passing control set points. These all now pass. I also made the type-hinting of `FlorisModel` for `heterogeneous_inflow_config` explicit, since this was missing before.