### PR TITLE
[BUGFIX] Enable Cumulative Curl model to work with a cubature grid

### DIFF
--- a/floris/core/solver.py
+++ b/floris/core/solver.py
@@ -529,9 +529,9 @@ def cc_solver(
             + (flow_field.u_initial_sorted - turb_u_wake) * mask2
         )
 
-        turb_avg_vels = average_velocity(turb_inflow_field)
+        turb_avg_vels = average_velocity(turb_inflow_field)[:, :, None, None]
         turb_Cts = thrust_coefficient(
-            turb_avg_vels[:, :, None, None],
+            turb_avg_vels,
             flow_field.turbulence_intensity_field_sorted,
             flow_field.air_density,
             farm.yaw_angles_sorted,
@@ -550,7 +550,7 @@ def cc_solver(
         )
         turb_Cts = turb_Cts[:, :, None, None]
         turb_aIs = axial_induction(
-            turb_avg_vels[:, :, None, None],
+            turb_avg_vels,
             flow_field.turbulence_intensity_field_sorted,
             flow_field.air_density,
             farm.yaw_angles_sorted,

--- a/floris/core/solver.py
+++ b/floris/core/solver.py
@@ -531,7 +531,7 @@ def cc_solver(
 
         turb_avg_vels = average_velocity(turb_inflow_field)
         turb_Cts = thrust_coefficient(
-            turb_avg_vels,
+            turb_avg_vels[:, :, None, None],
             flow_field.turbulence_intensity_field_sorted,
             flow_field.air_density,
             farm.yaw_angles_sorted,
@@ -550,7 +550,7 @@ def cc_solver(
         )
         turb_Cts = turb_Cts[:, :, None, None]
         turb_aIs = axial_induction(
-            turb_avg_vels,
+            turb_avg_vels[:, :, None, None],
             flow_field.turbulence_intensity_field_sorted,
             flow_field.air_density,
             farm.yaw_angles_sorted,


### PR DESCRIPTION
As raised in #970 and originally in #709 , the Cumulative Curl model does not currently work with a cubature grid. It took me quite a while to track the issue down, but finally, the solution was simply to add dimensions to `turb_avg_vels` for use in the initial computation of `thrust_coefficient` and `axial_induction`.

@Bartdoekemeijer kindly provided a test script:
```python
from floris import FlorisModel

fmodel = FlorisModel("inputs/cc.yaml")
fmodel.set(solver_settings={"type": "turbine_cubature_grid", "turbine_grid_points": 3})
fmodel.run()
print(fmodel.get_turbine_powers())
```

On the develop branch, this fails, producing the error reported in #970. After this bugfix, the code runs as expected, producing
```
[[1746971.6830192   471716.37117722  467636.89587481]]
```

Moreover, commenting out the line `fmodel.set(solver_settings={"type": "turbine_cubature_grid", "turbine_grid_points": 3})` (which is to say, using the "standard" square grid) produces
```
[[1753954.45917917  381082.81148362  446768.73505829]]
```
on both the develop branch and this bugfix branch (that is, no change to results when not using a cubature grid). The difference in powers between the cubature grid and square grid is expected.

All tests pass and this PR is ready for review and merger.