### PR TITLE
Update name of laboratory

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Usage question
     url: https://github.com/NREL/floris/discussions
-    about: Have any questions about using FLORIS? Post in Discussions to engage with the NREL team and FLORIS community.
+    about: Have any questions about using FLORIS? Post in Discussions to engage with the NLR team and FLORIS community.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -64,7 +64,7 @@ Add the results from unit tests and regression tests here along with justificati
 -->
 
 <!--
-__ For NREL use __
+__ For NLR use __
 Release checklist:
 - Update the version in
     - [ ] README.md (appears twice in README.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This document provides a high-level overview of how you can get involved.
 
 Have a question? Rather than opening an issue directly, please ask questions
 or post comments in [Q&A Discussions](https://github.com/NREL/floris/discussions/categories/q-a).
-The NREL team or other members of the community will assist. Your well-worded
+The NLR team or other members of the community will assist. Your well-worded
 question will serve as a resource to others searching for help.
 
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Alliance for Sustainable Energy LLC, All rights reserved.
+Copyright (c) 2025, Alliance for Sustainable Energy LLC, All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted
 provided that the following conditions are met:

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, Alliance for Sustainable Energy LLC, All rights reserved.
+Copyright (c) 2025, Alliance for Energy Innovation LLC, All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted
 provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ space to show off the things you are doing with FLORIS.
 
 BSD 3-Clause License
 
-Copyright (c) 2025, Alliance for Sustainable Energy LLC, All rights reserved.
+Copyright (c) 2025, Alliance for Energy Innovation LLC, All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted
 provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 FLORIS is a controls-focused wind farm simulation software incorporating
 steady-state engineering wake models into a performance-focused Python
-framework. It has been in active development at NREL since 2013 and the latest
+framework. It has been in active development at NLR since 2013 and the latest
 release is [FLORIS v.4.5.1](https://github.com/NREL/floris/releases/latest).
 Online documentation is available at https://nrel.github.io/floris.
 
@@ -68,7 +68,7 @@ and importing FLORIS:
 Help on package floris:
 
 NAME
-    floris - # Copyright 2024 NREL
+    floris
 
 PACKAGE CONTENTS
     convert_floris_input_v3_to_v4
@@ -156,7 +156,7 @@ space to show off the things you are doing with FLORIS.
 
 BSD 3-Clause License
 
-Copyright (c) 2024, Alliance for Sustainable Energy LLC, All rights reserved.
+Copyright (c) 2025, Alliance for Sustainable Energy LLC, All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted
 provided that the following conditions are met:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,9 +2,9 @@
 # Learn more at https://jupyterbook.org/customize/config.html
 
 title: FLORIS
-author: National Renewable Energy Laboratory
+author: National Laboratory of the Rockies
 logo: docs_image.png
-copyright: '2023'
+copyright: '2025'
 only_build_toc_files: false
 
 # Force re-execution of notebooks on each build.

--- a/docs/code_quality.ipynb
+++ b/docs/code_quality.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "The plot below shows the runtime performance over a series of commits for a\n",
     "3-turbine test case with 1,440 atmospheric conditions.\n",
-    "This data is collected on [NREL's Kestrel supercomputer](https://nrel.github.io/HPC/Documentation/Systems/Kestrel/)."
+    "This data is collected on [NLR's Kestrel supercomputer](https://nrel.github.io/HPC/Documentation/Systems/Kestrel/)."
    ]
   },
   {
@@ -301,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.1"
+   "version": "3.13.2"
   },
   "orig_nbformat": 4
  },

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1,6 +1,6 @@
 # Developer's Guide
 
-FLORIS is maintained at NREL's National Wind Technology Center.
+FLORIS is maintained by NRL.
 We are excited about community contribution, and this page outlines
 processes and procedures to follow when contributing to the
 source code. For technical questions regarding FLORIS usage, please
