### PR TITLE
[DOCS] Fix Empirical Gaussian wake-induced mixing term definition

### DIFF
--- a/docs/empirical_gauss_model.md
+++ b/docs/empirical_gauss_model.md
@@ -113,7 +113,7 @@ the empirical model, explicit dependencies on turbulence intensity are removed
 completely to aid in tuning. Instead, a non-physical "wake-induced mixing
 factor" is specified for turbine $j$ as
 
-$$ \text{WIM}_j = \sqrt{\sum_{i \neq j} 
+$$ \text{WIM}_j = \sqrt{\sum_{i \neq j}
 \left(\frac{A_{ij} a_i} {\bar{d}_{ij}^2}\right)^2} $$
 
 where $A_{ij}$ is the area of overlap of the wake of turbine $i$

--- a/docs/empirical_gauss_model.md
+++ b/docs/empirical_gauss_model.md
@@ -113,15 +113,14 @@ the empirical model, explicit dependencies on turbulence intensity are removed
 completely to aid in tuning. Instead, a non-physical "wake-induced mixing
 factor" is specified for turbine $j$ as
 
-$$ \text{WIM}_j = \sqrt{\sum_{i \in T^{\text{up}}(j)} 
+$$ \text{WIM}_j = \sqrt{\sum_{i \neq j} 
 \left(\frac{A_{ij} a_i} {\left((x_j - x_i)/D_i\right)^2}\right)^2} $$
 
-where $T_T^{\text{up}}(j)$ is the set of turbines upstream from the turbine
-$j$. Here, $A_{ij}$ is the area of overlap of the wake of turbine $i$
+where $A_{ij}$ is the area of overlap of the wake of turbine $i$
 onto turbine $j$; $a_i$ is the axial induction factor of the
 turbine $i$;
 and $(x_j - x_i)/D_i$ is the downstream distance of turbine $j$ from
-the turbine $i$, normalized by turbine $i$'s rotor diameter.
+the turbine $i$, normalized by turbine $i$'s rotor diameter. Here, $A_{ij} = 1$ if turbine $j$ is fully covered by turbine $i$'s wake; $A_{ij} = 0$ if turbine $j$ is not covered at all by turbine $i$'s wake; and $0 < A_{ij} < 1$ if turbine $j$ is partially covered by turbine $i$'s wake. By convention, $A_{ii} = 0$ and $A_{ij} = 0$ if $x_j \leq x_i$ (turbine $j$ is upstream of turbine $i$).
 
 Wake-induced mixing can affect both the velocity deficit and wake deflection.
 To account for wake-induced mixing, the wake width of turbine $j$ is adjusted
@@ -129,7 +128,7 @@ to
 
 $$ \sigma_{y}(x) = \int_{0}^x \sum_{i=0}^n k_i \ell_{[b_{i}, b_{i+1})}(x') + w_v \text{WIM}_j   dx' + \sigma_{y0} $$
 
-Here, $w_v$ is the velocity deficit wake-induced mixing gain, which the
+where $w_v$ is the velocity deficit wake-induced mixing gain, which the
 user can vary by setting `wim_gain_velocity` to represent different levels of
 mixing caused by the turbines.
 
@@ -144,6 +143,7 @@ user by setting `wim_gain_deflection`.
 The documentation previously had an erroneous form for the wake-induced mixing
 term
 $$ \text{WIM}_j = \sum_{i \in T^{\text{up}}(j)} \frac{A_{ij} a_i} {(x_j - x_i)/D_i} $$
+This has been corrected to the form shown above, which is consistent with the implementation. The implementation has not changed; only the documentation has been corrected.
 ```
 
 ## Yaw added mixing
@@ -154,7 +154,7 @@ is activated by setting
 `enable_yaw_added_recovery` to `true`. Yaw-added mixing is represented
 by updating the wake-induced mixing term as follows:
 
-$$ \text{WIM}_j = \sum_{i \in T^{\text{up}}(j)} \frac{A_{ij} a_i (1 + g_\text{YAM} (1-\cos(\gamma_i)))}{(x_j - x_i)/D_i} + a_j g_\text{YAM} (1-\cos(\gamma_j))$$
+$$ \text{WIM}_j = \sqrt{\sum_{i \\neq j} \left(\frac{A_{ij} a_i (1 + g_\text{YAM} (1-\cos(\gamma_i)))}{\left((x_j - x_i)/D_i\right)^2}\right)^2 + \left(a_j g_\text{YAM} (1-\cos(\gamma_j))\right)^2}$$
 
 Note that the second term means that, unlike when `enable_yaw_added_recovery`
 is `false`, a turbine may affect the recovery of its own wake by yawing.
@@ -178,9 +178,8 @@ setting the amplitude of the AWC excitation using `awc_amplitudes` (see the
 The effect of AWC is represented by updating the
 wake-induced mixing term as follows:
 
-$$ \text{WIM}_j = \sum_{i \in T^{\text{up}}(j)} 
-\left(\frac{A_{ij} a_i} {\left((x_j - x_i)/D_i\right)^2}\right)^2 +
-\frac{\beta_{j}^{p}}{d}$$
+$$ \text{WIM}_j = \sqrt{\sum_{i \neq j} \left(\frac{A_{ij} a_i}{\left((x_j - x_i)/D_i\right)^2}\right)^2 +
+\left(\frac{\beta_{j}^{p}}{d}\right)^2}$$
 
 where $\beta_{j}$ is the AWC amplitude of turbine $j$, and the exponent $p$ and
 denominator $d$ are tuning parameters that can be set in the `emgauss.yaml` file with

--- a/docs/empirical_gauss_model.md
+++ b/docs/empirical_gauss_model.md
@@ -113,7 +113,8 @@ the empirical model, explicit dependencies on turbulence intensity are removed
 completely to aid in tuning. Instead, a non-physical "wake-induced mixing
 factor" is specified for turbine $j$ as
 
-$$ \text{WIM}_j = \sum_{i \in T^{\text{up}}(j)} \frac{A_{ij} a_i} {(x_j - x_i)/D_i} $$
+$$ \text{WIM}_j = \sqrt{\sum_{i \in T^{\text{up}}(j)} 
+\left(\frac{A_{ij} a_i} {\left((x_j - x_i)/D_i\right)^2}\right)^2} $$
 
 where $T_T^{\text{up}}(j)$ is the set of turbines upstream from the turbine
 $j$. Here, $A_{ij}$ is the area of overlap of the wake of turbine $i$
@@ -138,6 +139,12 @@ $$ \delta = \frac{k_\text{def} C_T \alpha}{1 + w_d \text{WIM}_j}\operatorname{ln
 
 where $w_d$ is the wake-induced mixing gain for deflection, provided by the
 user by setting `wim_gain_deflection`.
+
+```{note}
+The documentation previously had an erroneous form for the wake-induced mixing
+term
+$$ \text{WIM}_j = \sum_{i \in T^{\text{up}}(j)} \frac{A_{ij} a_i} {(x_j - x_i)/D_i} $$
+```
 
 ## Yaw added mixing
 
@@ -171,7 +178,8 @@ setting the amplitude of the AWC excitation using `awc_amplitudes` (see the
 The effect of AWC is represented by updating the
 wake-induced mixing term as follows:
 
-$$ \text{WIM}_j = \sum_{i \in T^{\text{up}}(j)} \frac{A_{ij} a_i} {(x_j - x_i)/D_i} +
+$$ \text{WIM}_j = \sum_{i \in T^{\text{up}}(j)} 
+\left(\frac{A_{ij} a_i} {\left((x_j - x_i)/D_i\right)^2}\right)^2 +
 \frac{\beta_{j}^{p}}{d}$$
 
 where $\beta_{j}$ is the AWC amplitude of turbine $j$, and the exponent $p$ and

--- a/docs/empirical_gauss_model.md
+++ b/docs/empirical_gauss_model.md
@@ -114,12 +114,12 @@ completely to aid in tuning. Instead, a non-physical "wake-induced mixing
 factor" is specified for turbine $j$ as
 
 $$ \text{WIM}_j = \sqrt{\sum_{i \neq j} 
-\left(\frac{A_{ij} a_i} {\left((x_j - x_i)/D_i\right)^2}\right)^2} $$
+\left(\frac{A_{ij} a_i} {\bar{d}_{ij}^2}\right)^2} $$
 
 where $A_{ij}$ is the area of overlap of the wake of turbine $i$
 onto turbine $j$; $a_i$ is the axial induction factor of the
 turbine $i$;
-and $(x_j - x_i)/D_i$ is the downstream distance of turbine $j$ from
+and $\bar{d}_{ij} = (x_j - x_i)/D_i$ is the downstream distance of turbine $j$ from
 the turbine $i$, normalized by turbine $i$'s rotor diameter. Here, $A_{ij} = 1$ if turbine $j$ is fully covered by turbine $i$'s wake; $A_{ij} = 0$ if turbine $j$ is not covered at all by turbine $i$'s wake; and $0 < A_{ij} < 1$ if turbine $j$ is partially covered by turbine $i$'s wake. By convention, $A_{ii} = 0$ and $A_{ij} = 0$ if $x_j \leq x_i$ (turbine $j$ is upstream of turbine $i$).
 
 Wake-induced mixing can affect both the velocity deficit and wake deflection.
@@ -154,7 +154,7 @@ is activated by setting
 `enable_yaw_added_recovery` to `true`. Yaw-added mixing is represented
 by updating the wake-induced mixing term as follows:
 
-$$ \text{WIM}_j = \sqrt{\sum_{i \\neq j} \left(\frac{A_{ij} a_i (1 + g_\text{YAM} (1-\cos(\gamma_i)))}{\left((x_j - x_i)/D_i\right)^2}\right)^2 + \left(a_j g_\text{YAM} (1-\cos(\gamma_j))\right)^2}$$
+$$ \text{WIM}_j = \sqrt{\sum_{i \neq j} \left(\frac{A_{ij} a_i (1 + g_\text{YAM} (1-\cos(\gamma_i)))}{\bar{d}_{ij}^2}\right)^2 + \left(a_j g_\text{YAM} (1-\cos(\gamma_j))\right)^2}$$
 
 Note that the second term means that, unlike when `enable_yaw_added_recovery`
 is `false`, a turbine may affect the recovery of its own wake by yawing.
@@ -178,11 +178,10 @@ setting the amplitude of the AWC excitation using `awc_amplitudes` (see the
 The effect of AWC is represented by updating the
 wake-induced mixing term as follows:
 
-$$ \text{WIM}_j = \sqrt{\sum_{i \neq j} \left(\frac{A_{ij} a_i}{\left((x_j - x_i)/D_i\right)^2}\right)^2 +
-\left(\frac{\beta_{j}^{p}}{d}\right)^2}$$
+$$ \text{WIM}_j = \sqrt{\sum_{i \neq j} \left(\frac{A_{ij} a_i}{\bar{d}_{ij}^2}\right)^2 + \left(\frac{\beta_{j}^{p_\text{AWC}}}{d_\text{AWC}}\right)^2}$$
 
-where $\beta_{j}$ is the AWC amplitude of turbine $j$, and the exponent $p$ and
-denominator $d$ are tuning parameters that can be set in the `emgauss.yaml` file with
+where $\beta_{j}$ is the AWC amplitude of turbine $j$, and the exponent $p_\text{AWC}$ and
+denominator $d_\text{AWC}$ are tuning parameters that can be set in the `emgauss.yaml` file with
 the fields `awc_wake_exp` and `awc_wake_denominator`, respectively.
 Note that, in contrast to the yaw added mixing case, a turbine currently affects _only_ its own
 wake by applying AWC.


### PR DESCRIPTION
The current version of the [documentation on the Empricial Gaussian model](https://nrel.github.io/floris/empirical_gauss_model.html), in particular the [wake-induced mixing (WIM) terms](https://nrel.github.io/floris/empirical_gauss_model.html#wake-induced-mixing), is inaccurate. This PR updates the documentation so that it matches the source code. The source code itself is not changed at all; this PR simply updates the documentation so that the description matches the form of the Empirical Gaussian model in the code. There were two errors in the documentation: first, the implementation uses a root-sum-squared approach for computing the WIM term, rather than a sum of (positive) values (that is, a 2-norm is used rather than a 1-norm); and second, the denominator of the off-diagonal terms in the sum (the downstream distances between turbines) are now squared. I apologize for any confusion caused---these errors came in with the original merger of the EmGauss model #628 , but[I only noticed them recently](https://github.com/NREL/floris/discussions/1148#discussioncomment-14765911). 

Because the FLORIS documentation builds off the develop branch, once this is merged into develop the docs page will be updated. Before I merge, I plan to add a test to confirm that the form of the WIM is as expected and explained in the documentation.
