### PR TITLE
Update github URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Usage question
-    url: https://github.com/NREL/floris/discussions
+    url: https://github.com/NatLabRockies/floris/discussions
     about: Have any questions about using FLORIS? Post in Discussions to engage with the NLR team and FLORIS community.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ This document provides a high-level overview of how you can get involved.
 ## Asking Questions
 
 Have a question? Rather than opening an issue directly, please ask questions
-or post comments in [Q&A Discussions](https://github.com/NREL/floris/discussions/categories/q-a).
+or post comments in [Q&A Discussions](https://github.com/NatLabRockies/floris/discussions/categories/q-a).
 The NLR team or other members of the community will assist. Your well-worded
 question will serve as a resource to others searching for help.
 
@@ -16,7 +16,7 @@ question will serve as a resource to others searching for help.
 ## Providing Feedback
 
 Your comments and feedback are very welcome. Please post to
-[General Discussions](https://github.com/NREL/floris/discussions/categories/general)
+[General Discussions](https://github.com/NatLabRockies/floris/discussions/categories/general)
 with lots of information and detail. It is beneficial to consider
 how someone else will understand your comments in order to make
 them most effective.
@@ -73,7 +73,7 @@ Please remember to do the following:
 
 If you are interested in writing code to fix an issue or
 submit a new feature, let us know in
-[Ideas Discussions](https://github.com/NREL/floris/discussions/categories/ideas)!
+[Ideas Discussions](https://github.com/NatLabRockies/floris/discussions/categories/ideas)!
 
 We rely heavily on git and GitHub, so be sure to review the
 contributing guidelines in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,4 +77,4 @@ submit a new feature, let us know in
 
 We rely heavily on git and GitHub, so be sure to review the
 contributing guidelines in the
-[online documentation](https://nrel.github.io/floris/dev_guide.html).
+[online documentation](https://natlabrockies.github.io/floris/dev_guide.html).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ FLORIS is a controls-focused wind farm simulation software incorporating
 steady-state engineering wake models into a performance-focused Python
 framework. It has been in active development at NLR since 2013 and the latest
 release is [FLORIS v.4.6](https://github.com/NatLabRockies/floris/releases/latest).
-Online documentation is available at https://nrel.github.io/floris.
+Online documentation is available at https://natlabrockies.github.io/floris.
 
 The software is in active development and engagement with the development team
 is highly encouraged. If you are interested in using FLORIS to conduct studies
@@ -14,11 +14,11 @@ the conversation in [GitHub Discussions](https://github.com/NatLabRockies/floris
 ## WETO software
 
 FLORIS is primarily developed with the support from the U.S. Department of Energy and
-is part of the [WETO Software Stack](https://nrel.github.io/WETOStack).
+is part of the [WETO Software Stack](https://natlabrockies.github.io/WETOStack).
 For more information and other integrated modeling software, see:
 
-- [Portfolio Overview](https://nrel.github.io/WETOStack/portfolio_analysis/overview.html)
-- [Entry Guide](https://nrel.github.io/WETOStack/_static/entry_guide/index.html)
+- [Portfolio Overview](https://natlabrockies.github.io/WETOStack/portfolio_analysis/overview.html)
+- [Entry Guide](https://natlabrockies.github.io/WETOStack/_static/entry_guide/index.html)
 - [Wind Farm Controls Workshop](https://www.youtube.com/watch?v=f-w6whxIBrA&list=PL6ksUtsZI1dwRXeWFCmJT6cEN1xijsHJz)
 
 ## Installation
@@ -102,14 +102,14 @@ features, improvements, and bug fixes will be issued on an ongoing basis.
 
 FLORIS is a Python package run on the command line typically by providing
 an input file with an initial configuration. It can be installed with
-```pip install floris``` (see [installation](https://nrel.github.io/floris/installation.html)).
+```pip install floris``` (see [installation](https://natlabrockies.github.io/floris/installation.html)).
 The typical entry point is
-[FlorisModel](https://nrel.github.io/floris/_autosummary/floris.floris_model.html)
+[FlorisModel](https://natlabrockies.github.io/floris/_autosummary/floris.floris_model.html)
 which accepts the path to the input file as an argument. From there,
 changes can be made to the initial configuration through the
-[FlorisModel.set](https://nrel.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.set)
+[FlorisModel.set](https://natlabrockies.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.set)
 routine, and the simulation is executed with
-[FlorisModel.run](https://nrel.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.run).
+[FlorisModel.run](https://natlabrockies.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.run).
 
 ```python
 from floris import FlorisModel
@@ -123,17 +123,17 @@ fmodel.run()
 ```
 
 Finally, results can be analyzed via post-processing functions available within
-[FlorisModel](https://nrel.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel)
+[FlorisModel](https://natlabrockies.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel)
 such as
-- [FlorisModel.get_turbine_layout](https://nrel.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.get_turbine_layout)
-- [FlorisModel.get_turbine_powers](https://nrel.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.get_turbine_powers)
-- [FlorisModel.get_farm_AEP](https://nrel.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.get_farm_AEP)
+- [FlorisModel.get_turbine_layout](https://natlabrockies.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.get_turbine_layout)
+- [FlorisModel.get_turbine_powers](https://natlabrockies.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.get_turbine_powers)
+- [FlorisModel.get_farm_AEP](https://natlabrockies.github.io/floris/_autosummary/floris.floris_model.html#floris.floris_model.FlorisModel.get_farm_AEP)
 
-and in two visualization packages: [layoutviz](https://nrel.github.io/floris/_autosummary/floris.layout_visualization.html) and [flowviz](https://nrel.github.io/floris/_autosummary/floris.flow_visualization.html).
+and in two visualization packages: [layoutviz](https://natlabrockies.github.io/floris/_autosummary/floris.layout_visualization.html) and [flowviz](https://natlabrockies.github.io/floris/_autosummary/floris.flow_visualization.html).
 A collection of examples describing the creation of simulations as well as
 analysis and post processing are included in the
 [repository](https://github.com/NatLabRockies/floris/tree/main/examples). Examples are also listed
-in the [online documentation](https://nrel.github.io/floris/examples/001_opening_floris_computing_power.html).
+in the [online documentation](https://natlabrockies.github.io/floris/examples/001_opening_floris_computing_power.html).
 
 ## Engaging on GitHub
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 FLORIS is a controls-focused wind farm simulation software incorporating
 steady-state engineering wake models into a performance-focused Python
 framework. It has been in active development at NLR since 2013 and the latest
-release is [FLORIS v.4.6](https://github.com/NREL/floris/releases/latest).
+release is [FLORIS v.4.6](https://github.com/NatLabRockies/floris/releases/latest).
 Online documentation is available at https://nrel.github.io/floris.
 
 The software is in active development and engagement with the development team
 is highly encouraged. If you are interested in using FLORIS to conduct studies
 of a wind farm or extending FLORIS to include your own wake model, please join
-the conversation in [GitHub Discussions](https://github.com/NREL/floris/discussions/)!
+the conversation in [GitHub Discussions](https://github.com/NatLabRockies/floris/discussions/)!
 
 ## WETO software
 
@@ -46,7 +46,7 @@ commands in a terminal or shell will download and install FLORIS.
 
 ```bash
     # Download the source code from the `main` branch
-    git clone -b main https://github.com/NREL/floris.git
+    git clone -b main https://github.com/NatLabRockies/floris.git
 
     # If using conda, be sure to activate your environment prior to installing
     # conda activate <env name>
@@ -132,23 +132,23 @@ such as
 and in two visualization packages: [layoutviz](https://nrel.github.io/floris/_autosummary/floris.layout_visualization.html) and [flowviz](https://nrel.github.io/floris/_autosummary/floris.flow_visualization.html).
 A collection of examples describing the creation of simulations as well as
 analysis and post processing are included in the
-[repository](https://github.com/NREL/floris/tree/main/examples). Examples are also listed
+[repository](https://github.com/NatLabRockies/floris/tree/main/examples). Examples are also listed
 in the [online documentation](https://nrel.github.io/floris/examples/001_opening_floris_computing_power.html).
 
 ## Engaging on GitHub
 
 FLORIS leverages the following GitHub features to coordinate support and development efforts:
 
-- [Discussions](https://github.com/NREL/floris/discussions): Collaborate to develop ideas for new use cases, features, and software designs, and get support for usage questions
-- [Issues](https://github.com/NREL/floris/issues): Report potential bugs and well-developed feature requests
+- [Discussions](https://github.com/NatLabRockies/floris/discussions): Collaborate to develop ideas for new use cases, features, and software designs, and get support for usage questions
+- [Issues](https://github.com/NatLabRockies/floris/issues): Report potential bugs and well-developed feature requests
 - [Projects](https://github.com/orgs/NREL/projects/96): Include current and future work on a timeline and assign a person to "own" it
 
 Generally, the first entry point for the community will be within one of the
 categories in Discussions.
-[Ideas](https://github.com/NREL/floris/discussions/categories/ideas) is a great spot to develop the
-details for a feature request. [Q&A](https://github.com/NREL/floris/discussions/categories/q-a)
+[Ideas](https://github.com/NatLabRockies/floris/discussions/categories/ideas) is a great spot to develop the
+details for a feature request. [Q&A](https://github.com/NatLabRockies/floris/discussions/categories/q-a)
 is where to get usage support.
-[Show and tell](https://github.com/NREL/floris/discussions/categories/show-and-tell) is a free-form
+[Show and tell](https://github.com/NatLabRockies/floris/discussions/categories/show-and-tell) is a free-form
 space to show off the things you are doing with FLORIS.
 
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -24,7 +24,7 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/NREL/floris
+  url: https://github.com/NatLabRockies/floris
   path_to_book: docs
   branch: main
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -4,7 +4,7 @@ FLORIS is maintained by NLR.
 We are excited about community contribution, and this page outlines
 processes and procedures to follow when contributing to the
 source code. For technical questions regarding FLORIS usage, please
-post your questions to [GitHub Discussions](https://github.com/NREL/floris/discussions).
+post your questions to [GitHub Discussions](https://github.com/NatLabRockies/floris/discussions).
 
 ## Getting Started
 
@@ -42,11 +42,11 @@ developer's guide, so please read on to learn more about each of these steps.
 ## Git and GitHub Workflows
 
 The majority of the collaboration and development for FLORIS takes place in
-the [GitHub repository](http://github.com/nrel/floris). There,
-[issues](http://github.com/nrel/floris/issues) and
-[pull requests](http://github.com/nrel/floris/pulls) are managed,
-questions and ideas are [discussed](https://github.com/NREL/floris/discussions),
-and [new versions](http://github.com/nrel/floris/releases)
+the [GitHub repository](http://github.com/NatLabRockies/floris). There,
+[issues](http://github.com/NatLabRockies/floris/issues) and
+[pull requests](http://github.com/NatLabRockies/floris/pulls) are managed,
+questions and ideas are [discussed](https://github.com/NatLabRockies/floris/discussions),
+and [new versions](http://github.com/NatLabRockies/floris/releases)
 are released. It is the best mechanism for engaging with the NLR team
 and other developers throughout the FLORIS community.
 
@@ -96,7 +96,7 @@ are likely and should be resolved as early as possible.
 FLORIS is configured to use tools to automatically check and enforce
 aspects of code quality. In general, these should be adopted by all
 developers and incorporated into the development workflow. Most
-tools are configured in [pyproject.toml](https://github.com/NREL/floris/blob/main/pyproject.toml),
+tools are configured in [pyproject.toml](https://github.com/NatLabRockies/floris/blob/main/pyproject.toml),
 but some may have a dedicated configuration file.
 
 ### isort
@@ -111,7 +111,7 @@ isort <path to file>
 isort dir/*
 ```
 
-This tool was initially configured in [PR#535](https://github.com/NREL/floris/pull/535),
+This tool was initially configured in [PR#535](https://github.com/NatLabRockies/floris/pull/535),
 and additional information on specific decisions can be found there.
 
 ### Ruff
@@ -128,8 +128,8 @@ ruff . --fix
 This sets the configuration from `pyproject.toml`, applies the selected rules to Python files,
 and fixes errors in-place where possible.
 
-Ruff was initially configured in [PR#562](https://github.com/NREL/floris/pull/562), and discussed
-in more detail in [D#561](https://github.com/NREL/floris/discussions/561). See the Ruff
+Ruff was initially configured in [PR#562](https://github.com/NatLabRockies/floris/pull/562), and discussed
+in more detail in [D#561](https://github.com/NatLabRockies/floris/discussions/561). See the Ruff
 documentation for a list of [supported rules](https://github.com/charliermarsh/ruff#supported-rules)
 and [available options for various rules](https://github.com/charliermarsh/ruff#reference).
 
@@ -201,7 +201,7 @@ pytest tests/*_regression_test.py
 
 ### Continuous Integration
 
-Continuous integration is configured with [GitHub Actions](https://github.com/nrel/floris/actions)
+Continuous integration is configured with [GitHub Actions](https://github.com/NatLabRockies/floris/actions)
 and executes all of the existing tests for every push-event. The configuration file
 is located at `floris/.github/workflows/continuous-integration-workflow.yaml`.
 
@@ -245,8 +245,8 @@ Be sure to complete each step in the sequence as described.
 2. Update the version number and commit to the `develop`` branch
     with a commit message such as "Update version to vN.M".
     The version number must be updated in the following two files:
-    - [floris/README.md](https://github.com/NREL/floris/blob/main/README.md)
-    - [pyproject.toml](https://github.com/NREL/floris/blob/main/pyproject.toml)
+    - [floris/README.md](https://github.com/NatLabRockies/floris/blob/main/README.md)
+    - [pyproject.toml](https://github.com/NatLabRockies/floris/blob/main/pyproject.toml)
     Note that a `.0` version number is left off meaning that valid versions
     are `v3`, `v3.1`, `v3.1.1`, etc.
 
@@ -258,7 +258,7 @@ Be sure to complete each step in the sequence as described.
     Check this by opening the documentation website at https://nrel.github.io/floris
     and scrolling through the pages.
     Also, verify that the automated build process has successfully completed
-    for the commits to `develop` in [GitHub Actions](https://github.com/NREL/floris/actions/workflows/deploy-pages.yaml).
+    for the commits to `develop` in [GitHub Actions](https://github.com/NatLabRockies/floris/actions/workflows/deploy-pages.yaml).
 
 4. The changes since the prior commit can be gotten from GitHub by going through the
     process to create a release, but stopping short of actually publishing it.
@@ -270,7 +270,7 @@ Be sure to complete each step in the sequence as described.
 5. Merge the pull request into `main`. Select "Create a merge commit" from the merge
     dropdown, and hit "Merge pull request".
 
-6. Create a [new release](https://github.com/NREL/floris/releases/new) on GitHub
+6. Create a [new release](https://github.com/NatLabRockies/floris/releases/new) on GitHub
     with the title "vN.M". Choose to create a new tag on publish with the same
     name. Also, autogenerate the release notes again. If you autogenerated the release
     notes in step 4, make sure to start this step from a new browser window.
@@ -280,7 +280,7 @@ Be sure to complete each step in the sequence as described.
 
 8. Hit "Publish release".
 
-9. Go to GitHub Actions and watch the [Upload Python Package](https://github.com/NREL/floris/actions/workflows/python-publish.yml)
+9. Go to GitHub Actions and watch the [Upload Python Package](https://github.com/NatLabRockies/floris/actions/workflows/python-publish.yml)
     job complete. Upon success, FLORIS will be uploaded to PyPI for installation with pip.
     If it fails, the latest release will not be distributed.
 
@@ -307,11 +307,11 @@ FLORIS framework:
 - Grid-points
 
 Initially, it's recommended to copy an existing model as a starting point, and the
-[Jensen](https://github.com/NREL/floris/blob/main/floris/simulation/wake_velocity/jensen.py) and
-[Jimenez](https://github.com/NREL/floris/blob/main/floris/simulation/wake_deflection/jimenez.py)
+[Jensen](https://github.com/NatLabRockies/floris/blob/main/floris/simulation/wake_velocity/jensen.py) and
+[Jimenez](https://github.com/NatLabRockies/floris/blob/main/floris/simulation/wake_deflection/jimenez.py)
 models are good choices due to their simplicity.
 New models must be registered in
-[Wake.model_map](https://github.com/NREL/floris/blob/main/floris/simulation/wake.py#L45)
+[Wake.model_map](https://github.com/NatLabRockies/floris/blob/main/floris/simulation/wake.py#L45)
 so that they can be enabled via the input dictionary.
 
 ```{mermaid}
@@ -404,7 +404,7 @@ def function(
 ```
 
 Some models require a special grid and/or solver, and that mapping happens in
-[floris.simulation.Floris](https://github.com/NREL/floris/blob/main/floris/simulation/floris.py#L145).
+[floris.simulation.Floris](https://github.com/NatLabRockies/floris/blob/main/floris/simulation/floris.py#L145).
 Generally, a specific kind of solver requires one or a number of specific grid-types.
 For example, `full_flow_sequential_solver` requires either `FlowFieldGrid` or
 `FlowFieldPlanarGrid`.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -255,7 +255,7 @@ Be sure to complete each step in the sequence as described.
     surprises in this regard prior to a release. However, it's a good
     opportunity to ensure that the documentation is up to date and there
     are no obvious issues.
-    Check this by opening the documentation website at https://nrel.github.io/floris
+    Check this by opening the documentation website at https://natlabrockies.github.io/floris
     and scrolling through the pages.
     Also, verify that the automated build process has successfully completed
     for the commits to `develop` in [GitHub Actions](https://github.com/NatLabRockies/floris/actions/workflows/deploy-pages.yaml).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ framework.
 The software is in active development and engagement with the development team
 is highly encouraged. If you are interested in using FLORIS to conduct studies
 of a wind farm or extending FLORIS to include your own wake model, please join
-the conversation in [GitHub Discussions](https://github.com/NREL/floris/discussions/)!
+the conversation in [GitHub Discussions](https://github.com/NatLabRockies/floris/discussions/)!
 
 ```{note}
 FLORIS support for python version 3.8 and 3.9 was recently ended as they reached [end-of-life](https://devguide.python.org/versions/).
@@ -51,21 +51,21 @@ Finally, results can be analyzed via post-processing functions available within
 {py:meth}`.FlorisModel.get_turbine_powers` and
 {py:meth}`.FlorisModel.get_farm_AEP`, and
 a visualization package is available in {py:mod}`floris.flow_visualization`.
-A collection of examples are included in the [repository](https://github.com/NREL/floris/tree/main/examples)
+A collection of examples are included in the [repository](https://github.com/NatLabRockies/floris/tree/main/examples)
 and described in detail in {ref}`examples`.
 
 ## Engaging on GitHub
 
 FLORIS leverages the following GitHub features to coordinate support and development efforts:
 
-- [Discussions](https://github.com/NREL/floris/discussions): Collaborate to develop ideas for new use cases, features, and software designs, and get support for usage questions
-- [Issues](https://github.com/NREL/floris/issues): Report potential bugs and well-developed feature requests
+- [Discussions](https://github.com/NatLabRockies/floris/discussions): Collaborate to develop ideas for new use cases, features, and software designs, and get support for usage questions
+- [Issues](https://github.com/NatLabRockies/floris/issues): Report potential bugs and well-developed feature requests
 - [Projects](https://github.com/orgs/NREL/projects/18/): Include current and future work on a timeline and assign a person to "own" it
 
 Generally, the first entry point for the community will be within one of the
 categories in Discussions.
-[Ideas](https://github.com/NREL/floris/discussions/categories/ideas) is a great spot to develop the
-details for a feature request. [Q&A](https://github.com/NREL/floris/discussions/categories/q-a)
+[Ideas](https://github.com/NatLabRockies/floris/discussions/categories/ideas) is a great spot to develop the
+details for a feature request. [Q&A](https://github.com/NatLabRockies/floris/discussions/categories/q-a)
 is where to get usage support.
-[Show and tell](https://github.com/NREL/floris/discussions/categories/show-and-tell) is a free-form
+[Show and tell](https://github.com/NatLabRockies/floris/discussions/categories/show-and-tell) is a free-form
 space to show off the things you are doing with FLORIS.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,11 +16,11 @@ FLORIS v4.3 also made the move to requiring `numpy` version 2. See the [numpy do
 ## WETO software
 
 FLORIS is primarily developed with the support from the U.S. Department of Energy and
-is part of the `WETO Software Stack <https://nrel.github.io/WETOStack>`_.
+is part of the `WETO Software Stack <https://natlabrockies.github.io/WETOStack>`_.
 For more information and other integrated modeling software, see:
 
-- [Portfolio Overview](https://nrel.github.io/WETOStack/portfolio_analysis/overview.html)
-- [Entry Guide](https://nrel.github.io/WETOStack/_static/entry_guide/index.html)
+- [Portfolio Overview](https://natlabrockies.github.io/WETOStack/portfolio_analysis/overview.html)
+- [Entry Guide](https://natlabrockies.github.io/WETOStack/_static/entry_guide/index.html)
 - [Wind Farm Controls Workshop](https://www.youtube.com/watch?v=f-w6whxIBrA&list=PL6ksUtsZI1dwRXeWFCmJT6cEN1xijsHJz)
 
 ## Quick Start

--- a/docs/input_reference_main.md
+++ b/docs/input_reference_main.md
@@ -4,7 +4,7 @@ In addition to calling the `set()` method on {py:class}`FlorisModel`, users can 
 with an input file. The file must be YAML format with either "yaml" or "yml" extension.
 The below definitions guide a user to the top, mid, and lower level parameterizations. A few
 reference input files are available in the
-[floris/examples](https://github.com/NREL/floris/tree/main/examples/inputs) folder.
+[floris/examples](https://github.com/NatLabRockies/floris/tree/main/examples/inputs) folder.
 
 ```{eval-rst}
 .. autoyaml:: docs/gch.yaml

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,7 +48,7 @@ git repository from GitHub with ``git`` and use ``pip`` to locally install it. T
 
 ```bash
 # Download the source code from the `main` branch
-git clone -b main https://github.com/NREL/floris.git
+git clone -b main https://github.com/NatLabRockies/floris.git
 
 # If using conda, be sure to activate your environment prior to installing
 # conda activate <env name>

--- a/docs/turbine_library.md
+++ b/docs/turbine_library.md
@@ -38,7 +38,7 @@ The IEA 10MW turbine is used in the following examples:
 ## IEA 22MW reference wind turbine
 FLORIS representation of the IEA 22MW reference wind turbine {cite:t}`zahle_IEA22MW_2024`. Data
 generated using OpenFAST v4.1.2 and ROSCO v2.10.2. See
-[pull request](https://github.com/NREL/floris/pull/1146) for full OpenFAST and ROSCO input files.
+[pull request](https://github.com/NatLabRockies/floris/pull/1146) for full OpenFAST and ROSCO input files.
 Specified as `"iea_22MW"` in the `turbine_type` field of the FLORIS input dictionary.
 
 The IEA 22MW is demonstrated, alongside other reference wind turbines, in:

--- a/examples/examples_control_types/002_disable_turbines.py
+++ b/examples/examples_control_types/002_disable_turbines.py
@@ -1,6 +1,6 @@
 """Example: Disabling turbines
 
-This example is adapted from https://github.com/NREL/floris/pull/693
+This example is adapted from https://github.com/NatLabRockies/floris/pull/693
 contributed by Elie Kadoche.
 
 This example demonstrates the ability of FLORIS to shut down some turbines

--- a/floris/core/core.py
+++ b/floris/core/core.py
@@ -389,8 +389,9 @@ def check_input_file_for_v3_keys(input_dict) -> None:
     """
     v3_deprecation_msg = (
         "Consider using the convert_floris_input_v3_to_v4.py utility in floris/tools "
-        + "to convert from a FLORIS v3 input file to FLORIS v4. "
-        "See https://nrel.github.io/floris/upgrade_guides/v3_to_v4.html for more information."
+        "to convert from a FLORIS v3 input file to FLORIS v4. "
+        "See https://natlabrockies.github.io/floris/upgrade_guides/v3_to_v4.html "
+        "for more information."
     )
     if "turbulence_intensity" in input_dict["flow_field"]:
         raise AttributeError(

--- a/floris/core/farm.py
+++ b/floris/core/farm.py
@@ -495,7 +495,7 @@ def check_turbine_definition_for_v3_keys(turbine_definition: dict):
     v3_deprecation_msg = (
         "Consider using the convert_turbine_v3_to_v4.py utility in floris/tools "
         + "to convert from a FLORIS v3 turbine definition to FLORIS v4. "
-        + "See https://nrel.github.io/floris/v3_to_v4.html for more information."
+        + "See https://natlabrockies.github.io/floris/v3_to_v4.html for more information."
     )
     if "generator_efficiency" in turbine_definition:
         raise ValueError(

--- a/floris/floris_model.py
+++ b/floris/floris_model.py
@@ -1808,13 +1808,13 @@ class FlorisModel(LoggingManager):
     def calculate_wake(self, **_):
         raise NotImplementedError(
             "The calculate_wake method has been removed. Please use the run method. "
-            "See https://nrel.github.io/floris/v3_to_v4.html for more information."
+            "See https://natlabrockies.github.io/floris/v3_to_v4.html for more information."
         )
 
     def reinitialize(self, **_):
         raise NotImplementedError(
             "The reinitialize method has been removed. Please use the set method. "
-            "See https://nrel.github.io/floris/v3_to_v4.html for more information."
+            "See https://natlabrockies.github.io/floris/v3_to_v4.html for more information."
         )
 
 

--- a/floris/type_dec.py
+++ b/floris/type_dec.py
@@ -105,8 +105,8 @@ def _attr_floris_filter(inst: Attribute, value: Any) -> bool:
         return False
 
     # This is removed to support initializing FLORIS with default values:
-    # - defaults added in https://github.com/NREL/floris/pull/1040
-    # - bug fix in https://github.com/NREL/floris/pull/1061
+    # - defaults added in https://github.com/NatLabRockies/floris/pull/1040
+    # - bug fix in https://github.com/NatLabRockies/floris/pull/1061
     # When Core is exported to a dict in _reinitialize, this filter removes empty arrays.
     # For init with defaults, this results in FlowField losing the wind speed, wind direction and TI
     # arrays if they weren't provided in the .set function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ floris = [
 
 [project.urls]
 Homepage = "https://github.com/NatLabRockies/floris"
-Documentation = "https://nrel.github.io/floris/"
+Documentation = "https://natlabrockies.github.io/floris/"
 
 [coverage.run]
 # Coverage.py configuration file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ floris = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/NREL/floris"
+Homepage = "https://github.com/NatLabRockies/floris"
 Documentation = "https://nrel.github.io/floris/"
 
 [coverage.run]


### PR DESCRIPTION
The [github.com/NREL organization](https://github.com/nrel/) is being renamed github.com/NatLabRockies, following the change of the name of the laboratory. This PR, which should not be merged until the actual organization name changes, updates various URLs throughout the repository to follow the change.

Once the organization name changes and this PR is merged, I intend to make a patch release of FLORIS so that the main branch contains the correct URLs.

Related: #1160 

- [x] Prior to merger, check that natlabrockies.github.io/WETOStack is the destination of the WETOStack docs page.
