### PR TITLE
Use PyPI Trusted Publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,5 +1,7 @@
 # This workflows will upload a Python Package using Twine when a release is created
+# Published via GitHub Actions as a PyPI Trusted Publisher.
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# and: https://docs.pypi.org/trusted-publishers/
 
 name: Upload Python Package
 
@@ -9,22 +11,23 @@ on:
 
 jobs:
   deploy:
+    environment: release-pypi
     if: github.repository_owner == 'NatLabRockies'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
-        python -m build
-        twine upload dist/*
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies and build package
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+          python -m build
+          twine check --strict dist/*
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: True
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,9 +15,9 @@ jobs:
     if: github.repository_owner == 'NatLabRockies'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies and build package
@@ -30,4 +30,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: True
-          password: ${{ secrets.PYPI_PASSWORD }}
+

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,4 +30,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: True
-


### PR DESCRIPTION
This PR updates the python-publish workflow to use PyPI Trusted Publishing. In addition to the changes to python-publish.yml, I have also created a new Environment in the repository named `release-pypi`.

Details on trusted publishers here: https://docs.pypi.org/trusted-publishers/

Thanks @RHammond2 for the help! I've requested you as a reviewer---would you mind taking a look over the changes here and see if they look right? I always find changes to the publishing workflow a bit scary, as I don't know how to test them prior to just releasing a new version and hoping that it works...