### PR TITLE
Update package dependences (dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   target-branch: "develop"
   schedule:
     interval: "monthly"
+  labels:
+    - "package"
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-minor", "version-update:semver-patch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,17 +46,17 @@ dependencies = [
 docs = [
     "jupyter-book~=1.0",
     "sphinx-book-theme~=1.0",
-    "sphinx-autodoc-typehints~=2.0",
+    "sphinx-autodoc-typehints>=2,<4",
     "sphinxcontrib-autoyaml~=1.0",
     "sphinxcontrib.mermaid~=1.0",
     "bokeh~=3.7",
 ]
 develop = [
-    "pytest~=8.0",
+    "pytest>=8,<10",
     "pytest-benchmark~=5.1",
     "pre-commit~=4.0",
     "ruff~=0.9",
-    "isort~=5.0"
+    "isort>=5,<8"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
We recently introduced dependabot #1064 , and v4.6 is the first FLORIS version to include it; since v4.6 was released, dependabot opened four PRs to update dependencies: #1166, #1167, #1168, #1169. I have now tried various installations of FLORIS to confirm these, and the updates to `isort`, `pytest`, and `sphinx-autodoc-typehints` seem fine; however, the update to `jupter-book` I am not currently OK with (see below). This PR combines the acceptable updates into a single PR to avoid having to merge three separate PRs, and also updates the `labels` field of the dependabot.yml to prevent dependabot from automatically creating new labels (once this PR is merged and the ones dependabot opened are closed without merger, I will delete the automatically created labels).

Regarding `jupyter-book`: `jupyter-book` v2 seems to require that node.js is installed. See [here](https://blog.jupyterbook.org/posts/2024-11-15-jupyter-book-2-alpha/) for more info. This seems an unnecessary extra dependency (that I'm not sure can be installed via pip), so I've left `jupyter-book` fixed at `jupyter-book~=1.0` for the time being. @rafmudaf , would you like to weigh in on this at all?

Further, our current set-up of dependabot widens the version requirements to allow multiple major versions (e.g. from `isort~=5.0` to `isort>=5,<8`). @paulf81 , back in #748, I think you were making an argument for trying to stick to a single major version for each requirement using the compatible-release specifier. Any opinions on whether we should stick to a single major version per requirement or are happy with a range? If we want to go with a single major version, we could move up to the latest available (that works), which would be `isort~=7.0`, `pytest~=9.0`, `sphinx-autodoc-typehints~=3.0`.

Note that this PR only affects the "docs" and "develop" dependencies, not the main dependencies for simple installation of FLORIS. I believe this is simply luck this time around.

I have tried:
- `isort` versions `5.13.2` (installed under current specification), `6.1.0`, and `7.0.0`.
- `pytest` upgraded to `9.0.2`
- `sphinx-autodoc-typehints` upgrade to `3.6.0`

When installing with `jupyter-book~=1.0`, version `1.0.4.post1` is installed and works (including with the upgraded `sphinx-autodoc-typehints`); upgrading to `jupyter-book` version `2.1.0` triggered a prompt to install node.js, which I aborted.

This is on my 2023 M3 Mac Pro.

_Alternatively_, we could simply take the dependabot PRs as informational only and non-critical, and simply close them (and this PR) without merger at this time.