@@ -47,7 +47,7 @@ the [GitHub repository](http://github.com/nrel/floris). There,
 [pull requests](http://github.com/nrel/floris/pulls) are managed,
 questions and ideas are [discussed](https://github.com/NREL/floris/discussions),
 and [new versions](http://github.com/nrel/floris/releases)
-are released. It is the best mechanism for engaging with the NREL team
+are released. It is the best mechanism for engaging with the NLR team
 and other developers throughout the FLORIS community.
 
 FLORIS development should follow "Git Flow" when interacting with the GitHub
@@ -58,7 +58,7 @@ process is detailed nicely [here](http://nvie.com/posts/a-successful-git-branchi
 
 ### Syncing a local repository with NREL/FLORIS
 The "main" FLORIS repository is continuously updated along with ongoing
-research at NREL. From time to time, developers of FLORIS using their own
+research at NLR. From time to time, developers of FLORIS using their own
 "local" repositories (versions of the software that exist on a local computer)
 may want to sync with NREL/FLORIS. To do this, use the following git commands:
 
@@ -290,7 +290,7 @@ Be sure to complete each step in the sequence as described.
 
 ## Deploying to pip
 
-Generally, only NREL developers will have appropriate permissions to deploy
+Generally, only NLR developers will have appropriate permissions to deploy
 FLORIS updates. When the time comes, here is a great reference on doing it
 is available [here](https://medium.freecodecamp.org/how-to-publish-a-pyton-package-on-pypi-a89e9522ce24).
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1,6 +1,6 @@
 # Developer's Guide
 
-FLORIS is maintained by NRL.
+FLORIS is maintained by NLR.
 We are excited about community contribution, and this page outlines
 processes and procedures to follow when contributing to the
 source code. For technical questions regarding FLORIS usage, please

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,7 +70,7 @@ and importing FLORIS:
 Help on package floris:
 
 NAME
-    floris - # Copyright 2024 NREL
+    floris
 
 PACKAGE CONTENTS
     convert_floris_input_v3_to_v4
@@ -91,7 +91,7 @@ PACKAGE CONTENTS
     wind_data
 
 VERSION
-    4.0
+    4.5.1
 
 FILE
     ~/floris/floris/__init__.py

--- a/floris/core/wake_velocity/turboparkgauss.py
+++ b/floris/core/wake_velocity/turboparkgauss.py
@@ -1,15 +1,3 @@
-# Copyright 2021 NREL
-
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
-
 from typing import Any, Dict
 
 import numexpr as ne

--- a/floris/optimization/layout_optimization/layout_optimization_random_search.py
+++ b/floris/optimization/layout_optimization/layout_optimization_random_search.py
@@ -1,18 +1,3 @@
-# Copyright 2022 NREL
-
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not
-# use this file except in compliance with the License. You may obtain a copy of
-# the License at http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations under
-# the License.
-
-# See https://floris.readthedocs.io for documentation
-
-
 from multiprocessing import Pool
 from time import perf_counter as timerpc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "floris"
 version = "4.5.1"
 description = "A controls-oriented engineering wake model."
 readme = "README.md"
-requires-python = ">=3.10, <=3.14"
+requires-python = ">=3.10, <3.15"
 authors = [
     { name = "Rafael Mudafort", email = "Rafael.Mudafort@nrel.gov" },
     { name = "Paul Fleming", email = "Paul.Fleming@nrel.gov" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "floris"
 version = "4.5.1"
 description = "A controls-oriented engineering wake model."
 readme = "README.md"
-requires-python = ">=3.10, <3.15"
+requires-python = ">=3.10, <=3.14"
 authors = [
     { name = "Rafael Mudafort", email = "Rafael.Mudafort@nrel.gov" },
     { name = "Paul Fleming", email = "Paul.Fleming@nrel.gov" },


### PR DESCRIPTION
NREL has recently been renamed the National Laboratory of the Rockies (NRL). Further, the Alliance for Sustainable Energy has been renamed the Alliance for Energy Innovation. This pull request reflects these name changes. "NREL" is replaced with "NLR" where appropriate. There are a few places where the change is _not_ made:
- URLs containing NREL that continue to be correct (notably, github.com/NREL/...). 
- References to past NREL reports, most notably the NREL 5MW reference turbine.

I'm also taking this opportunity to bump up a few version numbers and years on the license file etc. Finally, the turboparkguass.py and layout_optimization_random_search.py files contained license headers that were removed from most files when we moved to the BSD 3-Clause license #810 , but these slipped back in on this file so I'm removing them now.

A second round of updates may be needed if URLs change in future.
